### PR TITLE
hashchange now scrolls to the top

### DIFF
--- a/services/catarse.js/legacy/src/h.js
+++ b/services/catarse.js/legacy/src/h.js
@@ -557,10 +557,14 @@ const _dataCache = {},
     redrawHashChange = before => {
         const callback = _.isFunction(before)
             ? () => {
-                  before();
-                  m.redraw();
+                    before();
+                    scrollTop();
+                    redraw();
               }
-            : m.redraw;
+            : () => {
+                scrollTop();
+                redraw();
+            }
 
         window.addEventListener('hashchange', callback, false);
     },

--- a/services/catarse.js/legacy/src/root/project-edit.js
+++ b/services/catarse.js/legacy/src/root/project-edit.js
@@ -34,7 +34,6 @@ const projectEdit = {
         const displayTabContent = () => {
 
             hash(window.location.hash);
-            h.scrollTop();
             const isUnpublishedAdmin = !project().is_published || project().is_admin_role;
             const isEmptyHash = _.isEmpty(hash()) || hash() === '#_=_';
 


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

When on project edit component, any field click was scrolling to the top.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
