### PR TITLE
fix migrations view '1'.projects columns order

### DIFF
--- a/services/catarse/db/migrate/20200328104317_projects_view_sort_by_city_match_first.rb
+++ b/services/catarse/db/migrate/20200328104317_projects_view_sort_by_city_match_first.rb
@@ -40,6 +40,9 @@ class ProjectsViewSortByCityMatchFirst < ActiveRecord::Migration
        (EXISTS ( SELECT true AS bool
               FROM project_reminders pr
              WHERE ((p.id = pr.project_id) AND (pr.user_id = current_user_id())))) AS saved_projects,
+        ( SELECT array_to_string(array_agg(COALESCE((integration.data ->> 'name'::text), (integration.name)::text)), ','::text) AS integration_name
+          FROM project_integrations integration
+        WHERE (integration.project_id = p.id)) AS integrations,
        COALESCE(cat.name_pt, (cat.name_en)::text) AS category_name
       FROM ((((((((projects p
         JOIN users u ON ((p.user_id = u.id)))

--- a/services/catarse/db/migrate/20200401041707_adjust_score_calculations.rb
+++ b/services/catarse/db/migrate/20200401041707_adjust_score_calculations.rb
@@ -57,6 +57,9 @@ CREATE OR REPLACE VIEW "1"."projects" AS
     (EXISTS ( SELECT true AS bool
            FROM project_reminders pr
           WHERE ((p.id = pr.project_id) AND (pr.user_id = current_user_id())))) AS saved_projects,
+    ( SELECT array_to_string(array_agg(COALESCE((integration.data ->> 'name'::text), (integration.name)::text)), ','::text) AS integration_name
+          FROM project_integrations integration
+        WHERE (integration.project_id = p.id)) AS integrations,
     COALESCE(cat.name_pt, (cat.name_en)::text) AS category_name
    FROM projects p
      JOIN users u ON p.user_id = u.id

--- a/services/catarse/db/migrate/20200423191436_add_solidarity_integrations_names_campaign_as_column.rb
+++ b/services/catarse/db/migrate/20200423191436_add_solidarity_integrations_names_campaign_as_column.rb
@@ -62,8 +62,8 @@ class AddSolidarityIntegrationsNamesCampaignAsColumn < ActiveRecord::Migration
                 WHERE ((p.id = pr.project_id) AND (pr.user_id = current_user_id()))
             )
         ) AS saved_projects,
-        COALESCE(category.name_pt, category.name_en) as category_name,
-        (select string_agg(data->>'name'::text, ',') from public.integrations(p.id)) as integrations
+        (select string_agg(data->>'name'::text, ',') from public.integrations(p.id)) as integrations,
+        COALESCE(category.name_pt, category.name_en) as category_name
     FROM projects p
     JOIN users u ON p.user_id = u.id
     LEFT JOIN project_score_storages pss ON pss.project_id = p.id

--- a/services/catarse/db/migrate/20200430192805_projects_with_all_integrations_names.rb
+++ b/services/catarse/db/migrate/20200430192805_projects_with_all_integrations_names.rb
@@ -44,13 +44,13 @@ class ProjectsWithAllIntegrationsNames < ActiveRecord::Migration
                 WHERE ((p.id = pr.project_id) AND (pr.user_id = current_user_id()))
             )
         ) AS saved_projects,
-        COALESCE(category.name_pt, category.name_en) as category_name,
         (
             SELECT 
                 array_to_string(array_agg(COALESCE(integration.data->>'name'::text, integration.name)), ',') as integration_name 
             FROM project_integrations AS integration 
             WHERE integration.project_id = p.id
-        ) as integrations
+        ) as integrations,
+        COALESCE(category.name_pt, category.name_en) as category_name
     FROM projects p
     JOIN users u ON p.user_id = u.id
     LEFT JOIN project_score_storages pss ON pss.project_id = p.id

--- a/services/catarse/db/migrate/20200504193428_add_category_name_to_projects_view.rb
+++ b/services/catarse/db/migrate/20200504193428_add_category_name_to_projects_view.rb
@@ -40,10 +40,10 @@ class AddCategoryNameToProjectsView < ActiveRecord::Migration
        (EXISTS ( SELECT true AS bool
               FROM project_reminders pr
              WHERE ((p.id = pr.project_id) AND (pr.user_id = current_user_id())))) AS saved_projects,
-             COALESCE(category.name_pt, category.name_en) as category_name,
-       ( SELECT array_to_string(array_agg(COALESCE((integration.data ->> 'name'::text), (integration.name)::text)), ','::text) AS integration_name
+        ( SELECT array_to_string(array_agg(COALESCE((integration.data ->> 'name'::text), (integration.name)::text)), ','::text) AS integration_name
               FROM project_integrations integration
-             WHERE (integration.project_id = p.id)) AS integrations       
+              WHERE (integration.project_id = p.id)) AS integrations,
+          COALESCE(category.name_pt, category.name_en) as category_name
       FROM projects p
         JOIN users u ON p.user_id = u.id
         LEFT JOIN project_score_storages pss ON pss.project_id = p.id

--- a/services/catarse/db/migrate/20200520153352_finished_projects_view_with_integrations.rb
+++ b/services/catarse/db/migrate/20200520153352_finished_projects_view_with_integrations.rb
@@ -35,10 +35,11 @@ class FinishedProjectsViewWithIntegrations < ActiveRecord::Migration
        (EXISTS ( SELECT true AS bool
               FROM project_reminders pr
              WHERE ((p.id = pr.project_id) AND (pr.user_id = current_user_id())))) AS saved_projects,
-             COALESCE(category.name_pt, category.name_en) as category_name,
+             
        ( SELECT array_to_string(array_agg(COALESCE((integration.data ->> 'name'::text), (integration.name)::text)), ','::text) AS integration_name
               FROM project_integrations integration
-             WHERE (integration.project_id = p.id)) AS integrations
+             WHERE (integration.project_id = p.id)) AS integrations,
+        COALESCE(category.name_pt, category.name_en) as category_name
       FROM projects p
         JOIN users u ON p.user_id = u.id
         JOIN cities c ON c.id = p.city_id


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Why
Change column order on "1".projects view from integrations and category_name
### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
