### PR TITLE
only validate document owner when contribution is national

### DIFF
--- a/services/catarse.js/legacy/src/c/payment-credit-card.js
+++ b/services/catarse.js/legacy/src/c/payment-credit-card.js
@@ -112,7 +112,9 @@ const paymentCreditCard = {
             vm.creditCardFields.errors([]);
 
             if (selectedCreditCard().id === -1) {
-                checkCardOwnerDocument();
+                if (!vm.isInternational()) {
+                    checkCardOwnerDocument();
+                }
                 checkExpiry();
                 checkcvv();
                 checkCreditCard();


### PR DESCRIPTION
### Why

Don't make owner document validation when contribution/subscription is international.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
