### PR TITLE
🐞Mensagem de erro na solicitação de saque passa a informar link para o Suporte

### DIFF
--- a/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/edit.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/edit.en.yml
@@ -8,6 +8,6 @@ en:
       request_refunds: Request refund
       input_bank_number_label: Bank Number (3 digits)
       search_bank_btn_html: Search by &nbsp;&gt;
-      document_owner_mismatch_error: "Name or document doesn't match to bank account. To change, <a href='%{profile_link}' target='_self' class='alt-link'>access your profile</a>."
-      validation_error: "Not possible to validate bank account. Try again later."
+      document_owner_mismatch_error: "Name doesn't match with the document informed. <a href='https://suporte.catarse.me/hc/pt-br/articles/360052525491' target='_blank' class='alt-link'>Know how you can solve this problem</a>."
+      validation_error: "Not possible to validate bank account. <a href='https://suporte.catarse.me/hc/pt-br/articles/360052525491' target='_blank' class='alt-link'>Know how you can solve this problem</a>."
       select_bank: "Select a bank"

--- a/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/edit.pt.yml
@@ -8,6 +8,6 @@ pt:
       request_refunds: "Solicitar reembolso"
       input_bank_number_label: "Número do banco (3 números)"
       search_bank_btn_html: "Busca por nome  &nbsp;&gt;"
-      document_owner_mismatch_error: "O nome ou documento não correspondem com os dados bancários. Para alterá-los, <a href='%{profile_link}' target='_self' class='alt-link'>acesse os seus dados cadastrais</a>."
-      validation_error: "Não foi possível validar a conta bancária. Tente novamente mais tarde."
+      document_owner_mismatch_error: "O nome não corresponde ao documento informado. <a href='https://suporte.catarse.me/hc/pt-br/articles/360052525491' target='_blank' class='alt-link'>Saiba como resolver esse problema</a>."
+      validation_error: "Não foi possível validar a conta bancária. <a href='https://suporte.catarse.me/hc/pt-br/articles/360052525491' target='_blank' class='alt-link'>Saiba como resolver esse problema</a>."
       select_bank: "Selecione um banco"


### PR DESCRIPTION
### Descrição

Esse PR muda a mensagem de erro que estamos informando no momento da solicitação de saque, referente ao Nome e Documento não estarem corretos. Agora a mensagem de erro passa a levar o user para um artigo da Base de Conhecimento, além de melhorar a redação da mensagem de erro em si.

### Referência

https://www.notion.so/catarse/Alterar-mensagem-de-erro-na-valida-o-de-saque-em-tempo-real-ec9f3561601a425c893bfe330919a399

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [X]  Descreveu o propósito do commit com o emoji no início da mensagem
- [X]  Mudanças estão unificadas em um único commit
- [X]  Revisou seu próprio código
- [X]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
