### PR TITLE
Change subscription total value copy

### DIFF
--- a/services/catarse.js/legacy/src/c/dashboard-subscription-card-detail-subscription-details.js
+++ b/services/catarse.js/legacy/src/c/dashboard-subscription-card-detail-subscription-details.js
@@ -48,7 +48,7 @@ const dashboardSubscriptionCardDetailSubscriptionDetails = {
                 ]),
                 m('div', [
                     m('span.fontcolor-secondary',
-                        'Tempo de assinatura: '
+                        'Qtde. de apoios confirmados: '
                     ),
                     `${subscription.paid_count} meses`
                 ]),

--- a/services/catarse/app/models/subscription_report_for_project_owner.rb
+++ b/services/catarse/app/models/subscription_report_for_project_owner.rb
@@ -7,7 +7,7 @@ class SubscriptionReportForProjectOwner < ActiveRecord::Base
   scope :status, ->(status) { where(status: status) }
 
   def self.to_csv
-    attributes = ['Nome completo',	'Nome público', 'CPF', 'Email perfil Catarse',	'Valor do apoio mensal',	'Título da recompensa',	'Descrição da recompensa',	'Total apoiado até hoje', 'Status da Assinatura',	'Meio de pagamento',	'Data de confirmação do último pagamento',	'Data de início da Assinatura',	'Tempo de assinatura',	'ID do usuário', 'Anônimo', 'Rua', 'Número', 'Complemento', 'Bairro',	'Cidade',	'Estado',	'CEP']
+    attributes = ['Nome completo',	'Nome público', 'CPF', 'Email perfil Catarse',	'Valor do apoio mensal',	'Título da recompensa',	'Descrição da recompensa',	'Total apoiado até hoje', 'Status da Assinatura',	'Meio de pagamento',	'Data de confirmação do último pagamento',	'Data de início da Assinatura',	'Qtde. de apoios confirmados',	'ID do usuário', 'Anônimo', 'Rua', 'Número', 'Complemento', 'Bairro',	'Cidade',	'Estado',	'CEP']
     CSV.generate(headers: true) do |csv|
       csv << attributes
 


### PR DESCRIPTION
### Why

It is just a small copy change to make it more clear that the number of months we show in a subscription report is actually the number of PAID MONTHS. Example: If a user started a subscription for a project in January and at the end of the year (December) she paid only 9 months, the report will say that the subscription is a 9-month subscription. The way we were saying that could lead the creator to think that the user started the subscription 9 minths ago, when actually she started 11 months ago, but skipped the payment in 2 months throughout the year.

### Wrap up checklist

- [X] All new code has tests
- [X] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [X] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
