### PR TITLE
fixing checkbox rewards selection when creating news #162162565

### DIFF
--- a/services/catarse.js/legacy/src/c/post-for-reward-checkbox.js
+++ b/services/catarse.js/legacy/src/c/post-for-reward-checkbox.js
@@ -10,7 +10,7 @@ const postForRewardCheckbox = {
 
         return m('.u-marginbottom-10.w-checkbox', [
             m(`input.w-checkbox-input[type=checkbox]`, {
-                onchange: m.withAttr('checked', reward_checkbox),
+                onchange: () => reward_checkbox.toggle(),
                 checked: reward_checkbox()
             }),
             m('label.fontsize-smaller.fontweight-semibold.lineheight-tighter.w-form-label', {

--- a/services/catarse.js/legacy/src/root/posts.js
+++ b/services/catarse.js/legacy/src/root/posts.js
@@ -44,7 +44,7 @@ const posts = {
                     else {
                         return fields
                             .get_selected_rewards()
-                            .map(rc => `RS${h.formatNumber(parseInt(rc.reward.data.minimum_value))}${rc.reward.data.title ? ` - ${rc.reward.data.title}` : ''}`).join(', ');
+                            .map(rc => `R$${h.formatNumber(parseInt(rc.reward.data.minimum_value))}${rc.reward.data.title ? ` - ${rc.reward.data.title}` : ''}`).join(', ');
                     }                    
                 },
                 get_selected_rewards: () => {                    


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

Click handler to toggle the checkbox was not setting true or false. The post preview was showing wrong currency symbol.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
