### PR TITLE
:beetle: fix backer user card cache

### DIFF
--- a/services/catarse.js/legacy/src/c/project-header.js
+++ b/services/catarse.js/legacy/src/c/project-header.js
@@ -19,16 +19,17 @@ const projectHeader = {
 
         if (h.isProjectPage() && currentUser && !_.isUndefined(project())) {
             if (!projectVM.isSubscription(project)) {
+                projectVM.projectContributions([]);
                 contributionVM
                     .getUserProjectContributions(currentUser.user_id, project().project_id, ['paid', 'refunded', 'pending_refund'])
-                    .then(vnode.attrs.projectContributions);
+                    .then(projectVM.projectContributions);
             }
         }
 
         vnode.state = {
             hasSubscription,
             userProjectSubscriptions,
-            projectContributions: vnode.attrs.projectContributions,
+            projectContributions: projectVM.projectContributions,
             showContributions: h.toggleProp(false, true)
         };
     },


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Descrição

Ao carregar a página de um projeto que o usuário contribuiu ele salva as contribuições em cache. Quando navegar para outra página do projeto, antes de carregar as contribuições, mostra as contribuições do projeto visitado anteriormente. Essa modificação limpa o cache antes de fazer o primeiro desenho da tela.

### Referência

https://www.notion.so/catarse/Header-do-projeto-vem-com-as-contribui-es-das-p-ginas-de-projeto-73f7d82df3f44ff5bdb2cae76ef8c4f8

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
