### PR TITLE
Change pagamento to cobrança in sub report online

### DIFF
--- a/services/catarse.js/legacy/src/root/projects-subscription-report.js
+++ b/services/catarse.js/legacy/src/root/projects-subscription-report.js
@@ -374,7 +374,7 @@ const projectSubscriptionReport = {
                                     ),
                                     m('.table-col.w-col.w-col-2.u-text-center',
                                         m('div',
-                                            'Último pagamento'
+                                            'Última cobrança'
                                         )
                                     ),
                                     m('.table-col.w-col.w-col-2.u-text-center',


### PR DESCRIPTION
Minor copy changing to make it clear that the online subscription reports shows not only confirmed payment but also charges that havent been confirmed