### PR TITLE
🐞 Limita tamanho dos dados enviados ao antifraude no assinaturas

### DIFF
--- a/services/payment-service-api/lib/konduto_data_builder.js
+++ b/services/payment-service-api/lib/konduto_data_builder.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { limitStringSize } = require('./limit_string_size')
+
 /*
  * buildAntifraudData(context, options)
  * build a object with antifraud data
@@ -22,8 +24,8 @@ const buildAntifraudData = (context, options) => {
   const sellerData = buildSeller(projectOwner)
 
   return {
-    id: options.transaction.id.toString(),
-    visitor: payment.user_id,
+    id: limitStringSize(options.transaction.id.toString(), 100),
+    visitor: limitStringSize(payment.user_id, 40),
     total_amount: payment.data.amount / 100,
     currency: 'BRL',
     installments: 1,
@@ -47,15 +49,15 @@ const buildAntifraudData = (context, options) => {
  */
 const buildCustomer = (payment, user) => {
   const customer = payment.data.customer
-  const taxId = customer.document_number ? { tax_id: customer.document_number } : {}
+  const taxId = customer.document_number ? { tax_id: limitStringSize(customer.document_number, 100) } : {}
 
   return {
     customer: {
       ...taxId,
-      id: payment.user_id,
-      name: customer.name,
-      phone1: buildPhoneNumber(customer.phone),
-      email: customer.email,
+      id: limitStringSize(payment.user_id, 100),
+      name: limitStringSize(customer.name, 100),
+      phone1: limitStringSize(buildPhoneNumber(customer.phone), 100),
+      email: limitStringSize(customer.email, 100),
       created_at: user.created_at.substr(0, 10),
     }
   }
@@ -92,12 +94,12 @@ const buildBilling = (customer, transaction) => {
 
   return {
     billing: {
-      name: transaction.card.holder_name,
-      address1: address.street,
-      address2: address.complementary,
-      city: address.city,
-      state: address.state,
-      zip: address.zipcode,
+      name: limitStringSize(transaction.card.holder_name, 100),
+      address1: limitStringSize(address.street, 255),
+      address2: limitStringSize(address.complementary, 255),
+      city: limitStringSize(address.city, 100),
+      state: limitStringSize(address.state, 100),
+      zip: limitStringSize(address.zipcode, 100),
       ...countryData
     }
   }
@@ -116,9 +118,9 @@ const buildShoppingCart = (payment, project, subscription) => {
 
   return {
     shopping_cart: [{
-      product_code: subscription.reward_id,
+      product_code: limitStringSize(subscription.reward_id, 100),
       category: 9999,
-      name: productName,
+      name: limitStringSize(productName, 100),
       unit_cost: payment.data.amount / 100.0,
       quantity: 1,
       created_at: subscription.created_at.substr(0, 10)
@@ -135,8 +137,8 @@ const buildShoppingCart = (payment, project, subscription) => {
 const buildSeller = (projectOwner) => {
   return {
     seller: {
-      id: projectOwner.id,
-      name: projectOwner.data.name,
+      id: limitStringSize(projectOwner.id, 100),
+      name: limitStringSize(projectOwner.data.name, 100),
       created_at: projectOwner.created_at.substr(0, 10)
     }
   }

--- a/services/payment-service-api/lib/limit_string_size.js
+++ b/services/payment-service-api/lib/limit_string_size.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/*
+ * limitStringSize(string, stringSize)
+ * Limit string size
+ * @param { String } string - String to limit size
+ * @param { String } stringSize - Desired string size
+ * @return { String } - String with size limited
+ */
+const limitStringSize = (string, stringSize) => {
+  return String(string || '').substring(0, stringSize)
+}
+
+module.exports = {
+  limitStringSize
+}

--- a/services/payment-service-api/lib/transaction_data_builder.js
+++ b/services/payment-service-api/lib/transaction_data_builder.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { limitStringSize } = require('./limit_string_size')
+
 /*
  * buildTransactionData(context)
  * build a object with transaction attributes
@@ -54,7 +56,7 @@ const bankSlipTransactionData = (context) => {
 
   return {
     customer: {
-      name: customer.name,
+      name: limitStringSize(customer.name, 100),
       type: isIndividual ? 'individual' : 'corporation',
       documents: [{
         type: isIndividual ? 'cpf' : 'cnpj',


### PR DESCRIPTION
### Descrição
Limita o tamanho dos dados enviados ao antifraude e gateway de pagamento para os pagamentos de assinatura.
Pesquei um erro no log, que o pagarme tem limite no tamanho do campo `customer.name`, então ajustei o branch pra limitar isso também.

### Referência

https://www.notion.so/catarse/Limitar-tamanho-dos-dados-enviados-ao-antifraude-do-pagamento-de-assinaturas-f262af7b0160446a9ee013cf76748e6d

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
