### PR TITLE
fix email errors corrected displayed on user edit settings #161850177

### DIFF
--- a/services/catarse.js/legacy/src/c/inline-error.js
+++ b/services/catarse.js/legacy/src/c/inline-error.js
@@ -2,7 +2,7 @@ import m from 'mithril';
 
 const inlineError = {
     view: function(ctrl, args) {
-        return m('.fontsize-smaller.text-error.u-marginbottom-20.fa.fa-exclamation-triangle', m('span', ` ${args.message}`));
+        return m('.fontsize-smaller.text-error.u-marginbottom-20.fa.fa-exclamation-triangle', m('span', m.trust(` ${args.message}`)));
     }
 };
 

--- a/services/catarse.js/legacy/src/c/user-about-edit.js
+++ b/services/catarse.js/legacy/src/c/user-about-edit.js
@@ -132,6 +132,7 @@ const userAboutEdit = {
                         parsedErrors.resetFieldErrors();
                     }
                     parsedErrors = userAboutVM.mapRailsErrors(err.errors_json);
+                    emailHasError(parsedErrors.hasError('email'));
                     errors('Erro ao atualizar informações.');
 
                     showError(true);
@@ -154,6 +155,8 @@ const userAboutEdit = {
             validateEmailConfirmation = () => {
                 if (fields.email() !== fields.email_confirmation()) {
                     emailHasError(true);
+                    const emailConfirmationDiff = '{"email":["Confirmação de email está incorreta."]}';
+                    parsedErrors = userAboutVM.mapRailsErrors(emailConfirmationDiff);
                 } else {
                     emailHasError(false);
                 }
@@ -304,9 +307,7 @@ const userAboutEdit = {
                                                 onchange: m.withAttr('value', fields.email_confirmation)
                                             })
                                         ]),
-                                        ctrl.emailHasError() ? m(inlineError, {
-                                            message: 'Confirmação de email está incorreta.'
-                                        }) : ''
+                                        ctrl.emailHasError() ? ctrl.parsedErrors.inlineError('email') : ''
                                     ])
                                 ]),
                                 m('.w-row.u-marginbottom-30.card.card-terciary', [

--- a/services/catarse.js/legacy/src/vms/user-about-vm.js
+++ b/services/catarse.js/legacy/src/vms/user-about-vm.js
@@ -37,8 +37,7 @@ const mapRailsErrors = (rails_errors) => {
         }
     };
 
-    // extractAndSetErrorMsg("about_html", ["user.about_html", "about_html"]);
-    // extractAndSetErrorMsg("public_name", ["user.public_name", "public_name"]);
+    extractAndSetErrorMsg('email', ['email']);
 
     return e;
 };

--- a/services/catarse/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -375,9 +375,10 @@ pt:
           attributes:
             email:
               not_found: "O email não está cadastrado, verifique o endereço ou faça seu cadastro"
-              taken: "O email já está cadastrado, faça seu login"
+              taken: 'Este email já está cadastrado no Catarse. <a href="https://suporte.catarse.me/hc/pt-br/articles/360019497612-Erro-ao-alterar-o-email" class="link-error" target="_blank">Saiba como resolver aqui</a>.'
               invalid: "Esse endereço de email é inválido"
               blank: "O email não pode ficar em branco"
+              confirmation: "Confirmação de email está incorreta."
             password:
               too_short: "A senha é muito curta. Mínimo 6 caracteres."
               confirmation: "A senha e a confirmação de senha preenchidas não estão iguais"


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

On users edit settings, change email errors were not being correctly displayed.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
