### PR TITLE
Hotfix/balance transaction metadata

### DIFF
--- a/services/catarse/app/decorators/reward_decorator.rb
+++ b/services/catarse/app/decorators/reward_decorator.rb
@@ -67,4 +67,8 @@ class RewardDecorator < Draper::Decorator
   def display_description
     auto_html(source.description) { html_escape; simple_format }
   end
+
+  def display_label
+    "#{source.minimum_value} - #{source.title}"
+  end
 end

--- a/services/catarse/app/models/balance_transaction.rb
+++ b/services/catarse/app/models/balance_transaction.rb
@@ -26,11 +26,33 @@ class BalanceTransaction < ActiveRecord::Base
   belongs_to :project
   belongs_to :contribution
   belongs_to :user
+  belongs_to :susbcription_payment
+  belongs_to :from_user, class_name: 'User'
+  belongs_to :to_user, class_name: 'User'
 
   validates :event_name, inclusion: { in: EVENT_NAMES }
   validates :amount, :event_name, :user_id, presence: true
 
   ## CLASS METHODS
+  def self.refresh_metadata(balance_transaction)
+    metadata = {
+      amount: balance_transaction.amount,
+      event_name: balance_transaction.event_name,
+      origin_objects: {
+        from_user_name: balance_transaction.from_user.try(:display_name),
+        to_user_name: balance_transaction.to_user.try(:display_name),
+        service_fee: balance_transaction.project.try(:service_fee),
+        contributor_name: balance_transaction.contribution.try(:user).try(:display_name),
+        subscriber_name: balance_transaction.subscription_payment.try(:user).try(:display_name),
+        subscription_reward_label: balance_transaction.subscription_payment.try(:reward).try(:display_label),
+        id: (balance_transaction.project_id.presence || balance_transaction.contribution_id),
+        project_id: balance_transaction.project_id,
+        contribution_id: balance_transaction.contrbution_id,
+        project_name: balance_transaction.project.try(:name),
+      }
+    }
+    balance_transaction.update_column(:metadata, metadata)
+  end
 
   def self.insert_balance_transfer_between_users(from_user, to_user)
     from_user.reload

--- a/services/catarse/app/models/reward.rb
+++ b/services/catarse/app/models/reward.rb
@@ -41,7 +41,7 @@ class Reward < ActiveRecord::Base
   scope :sort_asc, -> { order('id ASC') }
 
   delegate :display_deliver_estimate, :display_remaining, :name, :display_minimum, :short_description,
-           :medium_description, :last_description, :display_description, to: :decorator
+           :medium_description, :last_description, :display_description, :display_label, to: :decorator
 
   before_save :log_changes
   after_save :expires_project_cache

--- a/services/catarse/db/migrate/20180927134248_add_metadata_to_balance_transactions.rb
+++ b/services/catarse/db/migrate/20180927134248_add_metadata_to_balance_transactions.rb
@@ -1,0 +1,5 @@
+class AddMetadataToBalanceTransactions < ActiveRecord::Migration
+  def change
+    add_column :balance_transactions, :metadata, :jsonb
+  end
+end

--- a/services/catarse/db/migrate/20181002043524_adjust_balance_transactions_to_use_metadata.rb
+++ b/services/catarse/db/migrate/20181002043524_adjust_balance_transactions_to_use_metadata.rb
@@ -1,0 +1,57 @@
+class AdjustBalanceTransactionsToUseMetadata < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+CREATE OR REPLACE VIEW "1"."balance_transactions" AS 
+ SELECT bt.user_id,
+    sum(
+        CASE
+            WHEN (bt.amount > (0)::numeric) THEN bt.amount
+            ELSE (0)::numeric
+        END) AS credit,
+    sum(
+        CASE
+            WHEN (bt.amount < (0)::numeric) THEN bt.amount
+            ELSE (0)::numeric
+        END) AS debit,
+    sum(bt.amount) AS total_amount,
+    (zone_timestamp(bt.created_at))::date AS created_at,
+    json_agg(bt.metadata ORDER BY bt.id DESC) AS source
+   FROM balance_transactions bt
+  WHERE is_owner_or_admin(bt.user_id)
+  GROUP BY (zone_timestamp(bt.created_at))::date, bt.user_id
+  ORDER BY (zone_timestamp(bt.created_at))::date DESC;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+    CREATE OR REPLACE VIEW "1"."balance_transactions" AS 
+ SELECT bt.user_id,
+    sum(
+        CASE
+            WHEN (bt.amount > (0)::numeric) THEN bt.amount
+            ELSE (0)::numeric
+        END) AS credit,
+    sum(
+        CASE
+            WHEN (bt.amount < (0)::numeric) THEN bt.amount
+            ELSE (0)::numeric
+        END) AS debit,
+    sum(bt.amount) AS total_amount,
+    (zone_timestamp(bt.created_at))::date AS created_at,
+    json_agg(json_build_object('amount', bt.amount, 'event_name', bt.event_name, 'origin_objects', json_build_object('from_user_name', COALESCE(fromuser.public_name, fromuser.name), 'to_user_name', COALESCE(touser.public_name, touser.name), 'service_fee', p.service_fee, 'contributor_name', COALESCE(fu.public_name, fu.name), 'subscriber_name', COALESCE(su.public_name, su.name), 'subscription_reward_label', ((r.minimum_value || ' - '::text) || r.title), 'id', COALESCE(bt.project_id, bt.contribution_id), 'project_name', p.name)) ORDER BY bt.id DESC) AS source
+   FROM ((((((((balance_transactions bt
+     LEFT JOIN projects p ON ((p.id = bt.project_id)))
+     LEFT JOIN contributions c ON ((c.id = bt.contribution_id)))
+     LEFT JOIN users fu ON ((fu.id = c.user_id)))
+     LEFT JOIN common_schema.catalog_payments sp ON ((sp.id = bt.subscription_payment_uuid)))
+     LEFT JOIN users su ON ((su.common_id = sp.user_id)))
+     LEFT JOIN rewards r ON ((r.common_id = sp.reward_id)))
+     LEFT JOIN users fromuser ON (((fromuser.id = bt.from_user_id) AND (bt.from_user_id IS NOT NULL))))
+     LEFT JOIN users touser ON (((touser.id = bt.to_user_id) AND (bt.to_user_id IS NOT NULL))))
+  WHERE is_owner_or_admin(bt.user_id)
+  GROUP BY (zone_timestamp(bt.created_at))::date, bt.user_id
+  ORDER BY (zone_timestamp(bt.created_at))::date DESC;
+    SQL
+  end
+end


### PR DESCRIPTION
### Why

Add metadata column to balance_transactions, used has a cache to avoid calculate on runtime query
