### PR TITLE
:beetle: Diminuir tamanho do botão no slider da home

### DIFF
--- a/services/catarse.js/legacy/src/c/home-banner-slide.js
+++ b/services/catarse.js/legacy/src/c/home-banner-slide.js
@@ -18,7 +18,7 @@ export const HomeBannerSlide = {
                         m('.w-col.w-col-8.w-col-push-2', [
                             m('h1.hero-home-title', m.trust(slide.title)),
                             m('h2.hero-home-subtitle.u-marginbottom-20', m.trust(slide.subtitle)),
-                            m('a.btn.btn-large.btn-inline', { href: slide.link }, slide.cta)
+                            m('a.btn.btn-medium.btn-inline', { href: slide.link }, slide.cta)
                         ])
                     ])
                 ])


### PR DESCRIPTION
Ajuste simples para melhorar legibilidade

### Descrição

Ajuste simples para melhorar legibilidade. O botão no slider da home estava muito grande. Coloquei uma classe do btn-medium para ficar melhor balanceado

### Referência

https://www.notion.so/catarse/Redu-o-do-tamanho-do-banner-da-home-5ccf7bd819dc440aad6e40047376cec8

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [X]  Descreveu o propósito do commit com o emoji no início da mensagem
- [X]  Mudanças estão unificadas em um único commit
- [X]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
