### PR TITLE
✨ Inclui custo de antifraude na nota de débito

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_debit_note.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_debit_note.slim
@@ -40,6 +40,15 @@ table style="border: 1px solid;max-width:100%;border-collapse: collapse;"
       span #{project_link}
     td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
       span #{number_to_currency fiscal_data.total_gateway_fee, precision: 2}
+  tr
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{finished_date}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;"
+      span Tarifas das análises de antifraude dos apoios ao projeto "#{project['name']}".
+      br/
+      span #{project_link}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency fiscal_data.total_antifraud_cost.to_f, precision: 2}
 
 br/
 p Declaro para os devidos fins ter recebido a importância acima discriminada dando plena e irrevogável quitação.


### PR DESCRIPTION
### Descrição

Mostra custo do antifraude na nota de débito

### Referência

https://www.notion.so/catarse/Incluir-valor-antifraude-na-nota-de-d-bito-8b12e87c19ca47d4b6b8b583acfa9936

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
