### PR TITLE
adding onchange event on image selection [finishes #168293518]

### DIFF
--- a/services/catarse.js/legacy/src/c/dashboard-reward-card.js
+++ b/services/catarse.js/legacy/src/c/dashboard-reward-card.js
@@ -271,7 +271,8 @@ const dashboardRewardCard = {
                                     m("div.w-form", [
                                         m("form",
                                             m(`input.text-field.w-input[type='file'][placeholder='Choose file'][id='reward_image_file_closed_card_${attrs.index}']`, {
-                                                oninput: () => onSelectImageFile()
+                                                oninput: () => onSelectImageFile(),
+                                                onchange: () => onSelectImageFile(),
                                             })
                                         ),
                                         m("div.w-form-done",

--- a/services/catarse.js/legacy/src/c/edit-reward-card.js
+++ b/services/catarse.js/legacy/src/c/edit-reward-card.js
@@ -413,7 +413,8 @@ const editRewardCard = {
                                         ),
                                         m("div.w-col.w-col-7",
                                             m(`input.text-field.w-input[type='file'][placeholder='Choose file'][id='reward_image_file_open_card_${index}']`, {
-                                                oninput: () => state.onSelectImageFile()
+                                                oninput: () => state.onSelectImageFile(),
+                                                onchange: () => state.onSelectImageFile(),
                                             })
                                         )
                                     ])


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

Safari web browser (webkit based browsers) don't accept 'oninput' event on file field.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
