### PR TITLE
🔧 Ajusta CI do catarse.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/node:10.7.0-stretch
+      - image: circleci/node:10.22-browsers
     steps:
       - checkout
       - run:
@@ -138,11 +138,7 @@ jobs:
           command: |
             set -ex \
             && mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS \
-            && cd services/catarse.js \
-            && sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - \
-            && sudo echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list \
-            && sudo apt-get -y update \
-            && sudo apt-get -y install google-chrome-stable
+            && cd services/catarse.js
       - restore_cache:
           keys:
             - v1-dep-{{ .Branch }}-


### PR DESCRIPTION
### Descrição

Muda a imagem do Circle CI para os testes automatizados voltarem a funcionar.

### Referência

https://www.notion.so/catarse/Ajustar-CI-catarse-js-4b7b29bbbaf14f76a78405cbdd5029c5

### Antes de criar esse pull request confira se:

- [x]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
