### PR TITLE
survey preview now uses fields from addressVM [finishes #168931748]

### DIFF
--- a/services/catarse.js/legacy/src/c/survey-preview.js
+++ b/services/catarse.js/legacy/src/c/survey-preview.js
@@ -68,7 +68,7 @@ const surveyPreview = {
                                         `${window.I18n.t('address_state', I18nScope())}:`
                                     ),
                                     m.trust('&nbsp;'),
-                                    attrs.stateName,
+                                    state.fields.address_state,
                                     m('br'),
                                     m('span.fontweight-semibold',
                                         `${window.I18n.t('address_zip_code', I18nScope())}:`


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

Surveys preview were not showing users their state name

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
