### PR TITLE
set project.about to use original mithril trust [finishes #168986703]

### DIFF
--- a/services/catarse.js/legacy/spec/components/project-about.spec.js
+++ b/services/catarse.js/legacy/spec/components/project-about.spec.js
@@ -10,6 +10,7 @@ describe('ProjectAbout', () => {
         beforeAll(() => {
             projectDetail = ProjectDetailsMockery()[0];
             rewardDetail = RewardDetailsMockery()[0];
+            m.originalTrust = m.trust;
             $output = mq(projectAbout, {
                 hasSubscription: prop(false),
                 project: prop(projectDetail),

--- a/services/catarse.js/legacy/spec/components/root/projects-show.spec.js
+++ b/services/catarse.js/legacy/spec/components/root/projects-show.spec.js
@@ -5,6 +5,7 @@ describe('ProjectsShow', () => {
   let $output, projectDetail;
 
   beforeAll(() => {
+    m.originalTrust = m.trust;
     window.location.hash = '';
     projectDetail = ProjectDetailsMockery()[0];
     let component = m(projectsShow, {project_id: 123, project_user_id: 1231});

--- a/services/catarse.js/legacy/src/app.js
+++ b/services/catarse.js/legacy/src/app.js
@@ -6,6 +6,7 @@ import Chart from 'chart.js';
 import { isNumber } from 'util';
 import { wrap } from './wrap';
 
+m.originalTrust = m.trust;
 m.trust = (text) => h.trust(text);
 
 (function () {

--- a/services/catarse.js/legacy/src/c/project-about.js
+++ b/services/catarse.js/legacy/src/c/project-about.js
@@ -57,7 +57,7 @@ const projectAbout = {
                 m('p.fontsize-base', [
                     m('strong', 'O projeto'),
                 ]),
-                m('.fontsize-base[itemprop="about"]', m.trust(h.selfOrEmpty(project.about_html, '...'))),
+                m('.fontsize-base[itemprop="about"]', m.originalTrust(h.selfOrEmpty(project.about_html, '...'))),
                 project.budget ? [
                     m('p.fontsize-base.fontweight-semibold', 'Orçamento'),
                     m('p.fontsize-base', m.trust(project.budget))


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

generative trust breaks saved html.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
