### PR TITLE
use output file read to send_data

### DIFF
--- a/services/catarse/app/controllers/projects/project_report_exports_controller.rb
+++ b/services/catarse/app/controllers/projects/project_report_exports_controller.rb
@@ -17,7 +17,7 @@ class Projects::ProjectReportExportsController < ApplicationController
     authorize parent, :update?
     resource = parent.project_report_exports.find params[:id]
     if resource.try(:output).try(:url).present?  && resource.state.eql?('done')
-      send_data resource.output.uploaded_file_location,
+      send_data resource.output.file.read,
         type: resource.content_type,
         filename: resource.report_filename_locale,
         x_sendfile: true


### PR DESCRIPTION
### Why

Use file.read to use file contents in send_data instead file location

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
