### PR TITLE
Feature/project metrics store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -435,4 +435,28 @@ services:
     networks:
       - cluster
 
+#### TEST ENV services
+
+  catarse_specs:
+    build:
+      context: ./services/catarse
+      dockerfile: dev.Dockerfile
+    environment:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://catarse:example@localhostcatarse:5432/catarse_db_test
+      REDIS_URL: redis://catarse_redis:6379
+    command: "bash run_specs"
+    volumes:
+      # mount volumes for development on catarse / catarse.js
+      - ./services/catarse/:/usr/app
+     # - ./services/catarse.js/:/usr/app/node_modules/catarse.js
+    links:
+      - service_core_db
+      - "catarse_db:localhostcatarse"
+      - "catarse_redis:catarse_redis"
+    depends_on:
+      - catarse_db
+      - catarse_redis
+    networks:
+      - cluster
 

--- a/services/catarse/app/models/project.rb
+++ b/services/catarse/app/models/project.rb
@@ -75,12 +75,6 @@ class Project < ActiveRecord::Base
                   using: :trigram,
                   ignoring: :accents
 
-  after_commit :start_metric_storage_worker, on: :create
-
-  def start_metric_storage_worker
-    ProjectMetricStorageRefreshWorker.perform_async(id)
-  end
-
   def self.pg_search(term)
     search_tsearch(term).presence || search_trm(term)
   end
@@ -491,7 +485,6 @@ class Project < ActiveRecord::Base
   def is_flexible?
     mode == 'flex'
   end
-
 
   def is_sub?
     mode == 'sub'

--- a/services/catarse/app/observers/flexible_project_observer.rb
+++ b/services/catarse/app/observers/flexible_project_observer.rb
@@ -17,6 +17,7 @@ class FlexibleProjectObserver < ActiveRecord::Observer
                                 audited_user_cpf: project.user.cpf,
                                 audited_user_phone_number: project.user.phone_number
                               })
+    ProjectMetricStorageRefreshWorker.perform_in(5.seconds, flexible_project.id)
   end
 
   private

--- a/services/catarse/app/observers/payment_observer.rb
+++ b/services/catarse/app/observers/payment_observer.rb
@@ -78,7 +78,8 @@ class PaymentObserver < ActiveRecord::Observer
 
     unless payment.paid_at.present?
       contribution.notify_to_contributor(:confirm_contribution)
-      ProjectScoreStorageRefreshWorker.perform_async(project.id) if project.open_for_contributions?
+      ProjectScoreStorageRefreshWorker.perform_async(project.id)
+      ProjectMetricStorageRefreshWorker.perform_async(project.id)
       if project.successful? && project.successful_pledged_transaction
         transfer_diff = (
           project.paid_pledged - project.all_pledged_kind_transactions.sum(:amount))

--- a/services/catarse/app/observers/project_observer.rb
+++ b/services/catarse/app/observers/project_observer.rb
@@ -54,6 +54,7 @@ class ProjectObserver < ActiveRecord::Observer
     )
 
     FacebookScrapeReloadWorker.perform_async(project.direct_url)
+    ProjectMetricStorageRefreshWorker.perform_in(5.seconds, project.id)
   end
 
   def from_online_to_draft(project)

--- a/services/catarse/app/observers/subscription_project_observer.rb
+++ b/services/catarse/app/observers/subscription_project_observer.rb
@@ -3,6 +3,8 @@
 class SubscriptionProjectObserver < ActiveRecord::Observer
   observe :subscription_project
 
-  def from_draft_to_online(sub_project); end
+  def from_draft_to_online(sub_project); 
+    ProjectMetricStorageRefreshWorker.perform_in(5.seconds, sub_project.id)
+  end
 
 end

--- a/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
+++ b/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
@@ -6,9 +6,10 @@ class ProjectMetricStorageRefreshWorker < ProjectBaseWorker
 
   def perform(id)
     _resource = resource(id)
-    unless ['draft', 'rejected'].include?(_resource.state)
-      _resource.refresh_project_metric_storage
-    end
-    ProjectMetricStorageRefreshWorker.perform_in(10.seconds, id)
+    can_refresh = !%w[draft deleted].include?(_resource.state)
+    can_schedule = !%w[draft rejected deleted failed successful].include?(_resource.state)
+
+    _resource.refresh_project_metric_storage if can_refresh
+    ProjectMetricStorageRefreshWorker.perform_in(10.seconds, id) if can_schedule
   end
 end

--- a/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
+++ b/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
@@ -7,9 +7,8 @@ class ProjectMetricStorageRefreshWorker < ProjectBaseWorker
   def perform(id)
     _resource = resource(id)
     can_refresh = !%w[draft deleted].include?(_resource.state)
-    can_schedule = !%w[draft rejected deleted failed successful].include?(_resource.state)
 
     _resource.refresh_project_metric_storage if can_refresh
-    ProjectMetricStorageRefreshWorker.perform_in(10.seconds, id) if can_schedule
+    ProjectMetricStorageRefreshWorker.perform_in(10.seconds, id) if _resource.is_sub?
   end
 end

--- a/services/catarse/run_specs
+++ b/services/catarse/run_specs
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex \ 
+  bundle exec rake db:create && \
+  bundle exec rake db:test:prepare && \
+  bundle exec rspec spec

