### PR TITLE
Show type of bank account after transfer pending

### DIFF
--- a/services/catarse.js/legacy/src/c/admin-balance-transfer-item-detail.js
+++ b/services/catarse.js/legacy/src/c/admin-balance-transfer-item-detail.js
@@ -54,7 +54,6 @@ const adminBalanceTransferItemDetail = {
             };
 
         if (!_.isUndefined(metaBank)) {
-            console.log('metaBank', metaBank);
             if (metaBank.conta) {
                 transitionBankAccount({
                     account: metaBank.conta,

--- a/services/catarse.js/legacy/src/c/admin-balance-transfer-item-detail.js
+++ b/services/catarse.js/legacy/src/c/admin-balance-transfer-item-detail.js
@@ -54,11 +54,12 @@ const adminBalanceTransferItemDetail = {
             };
 
         if (!_.isUndefined(metaBank)) {
+            console.log('metaBank', metaBank);
             if (metaBank.conta) {
                 transitionBankAccount({
                     account: metaBank.conta,
                     account_digit: metaBank.conta_dv,
-                    account_type: null,
+                    account_type: metaBank.type,
                     agency: metaBank.agencia,
                     agency_digit: metaBank.agencia_dv,
                     bank_code: metaBank.bank_code,


### PR DESCRIPTION
### Why

Copy of account type after transfer left pending status was null.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
