### PR TITLE
💎 Atualiza catarse_pagarme para a 2.16.3

### DIFF
--- a/services/catarse/Gemfile
+++ b/services/catarse/Gemfile
@@ -45,7 +45,7 @@ gem 'mixpanel-ruby'
 gem 'mixpanel_client'
 
 # Payment engines
-gem 'catarse_pagarme', '~> 2.16.2'
+gem 'catarse_pagarme', '~> 2.16.3'
 # gem 'catarse_pagarme', path: '../catarse_pagarme'
 
 # Decorators

--- a/services/catarse/Gemfile.lock
+++ b/services/catarse/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    catarse_pagarme (2.16.2)
+    catarse_pagarme (2.16.3)
       countries (= 3.0.0)
       konduto-ruby (= 2.1.0)
       pagarme (= 2.1.4)
@@ -691,7 +691,7 @@ DEPENDENCIES
   browser (= 1.0.1)
   capybara
   carrierwave (~> 1.0)
-  catarse_pagarme (~> 2.16.2)
+  catarse_pagarme (~> 2.16.3)
   catarse_settings_db (>= 0.2.0)
   cocoon
   coffee-rails


### PR DESCRIPTION
### Descrição

Atualiza a catarse_pagarme para a 2.16.3, que é a versão onde os dados enviados a Konduto são limitados de acordo com a especificação da API.

### Referência

https://www.notion.so/catarse/Limitar-tamanho-dos-dados-enviados-ao-antifraude-79dfa71b29e6498a89a10d11e09b7ebb

Lá no **catarse_pagarme**: https://github.com/catarse/catarse_pagarme/pull/85

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
