### PR TITLE
🐞 Adiciona recompensas esgotadas à lógica de liberação de questionário

### DIFF
--- a/services/catarse.js/legacy/src/root/surveys.js
+++ b/services/catarse.js/legacy/src/root/surveys.js
@@ -72,9 +72,14 @@ const surveys = {
     },
     view: function({state}) {
 
-        const project = _.first(state.projectDetails());
-        const canBeCreated = reward => !reward.survey_sent_at && ((reward.maximum_contributions && (reward.paid_count >= reward.maximum_contributions)) || project.state !== 'online');
-        const cannotBeCreated = reward => !reward.survey_sent_at && project.state === 'online' && (!reward.maximum_contributions || (reward.paid_count < reward.maximum_contributions));
+        const project         = _.first(state.projectDetails());
+        const projectOnline   = project.state === 'online';
+        const runnedOut       = reward => reward.run_out;
+        const surveyNotSent   = reward => !reward.survey_sent_at;
+        const reachedLimit    = reward => (reward.maximum_contributions && (reward.paid_count >= reward.maximum_contributions));
+
+        const canBeCreated    = reward => surveyNotSent(reward) && (reachedLimit(reward) || !projectOnline || runnedOut(reward));
+        const cannotBeCreated = reward => surveyNotSent(reward) && projectOnline && !reachedLimit(reward);
         const availableAction = (reward) => {
             if (canBeCreated(reward)) {
                 return m('.w-col.w-col-3.w-col-small-small-stack.w-col-tiny-tiny-stack',


### PR DESCRIPTION
### Descrição

A lógica de liberação do botão de questionário leva em consideração o atributo `run_out` (esgotado) da recompensa.

### Referência

https://www.notion.so/catarse/Corrigir-l-gica-na-libera-o-de-question-rio-para-recompensas-esgotadas-ad95e3dc364e4b39974af3b7213c40df

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [X]  Descreveu o propósito do commit com o emoji no início da mensagem
- [X]  Mudanças estão unificadas em um único commit
- [X]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