--- a/services/catarse/spec/observers/payment_observer_spec.rb
+++ b/services/catarse/spec/observers/payment_observer_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe PaymentObserver do
   end
 
   describe '#from_pending_to_paid' do
+    context 'when first payment confirmation' do
+      before do
+        expect(payment.contribution).to receive(:notify_to_contributor).with(:confirm_contribution)
+        expect(ProjectScoreStorageRefreshWorker).to receive(:perform_async).with(payment.project.id)
+        expect(ProjectMetricStorageRefreshWorker).to receive(:perform_async).with(payment.project.id)
+      end
+
+      it 'should expectations' do
+        payment.notify_observers(:from_pending_to_paid)
+      end
+    end
     context 'when project is failed' do
       before do
         allow(payment.project).to receive(:state).and_return('failed')

--- a/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
+++ b/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
@@ -13,82 +13,41 @@ RSpec.describe ProjectMetricStorageRefreshWorker do
     Sidekiq::Testing.inline!
   end
 
-  context 'when project have status' do
-    context 'waiting_funds' do
-      let(:project) { create(:project, state: 'waiting_funds') }
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).to receive(:perform_in).with(10.seconds, project.id)
-      end
+  context 'when project is in draft' do
+    let(:project) { create(:project, state: 'draft') }
+    before do
+      expect(Project).to receive(:find).with(project.id).and_return(project)
+      expect(project).not_to receive(:refresh_project_metric_storage)
+      expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
+    end
+    it 'should not call refresh function' do
+      ProjectMetricStorageRefreshWorker.perform_async(project.id)
+    end
+  end
 
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+  context 'when project is not subscription type' do
+    let(:project) { create(:project, mode: 'flex', state: 'online') }
+    before do
+      expect(Project).to receive(:find).with(project.id).and_return(project)
+      expect(project).to receive(:refresh_project_metric_storage)
+      expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
     end
 
-    context 'online' do
-      let(:project) { create(:project, state: 'online') }
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).to receive(:perform_in).with(10.seconds, project.id)
-      end
+    it 'should not reschedule a next run for metrics refresh' do
+      ProjectMetricStorageRefreshWorker.perform_async(project.id)
+    end
+  end
 
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+  context 'when project is subscription type' do
+    let(:project) { create(:subscription_project, state: 'online') }
+    before do
+      expect(Project).to receive(:find).with(project.id).and_return(project)
+      expect(project).to receive(:refresh_project_metric_storage)
+      expect(ProjectMetricStorageRefreshWorker).to receive(:perform_in).with(10.seconds, project.id)
     end
 
-    context 'successful' do
-      let(:project) { create(:project, state: 'successful') }
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
-      end
-
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
-    end
-
-    context 'failed' do
-      let(:project) { create(:project, state: 'failed') }
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
-      end
-
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
-    end
-    context 'rejected' do
-      let(:project) { create(:project, state: 'rejected') }
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
-      end
-
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
-    end
-
-    context 'deleted' do
-      let(:project) { create(:project, state: 'deleted') }
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).not_to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
-      end
-
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
-    end
-
-    context 'draft' do
-      let(:project) { create(:project, state: 'draft') }
-
-      before do
-        expect(Project).to receive(:find).with(project.id).and_return(project)
-        expect(project).not_to receive(:refresh_project_metric_storage)
-        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
-      end
-
-      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    it 'should reschedule a next run for metrics refresh' do
+      ProjectMetricStorageRefreshWorker.perform_async(project.id)
     end
   end
 end

--- a/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
+++ b/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectMetricStorageRefreshWorker do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:confirmed_contribution) { create(:confirmed_contribution, project_id: project.id, user_id: user.id) }
+  let(:payment) { confirmed_contribution.payments.first }
+  let!(:contact_user) { create(:user, email: CatarseSettings[:email_contact]) }
+
+  before do
+    Sidekiq::Testing.inline!
+  end
+
+  context 'when project have status' do
+    context 'waiting_funds' do
+      let(:project) { create(:project, state: 'waiting_funds') }
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+
+    context 'online' do
+      let(:project) { create(:project, state: 'online') }
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+
+    context 'successful' do
+      let(:project) { create(:project, state: 'successful') }
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+
+    context 'failed' do
+      let(:project) { create(:project, state: 'failed') }
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+    context 'rejected' do
+      let(:project) { create(:project, state: 'rejected') }
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+
+    context 'deleted' do
+      let(:project) { create(:project, state: 'deleted') }
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).not_to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+
+    context 'draft' do
+      let(:project) { create(:project, state: 'draft') }
+
+      before do
+        expect(Project).to receive(:find).with(project.id).and_return(project)
+        expect(project).not_to receive(:refresh_project_metric_storage)
+        expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
+      end
+
+      it { ProjectMetricStorageRefreshWorker.perform_async(project.id)}
+    end
+  end
+end


### PR DESCRIPTION
### Why

Add adjusts to project metric store
- Only reschedule refresh worker job when project is a subscription project
- Spawn refresh worker job when project change transition to online
- Spawn refresh worker job when contribution is confirmed

### Wrap up checklist

- [x] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
