### PR TITLE
fixing anonymity checkbox to be checked when user click avoiding dela…

### DIFF
--- a/services/catarse.js/legacy/src/vms/subscription-vm.js
+++ b/services/catarse.js/legacy/src/vms/subscription-vm.js
@@ -87,6 +87,8 @@ const toogleAnonymous = (subscription) => {
     }
 
     const setAnonymityModel = models.setSubscriptionAnonymity(subscription.id)
+    subscription.checkout_data.anonymous = !subscription.checkout_data.anonymous;
+    m.redraw();
 
     return commonProxy
         .loaderWithToken(setAnonymityModel.postOptions(subscriptionAnonymity, {}))
@@ -95,10 +97,12 @@ const toogleAnonymous = (subscription) => {
             if ('set_subscription_anonymity' in d) {
                 subscription.checkout_data.anonymous = d.set_subscription_anonymity.anonymous;
                 m.redraw();
-            } else {
-                subscription.checkout_data.anonymous = !subscription.checkout_data.anonymous;
             }
             return d;
+        })
+        .catch(err => {
+            subscription.checkout_data.anonymous = !subscription.checkout_data.anonymous;
+            m.redraw();
         });
 };
 


### PR DESCRIPTION
…ys on visual responses

Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

When users change their anonymity to a subscription, this should respond immediately on visual. 
### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
