### PR TITLE
fixing the subscription reward id that should be searched for #163129641

### DIFF
--- a/services/catarse.js/legacy/src/c/dashboard-subscription-card.js
+++ b/services/catarse.js/legacy/src/c/dashboard-subscription-card.js
@@ -29,10 +29,10 @@ const dashboardSubscriptionCard = {
             });
         }
 
-        if (subscription.reward_external_id) {
+        if (subscription.current_reward_data && subscription.current_reward_data.external_id) {
             const filterRewVM = catarse.filtersVM({
                     id: 'eq'
-                }).id(subscription.reward_external_id),
+                }).id(subscription.current_reward_data.external_id),
                 lRew = catarse.loaderWithToken(models.rewardDetail.getRowOptions(filterRewVM.parameters()));
 
             lRew.load().then((data) => {


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

The reward that is showing on subscriptions report is the edited subscription reward. This fix to show the correct reward data.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
