### PR TITLE
Hotfix/add listen task balance transaction

### DIFF
--- a/services/catarse/Procfile
+++ b/services/catarse/Procfile
@@ -2,3 +2,4 @@ web: bundle exec unicorn_rails -p $PORT -c config/unicorn.rb
 worker: bundle exec sidekiq -c 10 -C config/sidekiq.yml
 worker_notifications: bundle exec rake listen:sync_notifications
 worker_rdstation: bundle exec rake listen:sync_rdstation
+worker_refresh_balance_transaction_metadata: bundle exec rake listen:syn_balance_transaction_metadata

--- a/services/catarse/Procfile
+++ b/services/catarse/Procfile
@@ -2,4 +2,4 @@ web: bundle exec unicorn_rails -p $PORT -c config/unicorn.rb
 worker: bundle exec sidekiq -c 10 -C config/sidekiq.yml
 worker_notifications: bundle exec rake listen:sync_notifications
 worker_rdstation: bundle exec rake listen:sync_rdstation
-worker_refresh_balance_transaction_metadata: bundle exec rake listen:syn_balance_transaction_metadata
+worker_refresh_balance_transaction_metadata: bundle exec rake listen:sync_balance_transaction_metadata

--- a/services/catarse/app/models/balance_transaction.rb
+++ b/services/catarse/app/models/balance_transaction.rb
@@ -103,6 +103,7 @@ class BalanceTransaction < ActiveRecord::Base
       balance_transaction_id: chargeback_transaction.id,
       event_name: 'revert_chargeback',
       amount: chargeback_transaction.amount.abs,
+      project_id: chargeback_transaction.project_id,
       contribution_id: chargeback_transaction.contribution_id,
       subscription_payment_uuid: chargeback_transaction.subscription_payment_uuid
     )

--- a/services/catarse/db/migrate/20181031224531_add_notify_to_withdraw_balance_trigger.rb
+++ b/services/catarse/db/migrate/20181031224531_add_notify_to_withdraw_balance_trigger.rb
@@ -1,0 +1,99 @@
+class AddNotifyToWithdrawBalanceTrigger < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.withdraw_balance()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+      DECLARE
+             v_balance "1".balances; 
+             v_balance_transfer_id integer; 
+             v_balance_transfer "1".balance_transfers; 
+             v_balance_transaction public.balance_transactions;
+         BEGIN 
+             IF NOT public.is_owner_or_admin(NEW.user_id) THEN 
+                 RAISE EXCEPTION 'insufficient privileges to insert balance_transactions'; 
+             END IF; 
+             SELECT * FROM "1".balances 
+                 WHERE user_id = NEW.user_id 
+                 INTO v_balance; 
+             IF COALESCE(v_balance.amount, 0) <= 0 THEN 
+                 RAISE EXCEPTION 'insufficient funds'; 
+             END IF; 
+             IF v_balance.in_period_yet is not null AND v_balance.in_period_yet THEN
+                RAISE EXCEPTION 'already requested transfer this month'; 
+             END IF;
+             INSERT INTO public.balance_transfers (user_id, amount, created_at) 
+                 VALUES (NEW.user_id, v_balance.amount, now()) 
+                 RETURNING id INTO v_balance_transfer_id; 
+             INSERT INTO public.balance_transactions (user_id, event_name, balance_transfer_id, created_at, amount) 
+                 VALUES (NEW.user_id, 'balance_transfer_request', v_balance_transfer_id, now(), (v_balance.amount * -1))
+                 RETURNING * INTO v_balance_transaction;
+
+             PERFORM pg_notify('balance_transaction_metadata_refresh', json_build_object('id', v_balance_transaction.id)::text);
+
+             INSERT INTO public.notifications(user_id, template_name, metadata, created_at, updated_at) VALUES 
+                 (NEW.user_id, 'balance_transfer_request', json_build_object( 
+                     'from_email', settings('email_contact'), 
+                     'from_name', settings('company_name'), 
+                     'associations', json_build_object('balance_transfer_id', v_balance_transfer_id) 
+                 )::jsonb, now(), now()); 
+
+             DELETE from contribution_notifications where template_name = 'contribution_refunded' and user_id = NEW.user_id and deliver_at > current_timestamp;
+             DELETE from project_notifications where template_name = 'project_success' and user_id = NEW.user_id and deliver_at > current_timestamp;
+
+             SELECT * FROM "1".balance_transfers WHERE id = v_balance_transfer_id 
+                 INTO v_balance_transfer; 
+             RETURN v_balance_transfer; 
+         END; 
+         $function$;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.withdraw_balance()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+      DECLARE
+             v_balance "1".balances; 
+             v_balance_transfer_id integer; 
+             v_balance_transfer "1".balance_transfers; 
+         BEGIN 
+             IF NOT public.is_owner_or_admin(NEW.user_id) THEN 
+                 RAISE EXCEPTION 'insufficient privileges to insert balance_transactions'; 
+             END IF; 
+             SELECT * FROM "1".balances 
+                 WHERE user_id = NEW.user_id 
+                 INTO v_balance; 
+             IF COALESCE(v_balance.amount, 0) <= 0 THEN 
+                 RAISE EXCEPTION 'insufficient funds'; 
+             END IF; 
+             IF v_balance.in_period_yet is not null AND v_balance.in_period_yet THEN
+                RAISE EXCEPTION 'already requested transfer this month'; 
+             END IF;
+             INSERT INTO public.balance_transfers (user_id, amount, created_at) 
+                 VALUES (NEW.user_id, v_balance.amount, now()) 
+                 RETURNING id INTO v_balance_transfer_id; 
+             INSERT INTO public.balance_transactions (user_id, event_name, balance_transfer_id, created_at, amount) 
+                 VALUES (NEW.user_id, 'balance_transfer_request', v_balance_transfer_id, now(), (v_balance.amount * -1));
+             INSERT INTO public.notifications(user_id, template_name, metadata, created_at, updated_at) VALUES 
+                 (NEW.user_id, 'balance_transfer_request', json_build_object( 
+                     'from_email', settings('email_contact'), 
+                     'from_name', settings('company_name'), 
+                     'associations', json_build_object('balance_transfer_id', v_balance_transfer_id) 
+                 )::jsonb, now(), now()); 
+
+             DELETE from contribution_notifications where template_name = 'contribution_refunded' and user_id = NEW.user_id and deliver_at > current_timestamp;
+             DELETE from project_notifications where template_name = 'project_success' and user_id = NEW.user_id and deliver_at > current_timestamp;
+
+             SELECT * FROM "1".balance_transfers WHERE id = v_balance_transfer_id 
+                 INTO v_balance_transfer; 
+             RETURN v_balance_transfer; 
+         END; 
+         $function$;
+
+    SQL
+  end
+end

