### PR TITLE
Fix how address state is filled [finishes #168061599]

### DIFF
--- a/services/catarse.js/legacy/src/vms/address-vm.js
+++ b/services/catarse.js/legacy/src/vms/address-vm.js
@@ -88,7 +88,7 @@ const addressVM = (args) => {
     const getFields = () => {
         const isInternational = Number(exportData.fields.countryID()) !== defaultCountryID;
 
-        if (!_.isEmpty(states()) && !exportData.international()) {
+        if (!_.isEmpty(states()) && !isInternational) {
             const countryState = _.first(_.filter(states(), countryState => {
                 return exportData.fields.stateID() === countryState.id;
             }));
@@ -98,15 +98,16 @@ const addressVM = (args) => {
         const data = {};
         // data.id = exportData.fields.id();
         data.country_id = exportData.fields.countryID();
-        data.state_id = exportData.fields.stateID();
         data.address_street = exportData.fields.addressStreet();
 
         if (!isInternational) {
+            data.state_id = exportData.fields.stateID();
             data.address_number = exportData.fields.addressNumber();
             data.address_complement = exportData.fields.addressComplement();
             data.address_neighbourhood = exportData.fields.addressNeighbourhood();
             data.phone_number = exportData.fields.phoneNumber();
         }
+
         data.address_city = exportData.fields.addressCity();
         data.address_state = exportData.fields.addressState();
         data.address_zip_code = exportData.fields.addressZipCode();


### PR DESCRIPTION
### Why

Quando mudava de um endereço nacional para internacional, a condicional `!exportData.international()` não estava funcionando corretamente e acabava  que algumas vezes sobrescrevendo o `stateAddress` preenchido pelo usuário com o acronimo do endereço nacional.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
