### PR TITLE
🐞 Atualiza o custo da transação ao importar os recebíveis

### DIFF
--- a/services/catarse/app/actions/import_missing_payables_action.rb
+++ b/services/catarse/app/actions/import_missing_payables_action.rb
@@ -11,7 +11,7 @@ class ImportMissingPayablesAction
 
     ActiveRecord::Base.transaction do
       import_payables
-      update_payment_fee
+      update_payment
     end
   rescue => e
     Raven.extra_context(payment_id: @payment.id)
@@ -42,8 +42,10 @@ class ImportMissingPayablesAction
     gateway_payable.save!
   end
 
-  def update_payment_fee
-    @payment.update!(gateway_fee: calculate_fee)
+  def update_payment
+    @payment.gateway_fee = calculate_fee
+    @payment.gateway_data['cost'] = @transaction.cost if @transaction.cost > 0
+    @payment.save!
   end
 
   def calculate_fee


### PR DESCRIPTION
### Descrição

Ao importar os recebíveis, o custo da transação é atualizado. Isso ajuda a diminir as chances do pagamento ficar com o custo da transação zerado.

### Referência

https://www.notion.so/catarse/Atualizar-custo-da-transa-o-ao-importar-receb-veis-7b9bb4a7c0914e27bbdb855feb8d638d

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