--- a/services/catarse/lib/tasks/listen.rake
+++ b/services/catarse/lib/tasks/listen.rake
@@ -94,4 +94,38 @@ namespace :listen do
       end
     end
   end
+
+  desc 'listen from database and refresh metadata for balance_transaction'
+  task sync_balance_transaction_metadata: [:environment] do
+    $stdout.sync = true
+    ActiveRecord::Base.connection_pool.with_connection do |connection|
+      conn = connection.instance_variable_get(:@connection)
+      begin
+        Rails.logger.info('STARTING LISTENER...')
+        conn.async_exec 'LISTEN balance_transaction_metadata_refresh'
+
+        loop do
+          conn.wait_for_notify do |channel, pid, payload|
+            if channel == 'balance_transaction_metadata_refresh'
+              begin
+                decoded = ActiveSupport::JSON.decode(payload)
+                Rails.logger.info("decoded payload -> #{decoded}")
+                balance_transaction = BalanceTransaction.find decoded['id']
+                Rails.logger.info("balance transaction -> #{balance_transaction.inspect}")
+                balance_transaction.refresh_metadata
+                balance_transaction.save!
+                Rails.logger.info("refresh metadata for #{payload}")
+              rescue Exception => e
+                Rails.logger.info("refresh metadata error => #{e.inspect} - payload #{payload.inspect}")
+              end
+            end
+          end
+          sleep 0.5
+        end
+      ensure
+        Rails.logger.info('unlisten time for balance_transaction_metadata_refresh')
+        conn.async_exec 'UNLISTEN balance_transaction_metadata_refresh;'
+      end
+    end
+  end
 end

--- a/services/catarse/spec/models/balance_transaction_spec.rb
+++ b/services/catarse/spec/models/balance_transaction_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe BalanceTransaction, type: :model do
         expect(subject.event_name).to eq('revert_chargeback')
         expect(subject.user_id).to eq(confirmed_contribution.project.user_id)
         expect(subject.contribution_id).to eq(confirmed_contribution.id)
+        expect(subject.project_id).to eq(confirmed_contribution.project_id)
         expect(subject.amount).to eq(subject.balance_transaction.amount.abs)
         expect(subject.balance_transaction.event_name).to eq('contribution_chargedback')
         expect(subject.balance_transaction.contribution_id).to eq(confirmed_contribution.id)


### PR DESCRIPTION
balance transaction created via postgrest dont trigger the refresh metadata inside app.
so we added a listen rake task to listen some channel and receive the message with id from database