### PR TITLE
Hotfix/reward details

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
   test_catarse:
     docker:
       - image: circleci/ruby:2.4.4-stretch-node-browsers
-      - image: postgres:9.4
+      - image: postgres:11.5
         environment:
           POSTGRES_DB: catarse_test
           POSTGRES_PASSWORD: example

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,10 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 17.05.0-ce
+      - run: sudo tee /etc/apt/sources.list.d/pgdg.list <<END deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main END
+      - run: sudo wget https://www.postgresql.org/media/keys/ACCC4CF8.asc && sudo apt-key add ACCC4CF8.asc
       - run: sudo apt update
-      - run: sudo apt install postgresql-client
+      - run: sudo apt install postgresql-client-11
       - run:
           name: Run catarse installs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,10 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 17.05.0-ce
-      - run: sudo tee /etc/apt/sources.list.d/pgdg.list <<END deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main END
+      - run: |
+          sudo tee /etc/apt/sources.list.d/pgdg.list <<END 
+            deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+          END
       - run: sudo wget https://www.postgresql.org/media/keys/ACCC4CF8.asc && sudo apt-key add ACCC4CF8.asc
       - run: sudo apt update
       - run: sudo apt install postgresql-client-11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         ipv4_address: 10.0.1.41
 
   catarse_db:
-    image: library/postgres:9.4-alpine
+    image: library/postgres:11.5-alpine
     volumes:
       - ./services/service-core-db/init_catarse.sql:/docker-entrypoint-initdb.d/init.sql
       - postgres-catarse-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,27 @@
-version: "3"
+version: "3.7"
+
+x-ctrse-service: &ctrse-service
+    build:
+      context: ./services/catarse
+      dockerfile: dev.Dockerfile
+    environment:
+      RAILS_ENV: development
+      DATABASE_URL: postgres://catarse:example@localhostcatarse:5432/catarse_db
+      REDIS_URL: redis://catarse_redis:6379
+    volumes:
+      # mount volumes for development on catarse / catarse.js
+      - ./services/catarse/:/usr/app
+     # - ./services/catarse.js/:/usr/app/node_modules/catarse.js
+    links:
+      - service_core_db
+      - "catarse_db:localhostcatarse"
+      - "catarse_redis:catarse_redis"
+    depends_on:
+      - catarse_db
+      - catarse_redis
+    networks:
+      - cluster
+
 volumes:
   postgres-data:
     driver: local
@@ -187,48 +210,12 @@ services:
         ipv4_address: 10.0.1.47
 
   catarse_migrations:
-    build:
-      context: ./services/catarse
-      dockerfile: dev.Dockerfile
-    environment:
-      RAILS_ENV: development
-      DATABASE_URL: postgres://catarse:example@localhostcatarse:5432/catarse_db
-      REDIS_URL: redis://catarse_redis:6379
+    <<: *ctrse-service
     command: ["bundle", "exec", "rake", "db:migrate"]
-    volumes:
-      # mount volumes for development on catarse / catarse.js
-      - ./services/catarse/:/usr/app
-     # - ./services/catarse.js/:/usr/app/node_modules/catarse.js
-    links:
-      - service_core_db
-      - "catarse_db:localhostcatarse"
-      - "catarse_redis:catarse_redis"
-    depends_on:
-      - catarse_db
-      - catarse_redis
-    networks:
-      - cluster
 
   catarse:
-    build:
-      context: ./services/catarse
-      dockerfile: dev.Dockerfile
-    environment:
-      RAILS_ENV: development
-      DATABASE_URL: postgres://catarse:example@localhostcatarse:5432/catarse_db
-      REDIS_URL: redis://catarse_redis:6379
+    <<: *ctrse-service
     command: ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
-    volumes:
-      # mount volumes for development on catarse / catarse.js
-      - ./services/catarse/:/usr/app
-      # - ./services/catarse.js/:/usr/app/node_modules/catarse.js
-    links:
-      - service_core_db
-      - "catarse_db:localhostcatarse"
-      - "catarse_redis:catarse_redis"
-    depends_on:
-      - catarse_db
-      - catarse_redis
     ports:
       - "3000:3000"
     networks:
@@ -440,25 +427,10 @@ services:
 #### TEST ENV services
 
   catarse_specs:
