### PR TITLE
🐞 Importa recebíveis que não foram importados em sua totalidade

### DIFF
--- a/services/catarse/app/models/payment.rb
+++ b/services/catarse/app/models/payment.rb
@@ -26,9 +26,11 @@ class Payment < ActiveRecord::Base
 
   scope :with_missing_payables, lambda {
     joins('LEFT JOIN gateway_payables gp ON gp.payment_id = payments.id')
-      .where(gateway: 'Pagarme', state: 'paid')
-      .where('gp.id IS NULL AND payments.gateway_id IS NOT NULL')
+      .where("gateway = 'Pagarme' AND state = 'paid' AND payments.gateway_id IS NOT NULL")
+      .group('payments.id')
+      .having('count(gp.id) < payments.installments')
   }
+
   def self.slip_expiration_weekdays
     connection.select_one('SELECT public.slip_expiration_weekdays()')['slip_expiration_weekdays'].to_i
   end


### PR DESCRIPTION
### Descrição

Antes a rotina observava os pagamentos que não tinham recebíveis. Agora ela passa a observar os pagamentos que a quantidade de recebíveis é menor que o número de parcelas.

### Referência

https://www.notion.so/catarse/Corrigir-importa-o-de-receb-veis-b6dea29d862045189d85b2f3aad2c14b

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
