### PR TITLE
Hotfix/project score table

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,6 @@
+services/catarse/tmp
+services/catarse/logs
+services/common-api/logs
+services/common-api/tmp
+services/catarse/public/assets
+services/catarse/app/assets/images

--- a/services/catarse/app/models/project.rb
+++ b/services/catarse/app/models/project.rb
@@ -36,6 +36,7 @@ class Project < ActiveRecord::Base
   has_one :project_cancelation
   has_one :project_total
   has_one :project_fiscal_data
+  has_one :project_score_storage
   has_many :balance_transactions
   has_many :taggings
   has_many :goals, foreign_key: :project_id
@@ -516,6 +517,10 @@ class Project < ActiveRecord::Base
 
   def can_cancel?
     pluck_from_database("can_cancel")
+  end
+
+  def refresh_project_score_storage
+    pluck_from_database('refresh_project_score_storage')
   end
 
   # State machine delegation methods

--- a/services/catarse/app/models/project_score_storage.rb
+++ b/services/catarse/app/models/project_score_storage.rb
@@ -1,0 +1,3 @@
+class ProjectScoreStorage < ActiveRecord::Base
+  belongs_to :project
+end

--- a/services/catarse/app/observers/payment_observer.rb
+++ b/services/catarse/app/observers/payment_observer.rb
@@ -78,7 +78,7 @@ class PaymentObserver < ActiveRecord::Observer
 
     unless payment.paid_at.present?
       contribution.notify_to_contributor(:confirm_contribution)
-
+      ProjectScoreStorageRefreshWorker.perform_async(project.id) if project.open_for_contributions?
       if project.successful? && project.successful_pledged_transaction
         transfer_diff = (
           project.paid_pledged - project.all_pledged_kind_transactions.sum(:amount))

--- a/services/catarse/app/workers/project_score_storage_refresh_worker.rb
+++ b/services/catarse/app/workers/project_score_storage_refresh_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ProjectScoreStorageRefreshWorker < ProjectBaseWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: false, queue: 'default'
+
+  def perform(id)
+    resource(id).refresh_project_score_storage
+  end
+end

--- a/services/catarse/db/migrate/20181121045541_create_project_score_storages.rb
+++ b/services/catarse/db/migrate/20181121045541_create_project_score_storages.rb
@@ -1,0 +1,9 @@
+class CreateProjectScoreStorages < ActiveRecord::Migration
+  def change
+    create_table :project_score_storages, id: false do |t|
+      t.references :project, index: true, foreign_key: true, unique: true
+      t.float :score
+      t.datetime :refreshed_at, null: false
+    end
+  end
+end

--- a/services/catarse/db/migrate/20181121045541_create_project_score_storages.rb
+++ b/services/catarse/db/migrate/20181121045541_create_project_score_storages.rb
@@ -1,9 +1,11 @@
 class CreateProjectScoreStorages < ActiveRecord::Migration
   def change
     create_table :project_score_storages, id: false do |t|
-      t.references :project, index: true, foreign_key: true, unique: true
+      t.references :project, foreign_key: true
       t.float :score
       t.datetime :refreshed_at, null: false
     end
+
+    add_index :project_score_storages, :project_id, unique: true
   end
 end

--- a/services/catarse/db/migrate/20181121051012_add_process_project_score_storages.rb
+++ b/services/catarse/db/migrate/20181121051012_add_process_project_score_storages.rb
@@ -1,0 +1,51 @@
+class AddProcessProjectScoreStorages < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+create or replace function public.refresh_project_score_storage(public.projects) returns numeric
+language plpgsql VOLATILE 
+as $$
+    declare
+        v_score numeric;
+    begin
+        v_score := coalesce(public.score($1), 0);
+
+        begin
+            insert into public.project_score_storages (project_id, score, refreshed_at)
+                values ($1.id, v_score, now());
+        exception when unique_violation then
+            update public.project_score_storages
+                set score = v_score,
+                    refreshed_at = now()
+                where project_id = $1.id;
+        end;
+
+        return v_score;
+    end;
+$$;
+
+create or replace function public.refresh_all_online_project_score_storages() returns void
+language plpgsql volatile
+as $$
+    declare
+        v_project public.projects;
+        v_score numeric;
+    begin
+        for v_project in (select * from public.projects where state = 'online') 
+        loop
+            v_score := public.refresh_project_score_storage(v_project);
+            raise notice 'performed on project id % with score %', v_project.id, v_score;
+        end loop;
+        return;
+    end;
+$$;
+
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      drop function public.refresh_all_online_project_score_storages();
+      drop function public.refresh_project_score_storage(public.projects);
+    SQL
+  end
+end

--- a/services/catarse/db/migrate/20181121053302_adjust_projects_view_to_use_project_score_storage_to_get_score.rb
+++ b/services/catarse/db/migrate/20181121053302_adjust_projects_view_to_use_project_score_storage_to_get_score.rb
@@ -25,7 +25,7 @@ CREATE OR REPLACE VIEW "1"."projects" AS
                                 WHEN ((p.state)::text = 'failed'::text) THEN pt.pledged
                                 ELSE pt.paid_pledged
                             END AS paid_pledged