-    build:
-      context: ./services/catarse
-      dockerfile: dev.Dockerfile
+    <<: *ctrse-service
     environment:
       RAILS_ENV: test
       DATABASE_URL: postgres://catarse:example@localhostcatarse:5432/catarse_db_test
       REDIS_URL: redis://catarse_redis:6379
     command: "bash run_specs"
-    volumes:
-      # mount volumes for development on catarse / catarse.js
-      - ./services/catarse/:/usr/app
-     # - ./services/catarse.js/:/usr/app/node_modules/catarse.js
-    links:
-      - service_core_db
-      - "catarse_db:localhostcatarse"
-      - "catarse_redis:catarse_redis"
-    depends_on:
-      - catarse_db
-      - catarse_redis
-    networks:
-      - cluster
 

--- a/services/catarse/.circleci/config.yml
+++ b/services/catarse/.circleci/config.yml
@@ -10,7 +10,10 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 17.05.0-ce
-      - run: sudo apt update && sudo apt install postgresql-client
+      - run: sudo tee /etc/apt/sources.list.d/pgdg.list <<END deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main END
+      - run: sudo wget https://www.postgresql.org/media/keys/ACCC4CF8.asc && sudo apt-key add ACCC4CF8.asc
+      - run: sudo apt update
+      - run: sudo apt install postgresql-client-11
       - run: bundle install
       - run: npm install
       - run: RAILS_ENV=test DATABASE_URL=postgres://postgres:example@localhost:5432/catarse_test bundle exec rake db:migrate

--- a/services/catarse/.circleci/config.yml
+++ b/services/catarse/.circleci/config.yml
@@ -10,7 +10,10 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 17.05.0-ce
-      - run: sudo tee /etc/apt/sources.list.d/pgdg.list <<END deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main END
+      - run: |
+          sudo tee /etc/apt/sources.list.d/pgdg.list <<END 
+            deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+          END
       - run: sudo wget https://www.postgresql.org/media/keys/ACCC4CF8.asc && sudo apt-key add ACCC4CF8.asc
       - run: sudo apt update
       - run: sudo apt install postgresql-client-11

--- a/services/catarse/.circleci/config.yml
+++ b/services/catarse/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.4.4-stretch-node-browsers
-      - image: postgres:9.4
+      - image: postgres:11.5
         environment:
           POSTGRES_DB: catarse_test
     steps:

--- a/services/catarse/Gemfile
+++ b/services/catarse/Gemfile
@@ -178,3 +178,4 @@ gem 'uglifier', '4.0.0'
 gem 'sprockets', '~> 3.7.2'
 gem "rack", ">= 1.6.11"
 gem "loofah", ">= 2.2.3"
+gem 'concurrent-ruby'

--- a/services/catarse/Gemfile.lock
+++ b/services/catarse/Gemfile.lock
@@ -695,6 +695,7 @@ DEPENDENCIES
   cocoon
   coffee-rails
   compass-rails
+  concurrent-ruby
   countries (= 3.0.0)
   cpf_cnpj
   cpf_faker

--- a/services/catarse/Procfile
+++ b/services/catarse/Procfile
@@ -5,3 +5,4 @@ export_report: bundle exec sidekiq -c 5 -q export_report
 worker_notifications: bundle exec rake listen:sync_notifications
 worker_rdstation: bundle exec rake listen:sync_rdstation
 worker_refresh_balance_transaction_metadata: bundle exec rake listen:sync_balance_transaction_metadata
+cache_reward: bundle exec rake cache:reward_metric_storages

--- a/services/catarse/app/models/reward.rb
+++ b/services/catarse/app/models/reward.rb
@@ -78,6 +78,10 @@ class Reward < ActiveRecord::Base
     paid_count + in_time_to_confirm
   end
 
+  def refresh_reward_metric_storage
+    pluck_from_database('refresh_reward_metric_storage')
+  end
+
   def paid_count
     pluck_from_database('paid_count')
   end

--- a/services/catarse/app/models/reward.rb
+++ b/services/catarse/app/models/reward.rb
@@ -11,9 +11,10 @@ class Reward < ActiveRecord::Base
 
   belongs_to :project
   has_many :payments, through: :contributions
+  has_many :contributions, dependent: :nullify
   has_many :shipping_fees, dependent: :destroy
   has_one :survey
-  has_many :contributions, dependent: :nullify
+  has_one :reward_metric_storage
 
   mount_uploader :uploaded_image, RewardUploader
 

