### PR TITLE
✨ Adiciona retenção de IRRF

### DIFF
--- a/services/catarse.js/legacy/src/root/users/edit/#balance/user-balance-amount/user-balance-withdraw-request/withdraw-request-form.tsx
+++ b/services/catarse.js/legacy/src/root/users/edit/#balance/user-balance-amount/user-balance-withdraw-request/withdraw-request-form.tsx
@@ -54,12 +54,15 @@ function _WithdrawRequestForm(props : WithdrawRequestFormProps) {
                         <CurrencyFormat label='R$' value={balance.amount} />
                     </span>
                 </div>
+                <p class='u-marginbottom-20'>
+                    <I18nText scope="users.balance.withdraw_irrf_message_html" trust={true}/>
+                </p>
                 <UserOwnerBox
                     user={user}
                     hideAvatar={true}
                     getErrors={getErrors}
                     />
-                <UserBankForm 
+                <UserBankForm
                     getErrors={getErrors}
                     bankAccount={bankAccount}
                     onChange={onChange}

--- a/services/catarse/app/models/balance_transaction.rb
+++ b/services/catarse/app/models/balance_transaction.rb
@@ -257,7 +257,7 @@ class BalanceTransaction < ActiveRecord::Base
     return unless project.successful?
     return unless project.project_total.present?
     transaction do
-      default_params = { project_id: project_id, user_id: project.user_id }
+      default_params = { project_id: project.id, user_id: project.user_id }
 
       create!(default_params.merge(
         event_name: 'successful_project_pledged',
@@ -268,13 +268,12 @@ class BalanceTransaction < ActiveRecord::Base
         amount: (project.total_catarse_fee * -1)
       ))
 
-      # uncomment to use irrf tax
-      # if project.irrf_tax > 0
-      #   create!(default_params.merge(
-      #     event_name: 'irrf_tax_project',
-      #     amount: project.irrf_tax
-      #   ))
-      # end
+      if project.irrf_tax > 0
+        create!(default_params.merge(
+          event_name: 'irrf_tax_project',
+          amount: project.irrf_tax
+        ))
+      end
     end
   end
 

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
@@ -16,6 +16,11 @@ en:
       value_text: Value
       value: Value
       request_fund: Request withdrawal
+      withdraw_irrf_message_html: |
+          Creator,<br>
+          According to article 718 from RIR/2018, we must withhold income tax on the amount paid by a legal entity, due to intermediation service provided.<br>
+          <br>
+          Remember that in this case you are responsible for collecting the tax!! Check your invoice if this is your case and talk to your accountant to understand how to proceed.
       event_names:
         successful_project_pledged: Project funded project %{project_name}
         catarse_project_service_fee: Catarse Service Rate (%{service_fee}%)

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
@@ -16,6 +16,11 @@ pt:
       value_text: 'Valor'
       value: 'Valor'
       request_fund: 'Solicitar saque'
+      withdraw_irrf_message_html: |
+          Realizador,<br>
+          De acordo com o artigo 718 do RIR/2018 devemos reter o imposto de renda na fonte sobre o valor pago por pessoa jurídica, pelo serviço prestado de intermediação.<br>
+          <br>
+          Lembre que neste caso você é responsável por recolher o imposto!! Confira em sua Nota Fiscal se este é o seu caso e converse com o seu contador para entender como proceder.
       event_names:
         successful_project_pledged: 'Arrecadação de projeto financiado %{project_name}'
         catarse_project_service_fee: 'Taxa de serviço do Catarse (%{service_fee}%)'
@@ -81,7 +86,7 @@ pt:
       multiple_project_contribution: "Apoiou %{n_projects} projetos"
       single_project_created: " e já criou 1 projeto"
       multiple_project_created: " e já criou %{n_projects} projetos"
-    
+
     contribution_row:
       total_amount: "Total com juros: R$ %{total_amount}"
       anonymous: Quero que meu apoio não seja público
@@ -103,7 +108,7 @@ pt:
     subscription_row:
       anonymous_sub: 'Quero que minha assinatura não seja pública'
       anonymous_sub_title: 'Assinatura anônima'
-      
+
     card:
       twitter_profile: "Perfil no Twitter"
       facebook_profile: "Perfil no Facebook"

--- a/services/catarse/db/migrate/20200922141633_add_antifraud_cost_to_project_totals.rb
+++ b/services/catarse/db/migrate/20200922141633_add_antifraud_cost_to_project_totals.rb
@@ -1,0 +1,56 @@
+class AddAntifraudCostToProjectTotals < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE VIEW "1".project_totals AS
+      SELECT
+        c.project_id,
+        sum(p.value) AS pledged,
+        sum(p.value) FILTER (WHERE p.state = 'paid'::text) AS paid_pledged,
+        sum(p.value) / projects.goal * 100::numeric AS progress,
+        sum(p.gateway_fee) AS total_payment_service_fee,
+        sum(p.gateway_fee) FILTER (WHERE p.state = 'paid'::text) AS paid_total_payment_service_fee,
+        count(DISTINCT c.id) AS total_contributions,
+        count(DISTINCT c.user_id) AS total_contributors,
+        sum(COALESCE(aa.cost, 0)) AS total_antifraud_cost,
+        sum(COALESCE(aa.cost, 0)) FILTER (WHERE p.state = 'paid'::text) AS paid_total_antifraud_cost
+      FROM contributions c
+      JOIN projects ON c.project_id = projects.id
+      JOIN payments p ON p.contribution_id = c.id
+      LEFT JOIN antifraud_analyses aa ON p.id = aa.payment_id
+      WHERE
+        CASE
+          WHEN projects.state::text <> ALL (ARRAY['failed'::text, 'rejected'::text]) THEN
+            p.state = 'paid'::text
+          ELSE
+            p.state = ANY (confirmed_states())
+        END
+      GROUP BY c.project_id, projects.id;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE VIEW "1".project_totals AS
+      SELECT
+        c.project_id,
+        sum(p.value) AS pledged,
+        sum(p.value) FILTER (WHERE p.state = 'paid'::text) AS paid_pledged,
+        sum(p.value) / projects.goal * 100::numeric AS progress,
+        sum(p.gateway_fee) AS total_payment_service_fee,
+        sum(p.gateway_fee) FILTER (WHERE p.state = 'paid'::text) AS paid_total_payment_service_fee,
+        count(DISTINCT c.id) AS total_contributions,
+        count(DISTINCT c.user_id) AS total_contributors
+      FROM contributions c
+      JOIN projects ON c.project_id = projects.id
+      JOIN payments p ON p.contribution_id = c.id
+      WHERE
+        CASE
+          WHEN projects.state::text <> ALL (ARRAY['failed'::text, 'rejected'::text]) THEN
+            p.state = 'paid'::text
+          ELSE
+            p.state = ANY (confirmed_states())
+        END
+      GROUP BY c.project_id, projects.id;
+    SQL
+  end
+end

--- a/services/catarse/db/migrate/20200922173934_add_antifraud_cost_to_catarse_fee_without_gateway_fee.rb
+++ b/services/catarse/db/migrate/20200922173934_add_antifraud_cost_to_catarse_fee_without_gateway_fee.rb
@@ -1,0 +1,33 @@
+class AddAntifraudCostToCatarseFeeWithoutGatewayFee < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.total_catarse_fee_without_gateway_fee(project projects)
+        RETURNS numeric
+        LANGUAGE sql
+        STABLE
+      AS $function$
+        SELECT
+            (p.service_fee * pt.paid_pledged) - pt.paid_total_payment_service_fee - pt.paid_total_antifraud_cost
+        FROM public.projects p
+        LEFT JOIN "1".project_totals pt ON pt.project_id = p.id
+        WHERE p.id = project.id;
+      $function$;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.total_catarse_fee_without_gateway_fee(project projects)
+        RETURNS numeric
+        LANGUAGE sql
+        STABLE
+      AS $function$
+        SELECT
+            (p.service_fee * pt.paid_pledged) - pt.paid_total_payment_service_fee
+        FROM public.projects p
+        LEFT JOIN "1".project_totals pt ON pt.project_id = p.id
+        WHERE p.id = project.id;
+      $function$;
+    SQL
+  end
+end

--- a/services/catarse/spec/models/balance_transaction_spec.rb
+++ b/services/catarse/spec/models/balance_transaction_spec.rb
@@ -173,8 +173,8 @@ RSpec.describe BalanceTransaction, type: :model do
         project.finish
       end
 
-      it 'should not create irrf_tax_project transaction' do
-        expect(BalanceTransaction.find_by(event_name: 'irrf_tax_project', project_id: project.id, user_id: project.user_id, amount: project.irrf_tax)).to be_nil
+      it 'should create irrf_tax_project transaction' do
+        expect(BalanceTransaction.find_by(event_name: 'irrf_tax_project', project_id: project.id, user_id: project.user_id, amount: project.irrf_tax)).to be_present
       end
     end
 


### PR DESCRIPTION
### Descrição

Reabilita a retenção do imposto de renda, reajustando os cálculos para considerar os valores de antifraude.

### Referência

https://www.notion.so/catarse/Incluir-c-lculo-de-reten-o-de-IRRF-1-5-do-valor-da-NF-834e6826a18c47458953af416a79d6cc

### Antes de criar esse pull request confira se:

- [x]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
