### PR TITLE
🐞 Ajusta e altera links de ajuda para os respectivos artigos no cadas…

### DIFF
--- a/services/catarse.js/legacy/src/c/project-basics-edit.js
+++ b/services/catarse.js/legacy/src/c/project-basics-edit.js
@@ -156,7 +156,7 @@ const projectBasicsEdit = {
     },
     view: function ({ state, attrs }) {
         const vm = state.vm;
-        
+
         return m('#basics-tab', [
             state.showSuccess()
                 ? m(popNotification, {
@@ -264,8 +264,8 @@ const projectBasicsEdit = {
                                                 try {
                                                     const content_rating_value = JSON.parse(event.target.value);
                                                     vm.fields.content_rating(content_rating_value);
-                                                    vm.fields.show_cans_and_cants(content_rating_value === ADULT_CONTENT_AGE);    
-                                                    vm.fields.force_show_cans_and_cants(false);                                                
+                                                    vm.fields.show_cans_and_cants(content_rating_value === ADULT_CONTENT_AGE);
+                                                    vm.fields.force_show_cans_and_cants(false);
                                                 } catch (e) {
                                                     console.log('Error setting content rating:', e);
                                                     h.captureException(e);
@@ -307,7 +307,7 @@ const projectBasicsEdit = {
                                             ])
                                         ]),
                                         m('div.fontsize-small.u-text-center.u-margintop-30.u-marginbottom-20',
-                                            m(`a.alt-link.fontweight-semibold[href="${I18n.t('adult_content_support_url', I18nScope())}"]`,
+                                            m(`a.alt-link.fontweight-semibold[target="_blank"][href="${I18n.t('adult_content_support_url', I18nScope())}"]`,
                                                 I18n.t('adult_content_more_info_link_text', I18nScope())
                                             )
                                         )

--- a/services/catarse.js/legacy/src/c/project-goals-edit.js
+++ b/services/catarse.js/legacy/src/c/project-goals-edit.js
@@ -125,27 +125,27 @@ const projectGoalsEdit = {
                           m('ul.w-list-unstyled',
                               [
                                   m('li.u-marginbottom-10',
-                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/115005632746-Catarse-Assinaturas-FAQ-Realizadores#meta_inicial"][target="_blank"]',
+                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360023830672-O-que-%C3%A9-a-meta-mensal-inicial-"][target="_blank"]',
                               'O que é a meta mensal inicial?'
                             )
                           ),
                                   m('li.u-marginbottom-10',
-                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/115005632746-Catarse-Assinaturas-FAQ-Realizadores#meta_futura"][target="_blank"]',
+                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360023830912-O-que-s%C3%A3o-as-metas-mensais-futuras-"][target="_blank"]',
                               'O que são as metas mensais futuras?'
                             )
                           ),
                                   m('li.u-marginbottom-10',
-                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/115005632746-Catarse-Assinaturas-FAQ-Realizadores#meta_atual"][target="_blank"]',
+                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360024085911-O-que-%C3%A9-a-meta-mensal-atual-"][target="_blank"]',
                               'O que é a meta mensal atual?'
                             )
                           ),
                                   m('li.u-marginbottom-10',
-                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/115005632746-Catarse-Assinaturas-FAQ-Realizadores#nova_meta"][target="_blank"]',
+                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360023831492-Posso-adicionar-novas-metas-depois-do-lan%C3%A7amento-"][target="_blank"]',
                               'Posso adicionar novas metas depois do lançamento?'
                             )
                           ),
                                   m('li.u-marginbottom-10',
-                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/115005632746-Catarse-Assinaturas-FAQ-Realizadores#nao_atingir"][target="_blank"]',
+                            m('a.fontsize-smaller.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360024086591-O-que-acontece-se-eu-n%C3%A3o-atingir-a-meta-do-meu-projeto-"][target="_blank"]',
                               'O que acontece se eu não atingir a meta do meu projeto?'
                             )
                           )

--- a/services/catarse.js/legacy/src/c/user-settings-help.js
+++ b/services/catarse.js/legacy/src/c/user-settings-help.js
@@ -31,12 +31,12 @@ const userSettingsHelp = {
                     m('ul.w-list-unstyled',
                         [
                             m('li.u-marginbottom-10',
-                                m('a.fontsize-smaller.alt-link[href=\'https://suporte.catarse.me/hc/pt-br/articles/217916143-A-transfer%C3%AAncia-do-dinheiro#conta\'][target=\'_blank\']',
+                                m('a.fontsize-smaller.alt-link[href=\'https://suporte.catarse.me/hc/pt-br/articles/360024259231\'][target=\'_blank\']',
                                     'Responsável pelo projeto e Conta bancária para receber o dinheiro'
                                 )
                             ),
                             m('li.u-marginbottom-10',
-                                m('a.fontsize-smaller.alt-link[href=\'https://suporte.catarse.me/hc/pt-br/articles/115002214043-Responsabilidades-e-Seguran%C3%A7a?ref=ctrse_footer\'][target=\'_blank\']',
+                                m('a.fontsize-smaller.alt-link[href=\'https://suporte.catarse.me/hc/pt-br/articles/115002214043-Responsabilidades-e-Seguran%C3%A7a\'][target=\'_blank\']',
                                     'Responsabilidades e Segurança no Catarse'
                                 )
                             )

--- a/services/catarse.js/legacy/src/root/project-edit-integrations.js
+++ b/services/catarse.js/legacy/src/root/project-edit-integrations.js
@@ -13,11 +13,11 @@ const PIXEL = 'PIXEL';
 export class ProjectEditIntegrations {
 
     oninit(/** @type {VNode} */vnode) {
-         
+
         /**
          * @param {string} name
          * @param {ProjectIntegration[]} integrations
-         * @returns {ProjectIntegration} 
+         * @returns {ProjectIntegration}
          * */
         const findIntegrationByName = (name = '', integrations = []) => integrations.find(integration => integration.name === name);
 
@@ -48,15 +48,15 @@ export class ProjectEditIntegrations {
             .catch(error => {
                 loadingIntegrations(false);
             });
-        
+
         /**
-         * @param {Stream<ProjectIntegration>} integration 
+         * @param {Stream<ProjectIntegration>} integration
          */
         async function requestForIntegration(integration) {
             const integrationData = integration();
             const shouldCreate = !!integrationData.id;
 
-            const response = shouldCreate ? 
+            const response = shouldCreate ?
                 await projectVM.updateIntegration(projectId, integrationData)
             :
                 await projectVM.createIntegration(projectId, integrationData);
@@ -73,7 +73,7 @@ export class ProjectEditIntegrations {
 
                 await requestForIntegration(GATracking);
                 await requestForIntegration(FBPixelTracking);
-                
+
                 showSuccess(true);
             } catch(e) {
                 error(true);
@@ -117,7 +117,7 @@ export class ProjectEditIntegrations {
                     toggleOpt: state.showError,
                     error: true
                 }) : ''),
-                
+
                 m('div.section',
                     m('div.w-container',
                         m('div.w-row', [
@@ -130,7 +130,7 @@ export class ProjectEditIntegrations {
                                                 m('label.fontweight-semibold.fontsize-base', 'Google Analytics'),
                                                 m('label.field-label.fontsize-smallest.fontcolor-secondary', [
                                                     'Informe o seu ID de Acompanhamento e comece a enviar informações dos visitantes de sua página para a sua conta do Google Analytics ',
-                                                    m('a.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360038491812"]', 'Saiba mais')
+                                                    m('a.alt-link[target="_blank"][href="https://suporte.catarse.me/hc/pt-br/articles/360040153431-Como-integrar-a-campanha-no-Catarse-com-o-Google-Analytics-"]', 'Saiba mais')
                                                 ]),
                                                 m('img[src="/assets/logo_lockup_analytics_icon_horizontal_black.png"][width="146"][alt=""]')
                                             ]),
@@ -153,7 +153,7 @@ export class ProjectEditIntegrations {
                                                 m('label.fontweight-semibold.fontsize-base', 'Facebook Pixel'),
                                                     m('label.field-label.fontsize-smallest.fontcolor-secondary', [
                                                         'Envia informações dos visitantes de sua página para o seu Facebook Pixel ',
-                                                        m('a.alt-link[href="https://suporte.catarse.me/hc/pt-br/articles/360038491672"]', 'Saiba mais')
+                                                        m('a.alt-link[target="_blank"][href="https://suporte.catarse.me/hc/pt-br/articles/360040152071-Como-integrar-a-campanha-no-Catarse-com-os-an%C3%BAncios-do-Facebook-por-meio-do-Facebook-Pixel-"]', 'Saiba mais')
                                                     ]),
                                                     m('img[src="/assets/facebook-pixel-logotyp.png"][width="146"][alt=""]')
                                             ]),
@@ -169,7 +169,7 @@ export class ProjectEditIntegrations {
                             ),
                         ])
                     ),
-        
+
                     m(projectEditSaveBtn, { loading: state.loading, onSubmit: save }),
                 )
             ]);

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/edit.pt.yml
@@ -84,7 +84,7 @@ pt:
       faq:
         1:
           title: 'Título, Descrição e Imagem da recompensa:'
-          description: 'Ajudam os apoiadores a entenderem e visualizarem o que você está oferecendo. Seja objetivo, criativo e transparente! Saiba neste artigo <a href="http://suporte.catarse.me/hc/pt-br/articles/212191546-Recompensas-realizadores-#o-que-oferecer" target="_blank" class="alt-link">o que você pode e o que não pode oferecer</a>  e se inspire com <a href="http://blog.catarse.me/mais-de-30-ideias-de-recompensa-para-seu-crowdfunding/" target="_blank" class="alt-link">ideias de recompensas</a>.'
+          description: 'Ajudam os apoiadores a entenderem e visualizarem o que você está oferecendo. Seja objetivo, criativo e transparente! Saiba neste artigo <a href="https://suporte.catarse.me/hc/pt-br/articles/360023813092-O-que-posso-oferecer-como-recompensa-" target="_blank" class="alt-link">o que você pode e o que não pode oferecer</a>  e se inspire com <a href="http://blog.catarse.me/mais-de-30-ideias-de-recompensa-para-seu-crowdfunding/" target="_blank" class="alt-link">ideias de recompensas</a>.'
         2:
           title: 'Valor da recompensa:'
           description: 'Indica com quanto o apoiador deve contribuir para receber a recompensa. Procure ofertar um valor justo e realista. Para te ajudar a definir esses valores, recomendamos a <a href="http://blog.catarse.me/meta-crowdfunding-calculadora-orcamento/" target="_blank" class="alt-link">Calculadora de Orçamento</a>.'
@@ -96,7 +96,7 @@ pt:
           description: 'Como será o envio da recompensa e quanto irá custar para o apoiador. Caso você adicione um valor de frete, ele será adicionado quando o apoiador selecionar a recompensa e a localidade. Lembre-se que a taxa do Catarse será aplicada também sobre o valor de frete. <a href="http://blog.catarse.me/o-calculo-de-envio-de-recompensas-financiamento-coletivo/" target="_blank" class="alt-link">Saiba mais</a>.'
         5:
           title: 'Número de recompensas:'
-          description: 'Você também pode Limitar uma recompensa para um determinado número de apoios e mudar a ordem que as recompensas aparecem em seu projeto. <a href="http://suporte.catarse.me/hc/pt-br/articles/212191546-tudo-sobre-RECOMPENSAS#como-editar" target="_blank" class="alt-link">Saiba mais</a>.'
+          description: 'Você também pode Limitar uma recompensa para um determinado número de apoios e mudar a ordem que as recompensas aparecem em seu projeto. <a href="https://suporte.catarse.me/hc/pt-br/articles/360023813232-Como-criar-editar-deletar-uma-recompensa-no-projeto-" target="_blank" class="alt-link">Saiba mais</a>.'
       minimum_value_title: 'Para R$ %{minimum_value} ou mais'
       minimum_value_subscription_title: 'R$ %{minimum_value} por mês'
       paid_contributors: '%{count} apoiadores'
@@ -314,7 +314,7 @@ pt:
       kind_link: "Se você quiser saber mais, clique aqui"
       flex:
         kind_text: "Você está participando do período de testes do modelo flexível. Sua participação é essencial para entendermos como podemos expandir esse modelo para todos os usuários. %{link}"
-    
+
     solidarity_taxes_description_html: '<div class="card u-radius u-marginbottom-30 medium u-margintop-60"><img src="https://www.catarse.me/assets/catarsesolidariablueheart.png" width="177" alt="" class="u-marginbottom-30"><div class="fontsize-small"><strong>O que é a taxa do Catarse?<br>&zwj;</strong><br>É o valor que será descontado do total arrecadado ao final da campanha, referente aos serviços do Catarse e do meio de pagamento.<br><br>Como o seu projeto faz parte do Programa Catarse Solidária, a taxa que será descontada no fim do seu projeto é definida por você mesmo. <strong>Quando você criou o seu rascunho, você disse que achava justo pagar %{percentage}% para o Catarse.</strong> <br><br><strong>Lembre-se, depois que sua campanha for publicada, você não poderá mais alterar essa taxa.</strong> Se mudou de ideia e quiser escolher outra taxa, o <a href="http://crowdfunding.catarse.me/solidaria/novo?utm_source=Catarse&amp;utm_medium=project_dashboard_goal&amp;utm_campaign=solidaria" target="_blank" class="alt-link">melhor é criar um outro rascunho.</a></div></div>'
 
     dashboard_description:


### PR DESCRIPTION
…tro de assinatura

### Descrição
Diversos links estavam referenciando para links inexistente ou links que não correspondiam exatamente ao que deveria (indo para a categoria mais geral do suporte). Além disso alguns não possuíam o ` target=_blank` . Aqui alterei para os links certos e específicos e adicionei o `target=_blank` onde era necessário.

### Referência

https://www.notion.so/catarse/Redirecionar-os-links-de-ajuda-de-metas-da-cria-o-de-assinatura-para-link-espec-fico-do-FAQ-6dd10a96d15c4c09b2f11a2ef7e7031d

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [X]  Descreveu o propósito do commit com o emoji no início da mensagem
- [X]  Mudanças estão unificadas em um único commit
- [X]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
