### PR TITLE
Fix missing payables scope

### DIFF
--- a/services/catarse/app/actions/import_missing_payables_action.rb
+++ b/services/catarse/app/actions/import_missing_payables_action.rb
@@ -14,7 +14,6 @@ class ImportMissingPayablesAction
       update_payment_fee
     end
   rescue => e
-    raise e
     Raven.extra_context(payment_id: @payment.id)
     Raven.capture_exception(e, level: 'fatal')
   end

--- a/services/catarse/app/models/payment.rb
+++ b/services/catarse/app/models/payment.rb
@@ -26,8 +26,8 @@ class Payment < ActiveRecord::Base
 
   scope :with_missing_payables, lambda {
     joins('LEFT JOIN gateway_payables gp ON gp.payment_id = payments.id')
-      .where(gateway: 'Pagarme', state: %w[paid chargedback refunded])
-      .where('gp.id IS NULL')
+      .where(gateway: 'Pagarme', state: 'paid')
+      .where('gp.id IS NULL AND payments.gateway_id IS NOT NULL')
   }
   def self.slip_expiration_weekdays
     connection.select_one('SELECT public.slip_expiration_weekdays()')['slip_expiration_weekdays'].to_i


### PR DESCRIPTION
### Why

O escopo `with_missing_payables` não busca mais os pagamentos reembolsados / chargedbacks e nem os sem gateway_id, e a ação de importar os recebíveis trata a exceção com o sentry.

### Wrap up checklist

- [ ] All new code has tests
- [ ] Comments's added to columns / views / functions ([ADD COMMENT](https://www.postgresql.org/docs/9.4/static/sql-comment.html)...) 
- [ ] Code is documented on docs? link PR from [docs repo](https://github.com/common-group/common)
- [ ] Code is reviewed
