### PR TITLE
🔧 Webapack  uglify compress=false

### DIFF
--- a/services/catarse.js/webpack.config.js
+++ b/services/catarse.js/webpack.config.js
@@ -74,7 +74,7 @@ module.exports = {
     plugins: isProd ? [new UglifyJsPlugin({
         sourceMap: true,
         uglifyOptions: {
-            compress: true
+            compress: false
         }
     })] : [],
 };


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Descrição

As requisições para a api do catarse estavam sendo enviadas sem o header Range.

### Referência

https://www.notion.so/catarse/Headers-de-request-range-n-o-est-o-sendo-enviados-b1ca4a742727454da1b4175069d09690

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