--- a/services/catarse/app/models/reward_metric_storage.rb
+++ b/services/catarse/app/models/reward_metric_storage.rb
@@ -1,0 +1,3 @@
+class RewardMetricStorage < ActiveRecord::Base
+  belongs_to :reward
+end

--- a/services/catarse/app/observers/payment_observer.rb
+++ b/services/catarse/app/observers/payment_observer.rb
@@ -80,6 +80,7 @@ class PaymentObserver < ActiveRecord::Observer
       contribution.notify_to_contributor(:confirm_contribution)
       ProjectScoreStorageRefreshWorker.perform_async(project.id)
       ProjectMetricStorageRefreshWorker.perform_async(project.id)
+      RewardMetricStorageRefreshWorker.perform_async(contribution.reward_id) if contribution.reward_id.present?
       if project.successful? && project.successful_pledged_transaction
         transfer_diff = (
           project.paid_pledged - project.all_pledged_kind_transactions.sum(:amount))

--- a/services/catarse/app/workers/reward_metric_storage_refresh_worker.rb
+++ b/services/catarse/app/workers/reward_metric_storage_refresh_worker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RewardMetricStorageRefreshWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'metric_storage'
+
+  def perform(id)
+    resource = Reward.find id
+    resource.refresh_reward_metric_storage
+  end
+end

--- a/services/catarse/db/migrate/20160505150034_refactor_views.rb
+++ b/services/catarse/db/migrate/20160505150034_refactor_views.rb
@@ -147,7 +147,7 @@ SET STATEMENT_TIMEOUT TO 0;
 
     GRANT select ON "1".project_transitions TO admin, web_user, anonymous;
 
-    DROP MATERIALIZED VIEW "1".finished_projects;
+    DROP MATERIALIZED VIEW IF EXISTS "1".finished_projects;
     CREATE MATERIALIZED VIEW "1".finished_projects AS
      SELECT p.id AS project_id,
         p.category_id,
@@ -186,7 +186,7 @@ SET STATEMENT_TIMEOUT TO 0;
 
       GRANT SELECT ON "1".finished_projects TO anonymous, web_user, admin;
 
-      DROP VIEW "1".project_details;
+      DROP VIEW IF EXISTS "1".project_details;
       CREATE OR REPLACE VIEW "1".project_details AS
         SELECT p.id AS project_id,
         p.id,
@@ -215,7 +215,7 @@ SET STATEMENT_TIMEOUT TO 0;
         COALESCE(pt.total_contributions, 0::bigint) AS total_contributions,
         COALESCE(pt.total_contributors, 0::bigint) AS total_contributors,
         p.state::text AS state,
-        mode(p.*) AS mode,
+        p.mode AS mode,
         state_order(p.*) AS state_order,
         p.expires_at,
         zone_timestamp(p.expires_at) AS zone_expires_at,
@@ -253,7 +253,7 @@ SET STATEMENT_TIMEOUT TO 0;
     grant select on "1".project_details to web_user;
     grant select on "1".project_details to anonymous;
 
-    DROP MATERIALIZED VIEW "1".statistics;
+    DROP MATERIALIZED VIEW IF EXISTS "1".statistics;
     CREATE MATERIALIZED VIEW "1".statistics AS
      SELECT ( SELECT count(*) AS count
                FROM public.users) AS total_users,
@@ -287,7 +287,7 @@ SET STATEMENT_TIMEOUT TO 0;
     GRANT SELECT ON "1".statistics TO admin, web_user, anonymous;
 
 
