### PR TITLE
address state id guard

### DIFF
--- a/services/catarse.js/legacy/src/vms/address-vm.js
+++ b/services/catarse.js/legacy/src/vms/address-vm.js
@@ -80,7 +80,10 @@ const addressVM = (args) => {
             const countryState = _.first(_.filter(states(), countryState => {
                 return exportData.fields.stateID() === countryState.id;
             }));
-            exportData.fields.addressState(countryState.acronym);
+            
+            if (countryState) {
+                exportData.fields.addressState(countryState.acronym);
+            }
         }
     };
 
@@ -91,7 +94,10 @@ const addressVM = (args) => {
             const countryState = _.first(_.filter(states(), countryState => {
                 return exportData.fields.stateID() === countryState.id;
             }));
-            exportData.fields.addressState(countryState.acronym);
+            
+            if (countryState) {
+                exportData.fields.addressState(countryState.acronym);
+            }
         }
         const data = {};
         // data.id = exportData.fields.id();


### PR DESCRIPTION
### Why

Address state id should be filled in order to lookup for state acronym.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
