### PR TITLE
🐞 Atualiza lista de atributos não permitidos para edição de projeto

### DIFF
--- a/services/catarse/app/policies/project_policy.rb
+++ b/services/catarse/app/policies/project_policy.rb
@@ -66,6 +66,7 @@ class ProjectPolicy < ApplicationPolicy
           audited_user_name audited_user_cpf audited_user_phone_number
           state origin_id service_fee total_installments
           recommended created_at updated_at expires_at all_tags
+          tracker_snippet_html user_id admin_tags solidarity_covid
         ]
         p_attr.delete_if { |key| not_allowed.include?(key) }
       end

--- a/services/catarse/spec/policies/project_policy_spec.rb
+++ b/services/catarse/spec/policies/project_policy_spec.rb
@@ -114,6 +114,29 @@ RSpec.describe ProjectPolicy do
         it { is_expected.to eq(false) }
       end
     end
+
+    context 'when user isn`t admin' do
+      let(:user) { create(:user) }
+      let(:project) { create(:project) }
+      let(:policy) { ProjectPolicy.new(user, project) }
+
+      before do
+        user.admin = false
+        user.save!
+      end
+
+      %i[
+        audited_user_name audited_user_cpf audited_user_phone_number state origin_id service_fee total_installments
+        recommended created_at updated_at expires_at all_tags tracker_snippet_html user_id admin_tags solidarity_covid
+      ].each do |attribute|
+        context "when field is #{attribute.to_s}" do
+          subject { policy.permitted?(attribute) }
+
+          it { is_expected.to be_falsey }
+        end
+      end
+    end
+
     context 'when user is admin' do
       let(:user) { create(:user) }
       let(:project) { create(:project) }


### PR DESCRIPTION
### Descrição
Atualiza lista de atributos bloqueados para usuários comuns durante a edição de projetos.

### Referência

https://www.notion.so/catarse/Evitar-que-usu-rio-comum-possa-atualizar-campos-exclusivos-para-administradores-8caebc714d384247bdd24bf3441d5802

### Antes de criar esse pull request confira se:

- [x]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