-                       FROM project_totals pt
+                       FROM "1".project_totals pt
                       WHERE (pt.project_id = p.id))
                 END AS paid_pledged), (0)::numeric) AS pledged,
     COALESCE(( SELECT
@@ -42,7 +42,7 @@ CREATE OR REPLACE VIEW "1"."projects" AS
                        FROM goals
                       WHERE (goals.project_id = p.id)))) * (100)::numeric)
                     ELSE ( SELECT pt.progress
-                       FROM project_totals pt
+                       FROM "1".project_totals pt
                       WHERE (pt.project_id = p.id))
                 END AS progress), (0)::numeric) AS progress,
     s.acronym AS state_acronym,
@@ -100,7 +100,7 @@ CREATE OR REPLACE VIEW "1"."projects" AS
                                 WHEN ((p.state)::text = 'failed'::text) THEN pt.pledged
                                 ELSE pt.paid_pledged
                             END AS paid_pledged
-                       FROM project_totals pt
+                       FROM "1".project_totals pt
                       WHERE (pt.project_id = p.id))
                 END AS paid_pledged), (0)::numeric) AS pledged,
     COALESCE(( SELECT
@@ -117,7 +117,7 @@ CREATE OR REPLACE VIEW "1"."projects" AS
                        FROM goals
                       WHERE (goals.project_id = p.id)))) * (100)::numeric)
                     ELSE ( SELECT pt.progress
-                       FROM project_totals pt
+                       FROM "1".project_totals pt
                       WHERE (pt.project_id = p.id))
                 END AS progress), (0)::numeric) AS progress,
     s.acronym AS state_acronym,

