### PR TITLE
Fix typo on home slide banner

### DIFF
--- a/services/catarse.js/legacy/src/c/home-banner-slide.js
+++ b/services/catarse.js/legacy/src/c/home-banner-slide.js
@@ -12,12 +12,12 @@ export const HomeBannerSlide = {
         return m(`.slide.w-slide.${slideClass}`, {
             style: `${sliderTransitionStyle} background-image: url(${slide.image});`
         }, [
-            m('hero-slide-wrapper', [ 
-                m('w-container.u-text-center', [
-                    m('w-row.u-marginbottom-20', [
-                        m('w-col.w-col-8.w-col-push-2', [
+            m('.hero-slide-wrapper', [ 
+                m('.w-container.u-text-center', [
+                    m('.w-row', [
+                        m('.w-col.w-col-8.w-col-push-2', [
                             m('h1.hero-home-title', m.trust(slide.title)),
-                            m('h2.hero-home-subtitle', m.trust(slide.subtitle))
+                            m('h2.hero-home-subtitle.u-marginbottom-20', m.trust(slide.subtitle))
                         ]),
                         m('a.btn.btn-large.btn-inline', { href: slide.link }, slide.cta)
                     ])


### PR DESCRIPTION
### Descrição

Esqueci de colocar um `.` ali e com isso as classes não foram aplicadas certinhas.

### Referência

https://www.notion.so/catarse/Redu-o-do-tamanho-do-banner-da-home-5ccf7bd819dc440aad6e40047376cec8

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [X]  Descreveu o propósito do commit com o emoji no início da mensagem
- [X]  Mudanças estão unificadas em um único commit
- [X]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
