### PR TITLE
🐞 atualiza text index do projeto quando muda de estado

### DIFF
--- a/services/catarse/db/migrate/20200916194222_projects_update_full_text_index_when_state_changes.rb
+++ b/services/catarse/db/migrate/20200916194222_projects_update_full_text_index_when_state_changes.rb
@@ -1,0 +1,29 @@
+class ProjectsUpdateFullTextIndexWhenStateChanges < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+
+    DROP TRIGGER update_full_text_index ON projects;
+
+    CREATE TRIGGER update_full_text_index 
+    BEFORE INSERT OR UPDATE OF name, permalink, headline, state
+    ON projects
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_full_text_index();
+
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+
+    DROP TRIGGER update_full_text_index ON projects;
+
+    CREATE TRIGGER update_full_text_index 
+    BEFORE INSERT OR UPDATE OF name, permalink, headline
+    ON projects
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_full_text_index();
+
+    SQL
+  end
+end

--- a/services/catarse/spec/models/project_spec.rb
+++ b/services/catarse/spec/models/project_spec.rb
@@ -716,4 +716,19 @@ RSpec.describe Project, type: :model do
       expect(event.event_name).to eq('solidaria_project_draft')
     end
   end
+
+  describe 'full_text_index' do
+
+    let(:project) { create(:project, { name: 'Project name', state: 'draft', full_text_index: nil, online_days: 3 }) }
+
+    it 'should update full_text_index from nil when state updates' do
+      expect(project.full_text_index).to eq(nil)
+      
+      project.state = 'online'      
+      project.save
+      project.reload
+
+      expect(project.full_text_index).not_to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
Signed-off-by: Gilberto Ribeiro <gilbertoribeiropazdarosa@gmail.com>

### Descrição

Atualiza o campo full_text_index, campo onde as buscas do admin projetos se valem, quando atualiza o campo state do projeto. O que acontecia era que se o nome, permalink ou headline do projeto não era alterado depois de publicado, o full_text_index não era calculado, pois a função do trigger só atualiza em state <> 'draft' e <> 'deleted'.

### Referência

https://www.notion.so/catarse/Busca-de-projetos-no-Admin-projetos-n-o-retorna-resultados-mesmo-quando-o-projeto-existe-460b50b05f2248f2b0b9a92378443c27

### Antes de criar esse pull request confira se:

- [x]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
