### PR TITLE
Change base image away from jessie

### DIFF
--- a/services/hook-service-api/Dockerfile
+++ b/services/hook-service-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM comum/pg-dispatcher:latest AS dispatcher-env
 
-FROM node:9.1
+FROM node:9.1-stretch
 
 RUN apt-get update
 RUN apt-get update && apt-get install -y libssl-dev

--- a/services/notification-service-api/Dockerfile
+++ b/services/notification-service-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM comum/pg-dispatcher:latest AS dispatcher-env
 
-FROM node:9.1
+FROM node:9.1-stretch
 
 RUN apt-get update
 RUN apt-get update && apt-get install -y libssl-dev

--- a/services/payment-service-api/Dockerfile
+++ b/services/payment-service-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM comum/pg-dispatcher:latest AS dispatcher-env
 
-FROM node:9.1
+FROM node:9.1-stretch
 
 RUN apt-get update
 RUN apt-get update && apt-get install -y libssl-dev


### PR DESCRIPTION
### Why

It fixes the following error when building from scratch:

```
+ apt-get update
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [7340 B]
Get:3 http://deb.debian.org jessie Release.gpg [2420 B]
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [825 kB]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Fetched 10.1 MB in 8s (1182 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
```
