### PR TITLE
🐞 Ajustes na atualização do cache de ProjectMetricStorage

### DIFF
--- a/services/catarse/Procfile
+++ b/services/catarse/Procfile
@@ -9,4 +9,5 @@ cache_reward: bundle exec rake cache:reward_metric_storages
 sub_cache_reward: bundle exec rake cache:refresh_subscription_reward_metrics
 con_cache_reward: bundle exec rake cache:refresh_contribution_reward_metrics
 pay_cache_reward: bundle exec rake cache:refresh_payment_reward_metrics
+projects_dispatch_metric_storage_refresh: bundle exec rake projects:dispatch_metric_storage_refresh_loop
 

--- a/services/catarse/Procfile
+++ b/services/catarse/Procfile
@@ -1,6 +1,6 @@
 web: bundle exec unicorn_rails -p $PORT -c config/unicorn.rb
 worker: bundle exec sidekiq -c 10 -C config/sidekiq.yml
-metric_storage_worker: bundle exec sidekiq -c 5 -q metric_storage
+metric_storage_worker: bundle exec sidekiq -c 20 -q metric_storage
 export_report: bundle exec sidekiq -c 5 -q export_report
 worker_notifications: bundle exec rake listen:sync_notifications
 worker_rdstation: bundle exec rake listen:sync_rdstation

--- a/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
+++ b/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
@@ -9,6 +9,5 @@ class ProjectMetricStorageRefreshWorker < ProjectBaseWorker
     can_refresh = !%w[draft deleted].include?(_resource.state)
 
     _resource.refresh_project_metric_storage if can_refresh
-    ProjectMetricStorageRefreshWorker.perform_in(10.seconds, id) if _resource.is_sub?
   end
 end

--- a/services/catarse/lib/tasks/dispatch_project_metric_storage_refresh_task.rake
+++ b/services/catarse/lib/tasks/dispatch_project_metric_storage_refresh_task.rake
@@ -1,0 +1,35 @@
+class DispatchProjectMetricStorageRefreshTask
+  include Rake::DSL
+
+  def initialize
+    namespace :projects do
+      task dispatch_metric_storage_refresh: :environment do
+        call
+      end
+
+      # NOTE: this cmd is only for sandbox environment
+      task dispatch_metric_storage_refresh_loop: :environment do
+        raise 'run only in sandox' unless Rails.env.sandbox?
+        loop do
+          call
+          sleep 300
+        end
+      end
+    end
+  end
+
+  private
+
+  def call
+    ProjectMetricStorage
+      .joins(:project)
+      .where("refreshed_at < now() - '5 minutes'::interval")
+      .where(projects: {state: 'online'})
+      .pluck(:project_id)
+      .each do |id|
+      ProjectMetricStorageRefreshWorker.perform_async(id)
+    end
+  end
+end
+
+DispatchProjectMetricStorageRefreshTask.new

--- a/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
+++ b/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
@@ -18,35 +18,20 @@ RSpec.describe ProjectMetricStorageRefreshWorker do
     before do
       expect(Project).to receive(:find).with(project.id).and_return(project)
       expect(project).not_to receive(:refresh_project_metric_storage)
-      expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
     end
     it 'should not call refresh function' do
       ProjectMetricStorageRefreshWorker.perform_async(project.id)
     end
   end
 
-  context 'when project is not subscription type' do
-    let(:project) { create(:project, mode: 'flex', state: 'online') }
-    before do
-      expect(Project).to receive(:find).with(project.id).and_return(project)
-      expect(project).to receive(:refresh_project_metric_storage)
-      expect(ProjectMetricStorageRefreshWorker).not_to receive(:perform_in).with(10.seconds, project.id)
-    end
-
-    it 'should not reschedule a next run for metrics refresh' do
-      ProjectMetricStorageRefreshWorker.perform_async(project.id)
-    end
-  end
-
-  context 'when project is subscription type' do
+  context 'when project can be processed' do
     let(:project) { create(:subscription_project, state: 'online') }
     before do
       expect(Project).to receive(:find).with(project.id).and_return(project)
       expect(project).to receive(:refresh_project_metric_storage)
-      expect(ProjectMetricStorageRefreshWorker).to receive(:perform_in).with(10.seconds, project.id)
     end
 
-    it 'should reschedule a next run for metrics refresh' do
+    it 'should call refresh_project_metric_storage' do
       ProjectMetricStorageRefreshWorker.perform_async(project.id)
     end
   end


### PR DESCRIPTION
### Descrição

Adicionado uma rotina para atualizar o cache de métricas do projeto que não foram atualizadas nos últimos 5 minutos
e também foi modificado para que a fila tenha mais processos concorrentes para lidar com a atualização desses dados.


### Referência

https://www.notion.so/catarse/Valores-de-arrecada-o-mensal-no-card-do-projeto-e-na-p-gina-do-projeto-exibiam-valores-diferentes-346bdf238822486c8b4a2d944abe22bd

https://www.notion.so/catarse/Investigar-projetos-com-cache-desatualizado-f48baeeb411c40deb8ea0bf9d6e036c0

### Antes de criar esse pull request confira se:

- [x]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [ ]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
