### PR TITLE
Fix/shipping fees with wrong decimal value 169267994

### DIFF
--- a/services/catarse.js/legacy/src/c/posts-preview.js
+++ b/services/catarse.js/legacy/src/c/posts-preview.js
@@ -107,7 +107,7 @@ const postsPreview = {
                                 m('.fontsize-larger.fontweight-semibold.u-marginbottom-30.u-text-center',
                                     title
                                 ),
-                                m('.fontsize-base', m.trust(comment_html))
+                                m('.fontsize-base', m.originalTrust(comment_html))
                             ]),
                             m('.w-col.w-col-1')
                         ])

--- a/services/catarse.js/legacy/src/c/project-posts.js
+++ b/services/catarse.js/legacy/src/c/project-posts.js
@@ -91,7 +91,7 @@ const projectPosts = {
                                     m('p.fontweight-semibold.fontsize-larger.u-text-center.u-marginbottom-30', [
                                         m(`a.link-hidden[href="/projects/${post.project_id}/posts/${post.id}#posts"]`, post.title)
                                     ]),
-                                    (m('.fontsize-base', m.trust(post.comment_html)))
+                                    (m('.fontsize-base', m.originalTrust(post.comment_html)))
                                 ]),
                                 m('.divider.u-marginbottom-60')
                             ])

--- a/services/catarse.js/legacy/src/c/shipping-fee-input.js
+++ b/services/catarse.js/legacy/src/c/shipping-fee-input.js
@@ -16,9 +16,8 @@ const shippingFeeInput = {
             applyMask = _.compose(fee.value, h.applyMonetaryMask);
 
         _.extend(fee, { deleted });
-        const onlyNumbersForFee = `${fee.value()}`.replace(/\D+/g, '');
-        const feeNumberValue = Number(onlyNumbersForFee);
-        fee.value(feeNumberValue ? `${h.formatNumber(feeNumberValue, 2, 3)}` : '0,00');
+        const feeNumberValue = Number(fee.value());
+        fee.value(feeNumberValue ? `${h.formatNumber(feeNumberValue, 2, 2)}` : '0,00');
         vnode.state = {
             fee,
             applyMask,
@@ -84,7 +83,7 @@ const shippingFeeInput = {
                         ),
                         m('.w-col.w-col-9',
                             m('input.positive.postfix.text-field.w-input', {
-                                value: state.feeValue(),
+                                value: state.applyMask(state.feeValue()),
                                 autocomplete: 'off',
                                 type: 'text',
                                 onkeyup: m.withAttr('value', state.applyMask),

--- a/services/catarse.js/legacy/src/root/posts.js
+++ b/services/catarse.js/legacy/src/root/posts.js
@@ -414,7 +414,7 @@ const posts = {
                                     m('.table-col.w-col.w-col-1')
                                 ]),
                                 (state.projectPosts() ? m('.fontsize-small.table-inner', [
-                                    _.map(state.projectPosts(), 
+                                    _.map(state.projectPosts(),
                                         post => m(postEntry, {
                                             post,
                                             project,


### PR DESCRIPTION
### Why

Shipping fees pt-br formatting were getting wrong when loading api's data.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
