### PR TITLE
home banner 'Ver todos' on covid banner redirects to covid mode and p…

### DIFF
--- a/services/catarse.js/legacy/src/c/projects-display.js
+++ b/services/catarse.js/legacy/src/c/projects-display.js
@@ -51,12 +51,14 @@ const projectsDisplay = {
                 )
                 .then(() => m.redraw());
 
-            const query = {};
-
-            if (f.mode) {
-                query.mode = f.mode;
-            } else {
-                query.filter = f.keyName;
+            const query = f.query || {};
+            
+            if (!f.query) {
+                if (f.mode) {
+                    query.mode = f.mode;
+                } else {
+                    query.filter = f.keyName;
+                }
             }
 
             return {

--- a/services/catarse.js/legacy/src/vms/project-filters-vm.js
+++ b/services/catarse.js/legacy/src/vms/project-filters-vm.js
@@ -101,6 +101,10 @@ const projectFiltersVM = () => {
                 nicename: 'Projetos COVID-19',
                 isContextual: false,
                 keyName: 'covid_19',
+                query: {
+                    mode: 'covid_19',
+                    filter: 'all'
+                }
             },
             saved_projects: {
                 title: 'Projetos Salvos',


### PR DESCRIPTION
…opulars

Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why

COVID-19 projects home banner see all button should redirect to COVID populars.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
