### PR TITLE
fix to hide print slip button when contribution state is different th…

### DIFF
--- a/services/catarse.js/legacy/src/vms/contribution-vm.js
+++ b/services/catarse.js/legacy/src/vms/contribution-vm.js
@@ -40,7 +40,7 @@ const wasConfirmed = contribution => _.contains(['paid', 'pending_refund', 'refu
 
 const canShowReceipt = contribution => wasConfirmed(contribution);
 
-const canShowSlip = contribution => contribution.payment_method === 'BoletoBancario' && moment(contribution.gateway_data.boleto_expiration_date).isAfter(moment());
+const canShowSlip = contribution => contribution.payment_method === 'BoletoBancario' && moment(contribution.gateway_data.boleto_expiration_date).isAfter(moment()) && contribution.state === 'pending';
 
 const canGenerateSlip = contribution => contribution.payment_method === 'BoletoBancario' &&
       (contribution.state === 'pending' || contribution.state === 'refused') &&


### PR DESCRIPTION
…an pending #158307523

Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

Print slip button was showing when state is 'paid'

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
