### PR TITLE
🐞 clipboard upload and upload url removed from redactor

### DIFF
--- a/services/catarse.js/legacy/src/h.ts
+++ b/services/catarse.js/legacy/src/h.ts
@@ -1030,6 +1030,8 @@ const _dataCache = {},
         imageGetJson: '/redactor_rails/pictures',
         path: '/assets/redactor-rails',
         css: 'style.css',
+        clipboardUpload: false,
+        clipboardUploadUrl: false,
     }),
     setRedactor = (
         prop,


### PR DESCRIPTION
### Descrição

Remover a possibilidade de adicionar imagens com copy & paste, pois no osx ele converte as imagens do clipboard para base64 e a imagem fica inapropriadamente salva inteira no banco. 

### Referência

https://www.notion.so/catarse/Evitar-que-imagens-sejam-adicionadas-em-formato-base64-em-nosso-editor-de-texto-2d55709dd2fb425994442530bb452369

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
