### PR TITLE
Fix international address form

### DIFF
--- a/services/catarse.js/legacy/src/vms/address-vm.js
+++ b/services/catarse.js/legacy/src/vms/address-vm.js
@@ -76,36 +76,43 @@ const addressVM = (args) => {
         exportData.fields.phoneNumber = prop(data.phone_number || '');
         international(Number(data.country_id) !== defaultCountryID);
 
-        
+
         if (!_.isEmpty(states()) && !exportData.international()) {
             const countryState = _.first(_.filter(states(), countryState => {
                 return exportData.fields.stateID() === countryState.id;
-            })); 
+            }));
             exportData.fields.addressState(countryState.acronym);
         }
     };
 
     const getFields = () => {
-        
+
         if (!_.isEmpty(states()) && !exportData.international()) {
             const countryState = _.first(_.filter(states(), countryState => {
                 return exportData.fields.stateID() === countryState.id;
-            })); 
+            }));
             exportData.fields.addressState(countryState.acronym);
         }
-        
+
         const data = {};
         // data.id = exportData.fields.id();
         data.country_id = exportData.fields.countryID();
         data.state_id = exportData.fields.stateID();
         data.address_street = exportData.fields.addressStreet();
-        data.address_number = exportData.fields.addressNumber();
-        data.address_complement = exportData.fields.addressComplement();
-        data.address_neighbourhood = exportData.fields.addressNeighbourhood();
+        if (international()) {
+            data.address_number = null;
+            data.address_complement = null;
+            data.address_neighbourhood = null;
+            data.phone_number = null;
+        } else {
+            data.address_number = exportData.fields.addressNumber();
+            data.address_complement = exportData.fields.addressComplement();
+            data.address_neighbourhood = exportData.fields.addressNeighbourhood();
+            data.phone_number = exportData.fields.phoneNumber();
+        }
         data.address_city = exportData.fields.addressCity();
         data.address_state = exportData.fields.addressState();
         data.address_zip_code = exportData.fields.addressZipCode();
-        data.phone_number = exportData.fields.phoneNumber();
         return data;
     };
 

--- a/services/catarse/app/models/address.rb
+++ b/services/catarse/app/models/address.rb
@@ -1,6 +1,10 @@
 class Address < ActiveRecord::Base
   include Shared::CommonWrapper
 
+  REQUIRED_ATTRIBUTES = %i[
+    address_city address_zip_code phone_number address_neighbourhood address_street address_number
+  ].freeze
+
   belongs_to :country
   belongs_to :state
 
@@ -28,5 +32,15 @@ class Address < ActiveRecord::Base
 
   def index_on_common
     common_wrapper.index_address(self) if common_wrapper
+  end
+
+  def required_attributes
+    return Address::REQUIRED_ATTRIBUTES unless international?
+
+    Address::REQUIRED_ATTRIBUTES - %i[address_number address_neighbourhood phone_number]
+  end
+
+  def international?
+    country.try(:name) != 'Brasil'
   end
 end

--- a/services/catarse/app/models/user.rb
+++ b/services/catarse/app/models/user.rb
@@ -180,8 +180,8 @@ class User < ActiveRecord::Base
 
   def address_fields_validation
     if !reseting_password && (published_projects.present? || publishing_project || publishing_user_settings)
-      [:address_city, :address_zip_code, :phone_number, :address_neighbourhood, :address_street, :address_number].each do |field|
-        errors.add(field, :invalid) if !address.try(:send, field).present?
+      address.required_attributes.each do |attribute|
+        errors.add(attribute, :invalid) if address.try(:send, attribute).blank?
       end
     end
   end

--- a/services/catarse/spec/models/address_spec.rb
+++ b/services/catarse/spec/models/address_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  describe 'Constants' do
+    it 'has REQUIRED_ATTRIBUTES constant' do
+      expect(described_class::REQUIRED_ATTRIBUTES).to eq %i[
+        address_city address_zip_code phone_number address_neighbourhood address_street address_number
+      ].freeze
+    end
+  end
+
+  describe 'Instance methods' do
+    describe '#required_attributes' do
+      context 'when is international' do
+        before { allow(subject).to receive(:international?).and_return(true) }
+
+        it 'doesn`t includes address_number address_neighbourhood and phone_number' do
+          expect(subject.required_attributes).to_not include(:address_number, :address_neighbourhood, :phone_number)
+        end
+      end
+
+      context 'when isn`t international' do
+        before { allow(subject).to receive(:international?).and_return(false) }
+
+        it 'returns REQUIRED_ATTRIBUTES constant' do
+          expect(subject.required_attributes).to eq described_class::REQUIRED_ATTRIBUTES
+        end
+      end
+    end
+
+    describe '#international?' do
+      context 'when country is Brasil' do
+        before { allow(subject).to receive_message_chain('country.name').and_return('Brasil') }
+
+        it { is_expected.to_not be_international }
+      end
+
+      context 'when country isn`t Brasil' do
+        before { allow(subject).to receive_message_chain('country.name').and_return('United States') }
+
+        it { is_expected.to be_international }
+      end
+    end
+  end
+end

--- a/services/catarse/spec/models/user_spec.rb
+++ b/services/catarse/spec/models/user_spec.rb
@@ -639,4 +639,24 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq(:inactive) }
     end
   end
+
+  describe '#address_fields_validation' do
+    let(:user) { described_class.new }
+    let(:address) { Address.new }
+
+    before do
+      allow(user).to receive(:reseting_password).and_return(false)
+      allow(user).to receive_message_chain('published_projects.present?').and_return(true)
+      allow(user).to receive(:address).and_return(address)
+      allow(address).to receive(:required_attributes).and_return([:address_number])
+    end
+
+
+    it 'validates address required fields' do
+        user.address_fields_validation
+
+      expect(user.errors.size).to eq 1
+      expect(user.errors[:address_number]).to_not be_empty
+    end
+  end
 end


### PR DESCRIPTION
### Why

Relatórios tinham os endereços nacionais e internacionais misturados, pois a requisição enviava no request o endereço nacional mesmo sem aparecer os campos no formulário internacional.

### Wrap up checklist

- [x] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
