### PR TITLE
Changing Novidades to Enviar Novidades

### DIFF
--- a/services/catarse.js/legacy/src/c/project-dashboard-menu.js
+++ b/services/catarse.js/legacy/src/c/project-dashboard-menu.js
@@ -115,7 +115,7 @@ const projectDashboardMenu = {
                                 window.I18n.t('posts_tab', I18nScope()),
                                 project.posts_count > 0 ?
                                 m('span.badge', project.posts_count) :
-                                m('span.badge.badge-attention', 'Nenhuma')
+                                m('span.badge.badge-attention', '0')
                             ]),
 
                             (projectVM.isSubscription(project) ? '' :

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/edit.pt.yml
@@ -240,7 +240,7 @@ pt:
       subscriptions_tab: ' Base de assinantes'
       surveys_tab: ' Questionários'
       preview_tab: Preview
-      posts_tab: ' Novidades '
+      posts_tab: ' Enviar Novidades '
       edit_project: ' Editar projeto '
       fiscal_tab: ' Documentos Fiscais'
       send: Enviar


### PR DESCRIPTION
### Why

Para melhorar a compreensão do que é a aba novidades, vamos mudar o nome da aba para 'Enviar Novidades'