### PR TITLE
Change link in sub report payment status

### DIFF
--- a/services/catarse.js/legacy/src/root/projects-subscription-report.js
+++ b/services/catarse.js/legacy/src/root/projects-subscription-report.js
@@ -19,7 +19,7 @@ const statusCustomFilter = {
     view: () => m('.fontsize-smaller.u-text-center', [
         'Status ',
         m('a.fontsize-smallest.tooltip-wrapper.fa.fa-question-circle.fontcolor-secondary', {
-            href: 'https://suporte.catarse.me/hc/pt-br/articles/115005632746-Catarse-Assinaturas-FAQ-Realizadores#status',
+            href: 'https://suporte.catarse.me/hc/pt-br/articles/360024090391-O-que-significa-cada-status-das-assinaturas-e-pagamentos-',
             target: '_blank'
         })
     ])


### PR DESCRIPTION
### Why

We are sending the users to the wrong knowledge base article about subscription status.
