### PR TITLE
Fix/translation breaks component 168207300

### DIFF
--- a/services/catarse.js/legacy/src/app.js
+++ b/services/catarse.js/legacy/src/app.js
@@ -6,6 +6,8 @@ import Chart from 'chart.js';
 import { isNumber } from 'util';
 import { wrap } from './wrap';
 
+m.trust = (text) => h.trust(text);
+
 (function () {
     /// Setup an AUTO-SCROLL TOP when change route
     const pushState = history.pushState;

--- a/services/catarse.js/legacy/src/h.js
+++ b/services/catarse.js/legacy/src/h.js
@@ -4,6 +4,7 @@ import m from 'mithril';
 import prop from 'mithril/stream';
 import { catarse } from './api';
 import contributionVM from './vms/contribution-vm';
+import generativeTrust from 'mithril-generative-trust/src/index';
 
 function getCallStack() {
     const callStackStr = new Error().stack;
@@ -1050,7 +1051,8 @@ const _dataCache = {},
                 });
             },
         };
-    };
+    },
+    trust = (text) => generativeTrust(text, { eliminateScriptTags : true });
 
 setMomentifyLocale();
 closeFlash();
@@ -1144,4 +1146,5 @@ export default {
     setCsrfToken,
     userSignedIn,
     isDevEnv,
+    trust,
 };

--- a/services/catarse.js/legacy/src/root/users-show.js
+++ b/services/catarse.js/legacy/src/root/users-show.js
@@ -59,10 +59,7 @@ const usersShow = {
                   [
                     (!_.isEmpty(user) ?
                      (user.is_owner_or_admin ?
-                      m(`a.dashboard-nav-link.dashboard[href=\'/${window.I18n.locale}/users/${user.id}/edit\']`, { oncreate: m.route.link,
-                          onclick: () => {
-                              m.route(`/users/edit/${user.id}`, { user_id: user.id });
-                          } },
+                      m(`a.dashboard-nav-link.dashboard[href=\'/${window.I18n.locale}/users/${user.id}/edit\']`,
                           [
                               m('span.fa.fa-cog'),
                               m.trust('&nbsp;'),

--- a/services/catarse.js/package.json
+++ b/services/catarse.js/package.json
@@ -37,7 +37,7 @@
     "scripts": {
         "test": "gulp test",
         "start": "webpack -d --watch",
-        "start-dev" : "NODE_OPTIONS=\"--max-old-space-size=512\" webpack -d --watch",
+        "start-dev": "NODE_OPTIONS=\"--max-old-space-size=512\" webpack -d --watch",
         "build": "./node_modules/.bin/webpack",
         "build:prod": "NODE_ENV=production ./node_modules/.bin/webpack --mode production",
         "build:dev": "./node_modules/.bin/webpack-dev-server"
@@ -58,6 +58,7 @@
         "webpack": "^4.12.0",
         "webpack-cli": "^3.0.4",
         "webpack-dev-server": "^3.1.4",
-        "ifdef-loader": "^2.1.1"
+        "ifdef-loader": "^2.1.1",
+        "mithril-generative-trust": "git+https://github.com/grpse/mithril-generative-trust.git#v1.0.0"
     }
 }


### PR DESCRIPTION
### Why

Using m.trust and in page translation, components generated were lost because html is replaced. This library generates recursively the mithril componentes structure from a html string.

### Wrap up checklist

- [x] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
