### PR TITLE
fill state string field

### DIFF
--- a/services/catarse.js/legacy/src/c/address-form-national.js
+++ b/services/catarse.js/legacy/src/c/address-form-national.js
@@ -130,7 +130,7 @@ const addressFormNational = {
                                         const stateSelectedID = Number(event.target.value);
                                         fields.stateID(stateSelectedID);
                                         
-                                        if (_.isEmpty(countryStates())) {
+                                        if (!_.isEmpty(countryStates())) {
                                             const countryState = _.first(_.filter(countryStates(), countryState => {
                                                 return stateSelectedID === countryState.id;
                                             })); 

--- a/services/catarse.js/legacy/src/c/address-form.js
+++ b/services/catarse.js/legacy/src/c/address-form.js
@@ -33,6 +33,7 @@ const addressForm = {
                     url: `https://api.pagar.me/1/zipcodes/${zipCode}`,
                 })
                 .then(response => {
+                    fields.addressState(response.state);
                     fields.addressStreet(response.street);
                     fields.addressNeighbourhood(response.neighborhood);
                     fields.addressCity(response.city);

--- a/services/catarse.js/legacy/src/root/projects-payment.js
+++ b/services/catarse.js/legacy/src/root/projects-payment.js
@@ -47,6 +47,7 @@ const projectsPayment = {
             if (vm.validate()) {
                 vm.kondutoExecute();
                 showPaymentForm(true);
+                h.redraw();
             }
         };
 
@@ -327,6 +328,7 @@ const projectsPayment = {
 
                                         m('.card.card-terciary.u-radius.u-marginbottom-40',
                                             m(addressForm, {
+                                                addVM: state.vm.fields.address(),
                                                 addressFields: state.vm.fields.address().fields,
                                                 international: state.vm.isInternational,
                                                 hideNationality: true,

--- a/services/catarse.js/legacy/src/root/projects-subscription-checkout.js
+++ b/services/catarse.js/legacy/src/root/projects-subscription-checkout.js
@@ -85,6 +85,7 @@ const projectsSubscriptionCheckout = {
         const validateForm = () => {
             if (vm.validate()) {
                 showPaymentForm(true);
+                h.redraw();
             }
         };
 

--- a/services/catarse.js/legacy/src/vms/address-vm.js
+++ b/services/catarse.js/legacy/src/vms/address-vm.js
@@ -14,10 +14,6 @@ const addressVM = (args) => {
     const data = args.data;
     const international = prop();
     const statesLoader = catarse.loader(models.state.getPageOptions());
-    statesLoader.load().then(data => {
-        states(data);
-        h.redraw();
-    });
 
     const fields = {
         id: prop(data.id || ''),
@@ -59,6 +55,11 @@ const addressVM = (args) => {
         countries,
         errors
     };
+
+    statesLoader.load().then(data => {
+        states(data);
+        h.redraw();
+    });
 
     const setFields = (data) => {
         exportData.fields.id = prop(data.id || '');

--- a/services/catarse.js/legacy/src/vms/payment-vm.js
+++ b/services/catarse.js/legacy/src/vms/payment-vm.js
@@ -51,7 +51,7 @@ const paymentVM = () => {
         fields.ownerDocument(data.owner_document);
 
         creditCardFields.cardOwnerDocument(data.owner_document);
-        m.redraw();
+        h.redraw();
     };
 
     const expMonthOptions = () => [


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

Users with no contribution are not able to do it because of the address state acronym is missing.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