-    DROP MATERIALIZED VIEW "1".category_totals;
+    DROP MATERIALIZED VIEW IF EXISTS "1".category_totals;
     CREATE MATERIALIZED VIEW "1".category_totals AS
      WITH project_stats AS (
              SELECT ca.id AS category_id,

--- a/services/catarse/db/migrate/20200617112622_create_reward_metric_storages.rb
+++ b/services/catarse/db/migrate/20200617112622_create_reward_metric_storages.rb
@@ -1,0 +1,13 @@
+class CreateRewardMetricStorages < ActiveRecord::Migration
+  def change
+    create_table :reward_metric_storages do |t|
+      t.references :reward, index: true, foreign_key: true
+      t.jsonb :data, null: false, default: {}
+      t.datetime :refreshed_at, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :reward_metric_storages, :reward_id, unique: true, name: 'uidx_reward_id_metric_storages'
+  end
+end

--- a/services/catarse/db/migrate/20200617114650_add_refresh_reward_metric_storage_fn.rb
+++ b/services/catarse/db/migrate/20200617114650_add_refresh_reward_metric_storage_fn.rb
@@ -1,0 +1,32 @@
+class AddRefreshRewardMetricStorageFn < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+
+CREATE OR REPLACE FUNCTION public.refresh_reward_metric_storage(arg_r rewards)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+declare
+    v_data jsonb;
+begin
+    select
+        json_build_object(
+            'paid_count', coalesce(public.paid_count(arg_r), 0),
+            'waiting_payment_count', coalesce(public.waiting_payment_count(arg_r), 0)
+        )::jsonb
+    into v_data;
+    
+    insert into public.reward_metric_storages (reward_id, data, refreshed_at, created_at, updated_at)
+        values (arg_r.id, v_data, now(), now(), now())
+    on conflict (reward_id) 
+        do update set
+            data = excluded.data,
+            refreshed_at = excluded.refreshed_at,
+            updated_at = excluded.updated_at;
+    
+    return;
+end;
+$function$;
+    SQL
+  end
+end

--- a/services/catarse/db/migrate/20200617150345_change_reward_details_to_use_reward_metric.rb
+++ b/services/catarse/db/migrate/20200617150345_change_reward_details_to_use_reward_metric.rb
@@ -1,0 +1,76 @@
+class ChangeRewardDetailsToUseRewardMetric < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+CREATE OR REPLACE VIEW "1"."reward_details" AS 
+ SELECT r.id,
+    r.project_id,
+    r.description,
+    r.minimum_value,
+    r.maximum_contributions,
+    r.deliver_at,
+    r.updated_at,
+    coalesce((rms.data->>'paid_count')::bigint, 0) AS paid_count,
+    coalesce((rms.data->>'waiting_payment_count')::bigint, 0) AS waiting_payment_count,
+    r.shipping_options,
+    r.row_order,
+    r.title,
+    s.sent_at AS survey_sent_at,
+    s.finished_at AS survey_finished_at,
+    r.common_id,
+        CASE
+            WHEN is_owner_or_admin(( SELECT p.user_id
+               FROM projects p
+              WHERE (p.id = r.project_id))) THEN r.welcome_message_subject
+            ELSE ''::text
+        END AS welcome_message_subject,
+        CASE
+            WHEN is_owner_or_admin(( SELECT p.user_id
+               FROM projects p
+              WHERE (p.id = r.project_id))) THEN r.welcome_message_body
+            ELSE ''::text
+        END AS welcome_message_body,
+    thumbnail_image(r.*) AS uploaded_image,
+    r.run_out
+   FROM (rewards r
+     LEFT JOIN reward_metric_storages rms on ((rms.reward_id = r.id))
+     LEFT JOIN surveys s ON ((s.reward_id = r.id)));
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+CREATE OR REPLACE VIEW "1"."reward_details" AS 
+ SELECT r.id,
+    r.project_id,
+    r.description,
+    r.minimum_value,
+    r.maximum_contributions,
+    r.deliver_at,
+    r.updated_at,
+    paid_count(r.*) AS paid_count,
+    waiting_payment_count(r.*) AS waiting_payment_count,
+    r.shipping_options,
+    r.row_order,
+    r.title,
+    s.sent_at AS survey_sent_at,
+    s.finished_at AS survey_finished_at,
+    r.common_id,
+        CASE
+            WHEN is_owner_or_admin(( SELECT p.user_id
+               FROM projects p
+              WHERE (p.id = r.project_id))) THEN r.welcome_message_subject
+            ELSE ''::text
+        END AS welcome_message_subject,
+        CASE
+            WHEN is_owner_or_admin(( SELECT p.user_id
+               FROM projects p
+              WHERE (p.id = r.project_id))) THEN r.welcome_message_body
+            ELSE ''::text
+        END AS welcome_message_body,
+    thumbnail_image(r.*) AS uploaded_image,
+    r.run_out
+   FROM (rewards r
+     LEFT JOIN surveys s ON ((s.reward_id = r.id)));
+    SQL
+  end
+end

--- a/services/catarse/dev.Dockerfile
+++ b/services/catarse/dev.Dockerfile
@@ -32,8 +32,8 @@ RUN npm install
 RUN set -ex \
   && mkdir -p /usr/app/tmp/cache \
   && mkdir -p /usr/app/tmp/pids \
-  && mkdir -p /usr/app/tmp/sockets \
-  && chown -R nobody /usr/app
+  && mkdir -p /usr/app/tmp/sockets 
+  #  && chown -R nobody /usr/app
 #
 ## ==================================================================================================
 ## 8: Set the container user to 'nobody':

--- a/services/catarse/lib/tasks/cache.rake
+++ b/services/catarse/lib/tasks/cache.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :cache do
+  desc 'Refresh reward metric storage from latest used rewards'
+  task reward_metric_storages: [:environment] do
+    loop do
+      reward_to_refresh = []
+      begin
+        SubscriptionPayment.where("created_at > now() - '30 seconds'::interval").pluck(:reward_id).uniq.each do |rid|
+          reward = Reward.find_by common_id: rid
+          reward_to_refresh << reward
+        end
+      rescue StandardError => e
+          Raven.extra_context(task: :cache_reward_metric_storage_subscription_payment_collection, reward_id: reward.id)
+          Raven.capture_exception(e)
+          Raven.extra_context({})
+      end
+
+      begin
+        Contribution.where("created_at > now() - '30 seconds'::interval").pluck(:reward_id).uniq.each do |rid|
+          reward = Reward.find rid
+          reward_to_refresh << reward
+        end
+      rescue StandardError => e
+          Raven.extra_context(task: :cache_reward_metric_contribution_collection, reward_id: reward.id)
+          Raven.capture_exception(e)
+          Raven.extra_context({})
+      end
+
+      reward_to_refresh.each do |reward|
+        begin
+          Rails.logger.debug("cache:reward_metric_storages -> refreshing reward: #{reward.id}")
+          reward.refresh_reward_metric_storage
+        rescue StandardError => e
+          Raven.extra_context(task: :cache_reward_metric_storage, reward_id: reward.id)
+          Raven.capture_exception(e)
+          Raven.extra_context({})
+        end
+      end
+
+      sleep 2
+    end
+  end
+end

--- a/services/catarse/spec/models/reward_metric_storage_spec.rb
+++ b/services/catarse/spec/models/reward_metric_storage_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RewardMetricStorage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/services/catarse/spec/models/reward_spec.rb
+++ b/services/catarse/spec/models/reward_spec.rb
@@ -184,4 +184,26 @@ RSpec.describe Reward, type: :model do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '.refresh_reward_metric_storage' do
+    let(:reward) { create(:reward, maximum_contributions: 20) }
+    before do
+      create(:confirmed_contribution, reward: reward, project: reward.project)
+      create(:pending_contribution, reward: reward, project: reward.project)
+      payment = create(:pending_contribution, reward: reward, project: reward.project).payments.first
+      payment.update_column(:created_at, 8.days.ago)
+
+      reward.refresh_reward_metric_storage
+    end
+
+    subject { reward.reward_metric_storage }
+
+    it "should have paid_count" do
+      expect(subject.data['paid_count']).to eq(1)
+    end
+
+    it "should have waiting_payment_count" do
+      expect(subject.data['waiting_payment_count']).to eq(1)
+    end
+  end
 end

--- a/services/catarse/spec/workers/reward_metric_storage_refresh_worker_spec.rb
+++ b/services/catarse/spec/workers/reward_metric_storage_refresh_worker_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RewardMetricStorageRefreshWorker do
+  before do
+    Sidekiq::Testing.inline!
+  end
+
+  describe 'perform' do
+    let(:reward) { create(:reward, maximum_contributions: 20) }
+    before do
+      create(:confirmed_contribution, reward: reward, project: reward.project)
+      create(:pending_contribution, reward: reward, project: reward.project)
+      payment = create(:pending_contribution, reward: reward, project: reward.project).payments.first
+      payment.update_column(:created_at, 8.days.ago)
+
+    end
+
+    before do
+      expect(Reward).to receive(:find).with(reward.id).and_return(reward)
+      expect(reward).to receive(:refresh_reward_metric_storage)
+    end
+    it 'should call refresh function' do
+      RewardMetricStorageRefreshWorker.perform_async(reward.id)
+    end
+  end
+end


### PR DESCRIPTION
### Why

When hit view 1.reward_details columns paid_count and waiting_payment_count for subscription projects whe need to count over foreign table, that is slow. 

This PRs add a reward_metric_storages to act as a cache when requesting these informations for a reward.

### Wrap up checklist

- [x] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
