### PR TITLE
Small fix on the email confirmation message copy

### DIFF
--- a/services/catarse/config/locales/catarse_bootstrap/views/users/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/edit.pt.yml
@@ -35,10 +35,10 @@ pt:
         label_address_phone: 'Telefone'
       email_confirmation:
         hello: "Olá %{name}"
-        hello_sub: "Estamos tendo problemas em falar com você..."
+        hello_sub: "Queremos certificar que temos o seu contato atualizado!"
         hello_email: "Esse é o seu email de contato? %{email}"
         confirmed_title: "Não deixe de olhar nossos emails!"
-        confirmed_sub: "Verifique seu SPAM e autorize os emails do Catarse."
+        confirmed_sub: "Se tiver problemas, olhe sempre seu SPAM e autorize os emails do Catarse ;)"
       contributions: "Apoiados"
       projects: "Criados"
       about_me: "Sobre você"


### PR DESCRIPTION
Just making it a bit less alarming ;)

### Why

O texto que usamos hoje na mensagem de email confirmado deixa margem à dúvidas sobre quais emails especificamente estamos tentando enviar e o user não está abrindo. Com esse copy, vai ficar um pouco mais genérico.