### PR TITLE
Change Catarse changelog URL on site's footer

### DIFF
--- a/services/catarse.js/legacy/src/root/footer.js
+++ b/services/catarse.js/legacy/src/root/footer.js
@@ -87,7 +87,7 @@ const footer = {
                                                     m('a.link-footer[href=\'http://suporte.catarse.me/hc/pt-br/requests/new\'][target="_BLANK"]',
                                                       ' Contato'
                                                      ),
-                                                m('a.link-footer[href=\'http://blog.catarse.me/category/atualizacoes\']',
+                                                m('a.link-footer[href=\'https://crowdfunding.catarse.me/changelog\']',
                                                   ' Atualizações 🌟'
                                                  ),
                                                 m('a.link-footer[href=\'https://www.ofinanciamentocoletivo.com.br/?ref=ctrse_footer\']',


### PR DESCRIPTION
### Why

We are launching a new site for our changelog: https://crowdfunding.catarse.me/changelog

