### PR TITLE
should check for was_confirmed contribution details

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/_contribution_data.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/_contribution_data.html.slim
@@ -1,4 +1,4 @@
-- detail = contribution.details.ordered.first
+- detail = contribution.details.was_confirmed.ordered.first
 
 p Seguem todos os dados do pagamento:
 p


### PR DESCRIPTION
### Why

Should use was_confirmed when showing contribution details inside contribution_data
