### PR TITLE
Including 2018 year in review on footer

### DIFF
--- a/services/catarse.js/legacy/src/root/footer.js
+++ b/services/catarse.js/legacy/src/root/footer.js
@@ -35,8 +35,8 @@ const footer = {
                                                 m(`a.link-footer[href=\'https://www.catarse.me/${window.I18n.locale}/press?ref=ctrse_footer\']`,
                                                     ' Imprensa'
                                                 ),
-                                                m('a.u-marginbottom-30.link-footer[href=\'http://ano.catarse.me/2017?ref=ctrse_footer\']',
-                                                    ' Retrospectiva 2017'
+                                                m('a.u-marginbottom-30.link-footer[href=\'http://ano.catarse.me/2018?ref=ctrse_footer\']',
+                                                    ' Retrospectiva 2018'
                                                 ),
                                                 m('.footer-full-signature-text.fontsize-small',
                                                     'Redes Sociais'
@@ -122,13 +122,7 @@ const footer = {
                                                     ' Publicações Independentes'
                                                 ),
                                                 m('a.u-marginbottom-30.link-footer[href=\'https://crowdfunding.catarse.me/assinaturas?ref=ctrse_footer\']',
-                                                    [
-                                                        'Catarse Assinaturas',
-                                                        m.trust('&nbsp;'),
-                                                        m('span.badge.badge-success',
-                                                        'Novidade‍'
-                                                       )
-                                                    ]
+                                                    'Catarse Assinaturas'
                                                  ),
                                                 m('.footer-full-signature-text.fontsize-small',
                                                     'Apoie projetos no Catarse'


### PR DESCRIPTION
### Why

We still had the 2017 Year in review on footer. Also we still had the "NEWS" badge next to Catarse Assinaturas link.