--- a/services/catarse/db/migrate/20181121053302_adjust_projects_view_to_use_project_score_storage_to_get_score.rb
+++ b/services/catarse/db/migrate/20181121053302_adjust_projects_view_to_use_project_score_storage_to_get_score.rb
@@ -1,0 +1,148 @@
+class AdjustProjectsViewToUseProjectScoreStorageToGetScore < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+CREATE OR REPLACE VIEW "1"."projects" AS 
+ SELECT p.id AS project_id,
+    p.category_id,
+    p.name AS project_name,
+    p.headline,
+    p.permalink,
+    p.mode,
+    (p.state)::text AS state,
+    so.so AS state_order,
+    od.od AS online_date,
+    p.recommended,
+    thumbnail_image(p.*, 'large'::text) AS project_img,
+    remaining_time_json(p.*) AS remaining_time,
+    p.expires_at,
+    COALESCE(( SELECT
+                CASE
+                    WHEN (p.mode = 'sub'::text) THEN ( SELECT sum((((s_1.checkout_data ->> 'amount'::text))::numeric / (100)::numeric)) AS sum
+                       FROM common_schema.subscriptions s_1
+                      WHERE ((s_1.project_id = p.common_id) AND ((s_1.status)::text = 'active'::text)))
+                    ELSE ( SELECT
+                            CASE
+                                WHEN ((p.state)::text = 'failed'::text) THEN pt.pledged
+                                ELSE pt.paid_pledged
+                            END AS paid_pledged
+                       FROM project_totals pt
+                      WHERE (pt.project_id = p.id))
+                END AS paid_pledged), (0)::numeric) AS pledged,
+    COALESCE(( SELECT
+                CASE
+                    WHEN (p.mode = 'sub'::text) THEN ((( SELECT sum((((s_1.checkout_data ->> 'amount'::text))::numeric / (100)::numeric)) AS sum
+                       FROM common_schema.subscriptions s_1
+                      WHERE ((s_1.project_id = p.common_id) AND ((s_1.status)::text = 'active'::text))) / COALESCE(( SELECT min(g.value) AS min
+                       FROM goals g
+                      WHERE ((g.project_id = p.id) AND (g.value > ( SELECT total_amount.sum
+                               FROM ( SELECT sum((((s_2.checkout_data ->> 'amount'::text))::numeric / (100)::numeric)) AS sum
+                                       FROM common_schema.subscriptions s_2
+                                      WHERE ((s_2.project_id = p.common_id) AND ((s_2.status)::text = 'active'::text))) total_amount)))
+                     LIMIT 1), ( SELECT max(goals.value) AS max
+                       FROM goals
+                      WHERE (goals.project_id = p.id)))) * (100)::numeric)
+                    ELSE ( SELECT pt.progress
+                       FROM project_totals pt
+                      WHERE (pt.project_id = p.id))
+                END AS progress), (0)::numeric) AS progress,
+    s.acronym AS state_acronym,
+    u.name AS owner_name,
+    c.name AS city_name,
+    p.full_text_index,
+    is_current_and_online(p.expires_at, (p.state)::text) AS open_for_contributions,
+    elapsed_time_json(p.*) AS elapsed_time,
+    pss.score::numeric AS score,
+    (EXISTS ( SELECT true AS bool
+           FROM (contributions c_1
+             JOIN user_follows uf ON ((uf.follow_id = c_1.user_id)))
+          WHERE ((is_confirmed(c_1.*) AND (uf.user_id = current_user_id())) AND (c_1.project_id = p.id)))) AS contributed_by_friends,
+    p.user_id AS project_user_id,
+    p.video_embed_url,
+    p.updated_at,
+    u.public_name AS owner_public_name,
+    zone_timestamp(p.expires_at) AS zone_expires_at,
+    p.common_id
+   FROM projects p
+     JOIN users u ON p.user_id = u.id
+     LEFT JOIN project_score_storages pss on pss.project_id = p.id
+     LEFT JOIN cities c ON c.id = p.city_id
+     LEFT JOIN states s ON s.id = c.state_id
+     JOIN LATERAL zone_timestamp(online_at(p.*)) od(od) ON (true)
+     JOIN LATERAL state_order(p.*) so(so) ON (true);
+
+grant select on table project_score_storages to admin, web_user, anonymous;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+CREATE OR REPLACE VIEW "1"."projects" AS 
+ SELECT p.id AS project_id,
+    p.category_id,
+    p.name AS project_name,
+    p.headline,
+    p.permalink,
+    p.mode,
+    (p.state)::text AS state,
+    so.so AS state_order,
+    od.od AS online_date,
+    p.recommended,
+    thumbnail_image(p.*, 'large'::text) AS project_img,
+    remaining_time_json(p.*) AS remaining_time,
+    p.expires_at,
+    COALESCE(( SELECT
+                CASE
+                    WHEN (p.mode = 'sub'::text) THEN ( SELECT sum((((s_1.checkout_data ->> 'amount'::text))::numeric / (100)::numeric)) AS sum
+                       FROM common_schema.subscriptions s_1
+                      WHERE ((s_1.project_id = p.common_id) AND ((s_1.status)::text = 'active'::text)))
+                    ELSE ( SELECT
+                            CASE
+                                WHEN ((p.state)::text = 'failed'::text) THEN pt.pledged
+                                ELSE pt.paid_pledged
+                            END AS paid_pledged
+                       FROM project_totals pt
+                      WHERE (pt.project_id = p.id))
+                END AS paid_pledged), (0)::numeric) AS pledged,
+    COALESCE(( SELECT
+                CASE
+                    WHEN (p.mode = 'sub'::text) THEN ((( SELECT sum((((s_1.checkout_data ->> 'amount'::text))::numeric / (100)::numeric)) AS sum
+                       FROM common_schema.subscriptions s_1
+                      WHERE ((s_1.project_id = p.common_id) AND ((s_1.status)::text = 'active'::text))) / COALESCE(( SELECT min(g.value) AS min
+                       FROM goals g
+                      WHERE ((g.project_id = p.id) AND (g.value > ( SELECT total_amount.sum
+                               FROM ( SELECT sum((((s_2.checkout_data ->> 'amount'::text))::numeric / (100)::numeric)) AS sum
+                                       FROM common_schema.subscriptions s_2
+                                      WHERE ((s_2.project_id = p.common_id) AND ((s_2.status)::text = 'active'::text))) total_amount)))
+                     LIMIT 1), ( SELECT max(goals.value) AS max
+                       FROM goals
+                      WHERE (goals.project_id = p.id)))) * (100)::numeric)
+                    ELSE ( SELECT pt.progress
+                       FROM project_totals pt
+                      WHERE (pt.project_id = p.id))
+                END AS progress), (0)::numeric) AS progress,
+    s.acronym AS state_acronym,
+    u.name AS owner_name,
+    c.name AS city_name,
+    p.full_text_index,
+    is_current_and_online(p.expires_at, (p.state)::text) AS open_for_contributions,
+    elapsed_time_json(p.*) AS elapsed_time,
+    score(p.*) AS score,
+    (EXISTS ( SELECT true AS bool
+           FROM (contributions c_1
+             JOIN user_follows uf ON ((uf.follow_id = c_1.user_id)))
+          WHERE ((is_confirmed(c_1.*) AND (uf.user_id = current_user_id())) AND (c_1.project_id = p.id)))) AS contributed_by_friends,
+    p.user_id AS project_user_id,
+    p.video_embed_url,
+    p.updated_at,
+    u.public_name AS owner_public_name,
+    zone_timestamp(p.expires_at) AS zone_expires_at,
+    p.common_id
+   FROM (((((projects p
+     JOIN users u ON ((p.user_id = u.id)))
+     LEFT JOIN cities c ON ((c.id = p.city_id)))
+     LEFT JOIN states s ON ((s.id = c.state_id)))
+     JOIN LATERAL zone_timestamp(online_at(p.*)) od(od) ON (true))
+     JOIN LATERAL state_order(p.*) so(so) ON (true));
+    SQL
+  end
+end

--- a/services/catarse/spec/models/project_score_storage_spec.rb
+++ b/services/catarse/spec/models/project_score_storage_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProjectScoreStorage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Why

- add table to store project score (dont need to be processed all time)
- added worker to refresh score after first transition of payment to paid
