### PR TITLE
Remove spare 'Created projects' link at user menu

### DIFF
--- a/services/catarse.js/legacy/src/c/menu-profile.js
+++ b/services/catarse.js/legacy/src/c/menu-profile.js
@@ -84,11 +84,6 @@ const menuProfile = {
                                                     )
                                                 ),
                                                 m('li.lineheight-looser',
-                                                  m(`a.alt-link.fontsize-smaller[href='/pt/users/${user.id}/edit#projects']`,
-                                                    'Projetos criados'
-                                                   )
-                                                 ),
-                                                m('li.w-hidden-main.w-hidden-medium.lineheight-looser',
                                                     m(`a.alt-link.fontsize-smaller[href='/pt/users/${user.id}/edit#projects']`,
                                                         'Projetos criados'
                                                     )


### PR DESCRIPTION
We had a spare 'Created projects' link at user menu (in mobile)

### Why

Explain what this PR does.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
