### PR TITLE
Ajustar ícone de fechar filtro do explore

### DIFF
--- a/services/catarse.js/legacy/spec/components/explore-search-filter-select.spec.js
+++ b/services/catarse.js/legacy/spec/components/explore-search-filter-select.spec.js
@@ -63,7 +63,7 @@ describe('ExploreFilterSelect', () => {
             component.click(`a.fontsize-smallest.link-hidden-light:contains("${values[0].label}")`,  new Event('click'));
             component.should.not.have(`a.fontsize-smallest.link-hidden-light`);
             expect(currentValue.value).toBe(values[0].value);
-            component.click('.inline-block.fa.fa-times', new Event('click'));
+            component.click('.inline-block.fa.far-times', new Event('click'));
             component.should.have(`.explore-span-filter-name > .inline-block:contains("${attrs.noneSelected}")`);
         });
 

--- a/services/catarse.js/legacy/src/c/explore-search-filter-select.js
+++ b/services/catarse.js/legacy/src/c/explore-search-filter-select.js
@@ -39,7 +39,7 @@ export const ExploreSearchFilterSelect = {
                     m('div.explore-mobile-label', mobileLabel),
                     m('div.inline-block', selectedItem)
                 ]),
-                m(`.inline-block.fa${ hasItemSelected ? '.fa-times' : '.fa-angle-down'}[aria-hidden="true"]`, {
+                m(`.inline-block${ hasItemSelected ? '.far.fa-times' : '.fa.fa-angle-down'}[aria-hidden="true"]`, {
                     onclick: (/** @type {Event} */ event) => {
                         if (hasItemSelected) {
                             onSelect(null);


### PR DESCRIPTION
Um pequeno ajuste para que o 'X' de fechar o filtro do explore use a font awesome 'far' (que é a fonte regular, com um peso um pouco mais leve) do que a 'fa' que é usado para o 'angle-down'

