### PR TITLE
✨ Adiciona validação para verificar imagens base64 no corpo do projet…

### DIFF
--- a/services/catarse.js/legacy/src/error.js
+++ b/services/catarse.js/legacy/src/error.js
@@ -37,10 +37,10 @@ const generateErrorInstance = () => {
     e.displaySubmissionError = () => {
         if (submissionError()) {
             return m('.card.card-error.u-radius.zindex-10.u-marginbottom-30.fontsize-smaller',
-                     m('.u-marginbottom-10.fontweight-bold',
-                       m.trust(submissionErrorMsg())
-                      )
-                    );
+                m('.u-marginbottom-10.fontweight-bold',
+                    m.trust(submissionErrorMsg())
+                )
+            );
         }
 
         return null;
@@ -57,7 +57,7 @@ const generateErrorInstance = () => {
     e.inlineError = (field, flag) => {
         if (_.isUndefined(flag)) {
             if (hasError(field)) {
-                return m(inlineError, { message: getErrorMsg(field) });
+                return m(inlineError, { message: m.trust(getErrorMsg(field)) });
             }
 
             return null;

--- a/services/catarse.js/legacy/src/vms/user-about-vm.js
+++ b/services/catarse.js/legacy/src/vms/user-about-vm.js
@@ -39,6 +39,7 @@ const mapRailsErrors = (rails_errors) => {
     };
 
     extractAndSetErrorMsg('email', ['email']);
+    extractAndSetErrorMsg('about_html', ['about_html']);
 
     return e;
 };

--- a/services/catarse/app/models/concerns/project/custom_validators.rb
+++ b/services/catarse/app/models/concerns/project/custom_validators.rb
@@ -9,6 +9,7 @@ module Project::CustomValidators
     # This code might come back in a near future
     # validate :ensure_at_least_one_reward_validation, unless: :is_flexible?
     validate :validate_tags
+    validate :no_base64_images
 
     def validate_tags
       errors.add(:public_tags, :less_than_or_equal_to, count: 5) if public_tags.size > 5
@@ -35,7 +36,12 @@ module Project::CustomValidators
           I18n.t('activerecord.errors.models.project.attributes.rewards.at_least_one')
         )
       end
-    end    
+    end
+
+    def no_base64_images
+      errors.add(:about_html, :base64_images_not_allowed) if about_html.try(:match?, 'data:image/.*;base64')
+      errors.add(:budget, :base64_images_not_allowed) if budget.try(:match?, 'data:image/.*;base64')
+    end
 
   end
 end

--- a/services/catarse/app/models/concerns/user/custom_validators.rb
+++ b/services/catarse/app/models/concerns/user/custom_validators.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module User::CustomValidators
+  extend ActiveSupport::Concern
+
+  included do
+    validate :no_base64_images
+
+    def no_base64_images
+      errors.add(:about_html, :base64_images_not_allowed) if about_html.try(:match?, 'data:image/.*;base64')
+    end
+  end
+end

--- a/services/catarse/app/models/user.rb
+++ b/services/catarse/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
   include I18n::Alchemy
   acts_as_token_authenticatable
   include User::OmniauthHandler
+  include User::CustomValidators
   include Shared::CommonWrapper
   has_notifications
   # Include default devise modules. Others available are:

--- a/services/catarse/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -446,14 +446,14 @@ pt:
         refunded: "Reembolsado em %{date}"
         pending_refund: "Reembolso solicitado em %{date}"
         refused: "Pagamento não realizado"
-        chargeback: "Contestado"      
+        chargeback: "Contestado"
       cartaodecredito:
         pending: "Aguardando confirmação do pagamento"
         paid: "Confirmado em %{date}"
         refunded: "Reembolsado em %{date}"
         pending_refund: "Reembolso solicitado em %{date}"
         refused: "Pagamento recusado em %{date}"
-        chargeback: "Contestado"      
+        chargeback: "Contestado"
   contribution:
     payment_details:
       desconhecido: ""

--- a/services/catarse/config/locales/en.yml
+++ b/services/catarse/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
       mini_magick_processing_error: "Error while handling image, Original Error: %{e}"
       min_size_error: File must be larger than %{min_size}
       max_size_error: File must be less than %{max_size}
+      base64_images_not_allowed: "Base64 images are not allowed. Please, upload images using the upload button. <a target='_blank' href='https://suporte.catarse.me/hc/pt-br/articles/360023812172-Como-adicionar-imagens-e-v%C3%ADdeos-%C3%A0-descri%C3%A7%C3%A3o-do-projeto-'> Learn more.</a>"
   not_filled: Not filled
   days: days
   facebook_locale: en

--- a/services/catarse/config/locales/pt.yml
+++ b/services/catarse/config/locales/pt.yml
@@ -12,6 +12,7 @@ pt:
       mini_magick_processing_error: "Erro ao manipular imagem, Original Error: %{e}"
       min_size_error: "Arquivo deve ser maior que %{min_size}"
       max_size_error: "Arquivo deve ser menor que %{max_size}"
+      base64_images_not_allowed: "O formato de imagem base64 não é permitido. Por favor, inclua imagens usando o botão de adicionar imagens do editor de texto. <a target='_blank' href='https://suporte.catarse.me/hc/pt-br/articles/360023812172-Como-adicionar-imagens-e-v%C3%ADdeos-%C3%A0-descri%C3%A7%C3%A3o-do-projeto-'> Saiba como aqui.</a>"
   not_filled: 'Não preenchido'
   days: dias
   facebook_locale: pt_BR

--- a/services/catarse/dev.Dockerfile
+++ b/services/catarse/dev.Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.7.1-alpine
 #FROM alpine:3.7
 MAINTAINER Catarse <contato@catarse.me>
 
-ENV BUILD_PACKAGES postgresql-dev libxml2-dev libxslt-dev imagemagick imagemagick-dev openssl libpq libffi-dev bash curl-dev libstdc++ tzdata bash ca-certificates build-base ruby-dev libc-dev linux-headers postgresql-client postgresql git
+ENV BUILD_PACKAGES less postgresql-dev libxml2-dev libxslt-dev imagemagick imagemagick-dev openssl libpq libffi-dev bash curl-dev libstdc++ tzdata bash ca-certificates build-base ruby-dev libc-dev linux-headers postgresql-client postgresql git
 ENV RUBY_PACKAGES ruby ruby-io-console ruby-bundler ruby-irb ruby-bigdecimal ruby-json nodejs nodejs-npm zlib-dev yaml-dev readline-dev ruby-dev ncurses
 #
 ## Update and install all of the required packages.

--- a/services/catarse/spec/models/concerns/project/custom_validators_spec.rb
+++ b/services/catarse/spec/models/concerns/project/custom_validators_spec.rb
@@ -69,4 +69,52 @@ RSpec.describe Project::CustomValidators, type: :model do
     end
   end
 
+  describe '#no_base64_images' do
+    let(:project) { Project.new }
+
+    context 'when about_html has base64 images' do
+      before do
+        project.about_html = "<img src='data:image/png;base64'></img>"
+        project.valid?
+      end
+
+      it 'adds error message to about_html'  do
+        expect(project.errors[:about_html]).to include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+
+    context 'when about_html hasn`t base64 images' do
+      before do
+        project.about_html = "<img src='image.png'></img>"
+        project.valid?
+      end
+
+      it 'don`t add error message to about_html' do
+        expect(project.errors[:about_html]).to_not include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+
+    context 'when budget has base64 images' do
+      before do
+        project.budget = "<img src='data:image/png;base64'></img>"
+        project.valid?
+      end
+
+      it 'adds error message to budget' do
+        expect(project.errors[:budget]).to include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+
+    context 'when budget hasn`t base64 images' do
+      before do
+        project.budget = "<img src='image.png'></img>"
+        project.valid?
+      end
+
+      it 'don`t add error message to budget' do
+        expect(project.errors[:budget]).to_not include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+  end
+
 end

--- a/services/catarse/spec/models/concerns/user/custom_validators_spec.rb
+++ b/services/catarse/spec/models/concerns/user/custom_validators_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Project::CustomValidators, type: :model do
+  describe '#no_base64_images' do
+    let(:user) { User.new }
+
+    context 'when about_html has base64 images' do
+      before do
+        user.about_html = "<img src='data:image/png;base64'></img>"
+        user.valid?
+      end
+
+      it 'adds error message to about_html'  do
+        expect(user.errors[:about_html]).to include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+
+    context 'when about_html hasn`t base64 images' do
+      before do
+        user.about_html = "<img src='image.png'></img>"
+        user.valid?
+      end
+
+      it 'don`t add error message to about_html' do
+        expect(user.errors[:about_html]).to_not include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Descrição

Retorna erro ao tentar salvar images em base64 na descrição do projeto e na descrição do usuário.

### Referência

https://www.notion.so/catarse/Valida-o-no-backend-para-evitar-imagens-base64-na-descri-o-de-projetos-f8598d3af82f41078370781b4f251980

### Antes de criar esse pull request confira se:

- [x]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
