### PR TITLE
🐞 Melhora mensagem de retenção de IRRF

### DIFF
--- a/services/catarse.js/legacy/src/root/users/edit/#balance/index.tsx
+++ b/services/catarse.js/legacy/src/root/users/edit/#balance/index.tsx
@@ -2,8 +2,9 @@ import { withHooks } from 'mithril-hooks'
 import { UserBalanceAmount, UserBalanceAmountProps } from './user-balance-amount/user-balance-amount'
 import { UserBalanceTransactionsWithServices } from './user-balance-transactions'
 import { UserBalanceWithdrawHistoryWithServices } from './user-balance-withdraw-history'
-import { UserDetails } from '../../../../entities'
+import { UserDetails } from '@/entities'
 import { UserBalanceAmountWithServices } from './user-balance-amount'
+import { I18nText } from '@/shared/components/i18n-text'
 
 export type UserBalanceProps = {
     user: UserDetails
@@ -14,6 +15,7 @@ export const UserBalance = withHooks<UserBalanceProps>(_UserBalance)
 function _UserBalance({user} : UserBalanceProps) {
     return (
         <div id='balance-area'>
+            <IrrfRetentionMessage user={user}/>
             <UserBalanceAmountWithServices user={user} />
             <UserBalanceWithdrawHistoryWithServices user={user} />
             <div class='divider'></div>
@@ -22,4 +24,18 @@ function _UserBalance({user} : UserBalanceProps) {
             <div class='w-section section card-terciary before-footer'></div>
         </div>
     )
+}
+
+const IrrfRetentionMessage = withHooks<UserBalanceProps>(_IrrfRetentionMessage)
+
+function _IrrfRetentionMessage({user}: UserBalanceProps) {
+    if (user.account_type === 'pj') {
+        return (
+            <div class="w-container">
+                <div class="card card-message u-radius fontsize-small">
+                    <I18nText scope="users.balance.withdraw_irrf_message_html" trust={true}/>
+                </div>
+            </div>
+        )
+    }
 }

--- a/services/catarse.js/legacy/src/root/users/edit/#balance/user-balance-amount/user-balance-withdraw-request/withdraw-request-form.tsx
+++ b/services/catarse.js/legacy/src/root/users/edit/#balance/user-balance-amount/user-balance-withdraw-request/withdraw-request-form.tsx
@@ -54,9 +54,6 @@ function _WithdrawRequestForm(props : WithdrawRequestFormProps) {
                         <CurrencyFormat label='R$' value={balance.amount} />
                     </span>
                 </div>
-                <p class='u-marginbottom-20'>
-                    <I18nText scope="users.balance.withdraw_irrf_message_html" trust={true}/>
-                </p>
                 <UserOwnerBox
                     user={user}
                     hideAvatar={true}

--- a/services/catarse.js/webpack.config.js
+++ b/services/catarse.js/webpack.config.js
@@ -61,6 +61,9 @@ module.exports = {
     },
     resolve: {
         extensions: ['.tsx', '.ts', '.jsx', '.js'],
+        alias: {
+            '@': path.resolve(__dirname, 'legacy/src')
+        }
     },
     devServer: {
         contentBase: './dist',

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
@@ -17,10 +17,10 @@ en:
       value: Value
       request_fund: Request withdrawal
       withdraw_irrf_message_html: |
-          Creator,<br>
-          According to article 718 from RIR/2018, we must withhold income tax on the amount paid by a legal entity, due to intermediation service provided.<br>
-          <br>
-          Remember that in this case you are responsible for collecting the tax!! Check your invoice if this is your case and talk to your accountant to understand how to proceed.
+          <b>Creator</b>: According to article 718 from RIR/2018, we must withhold income tax on the amount paid by a
+          legal entity, due to intermediation service provided. Remember that in this case you are responsible for
+          collecting the tax!! Check your invoice if this is your case and talk to your accountant to understand how to
+          proceed.
       event_names:
         successful_project_pledged: Project funded project %{project_name}
         catarse_project_service_fee: Catarse Service Rate (%{service_fee}%)

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
@@ -17,10 +17,10 @@ pt:
       value: 'Valor'
       request_fund: 'Solicitar saque'
       withdraw_irrf_message_html: |
-          Realizador,<br>
-          De acordo com o artigo 718 do RIR/2018 devemos reter o imposto de renda na fonte sobre o valor pago por pessoa jurídica, pelo serviço prestado de intermediação.<br>
-          <br>
-          Lembre que neste caso você é responsável por recolher o imposto!! Confira em sua Nota Fiscal se este é o seu caso e converse com o seu contador para entender como proceder.
+          <b>Aviso a Realizadores com cadastro de Pessoa Jurídica:</b> De acordo com o artigo 718 do RIR/2018 devemos
+          reter o imposto de renda na fonte sobre o valor pago por pessoa jurídica, pelo serviço prestado de
+          intermediação. Lembre que neste caso você é responsável por recolher o imposto!! Confira em sua Nota Fiscal se
+          este é o seu caso e converse com o seu contador para entender como proceder.
       event_names:
         successful_project_pledged: 'Arrecadação de projeto financiado %{project_name}'
         catarse_project_service_fee: 'Taxa de serviço do Catarse (%{service_fee}%)'


### PR DESCRIPTION
### Descrição
A mensagem de aviso de retenção do IRRF estava dentro do pop-up de preenchimento de dados para o saque. Isso fazia a experiência de usuário ser pior pois encondia o formulário com um scroll. Agora a mensagem foi movida para a tela principal de saldo. 
Aproveitei pra criar um alias para o "root_path" do projeto catarse.js, assim fica mais fácil apontar para um arquivo usando o `@/shared/components...` do que fazendo `../../../../../shared/components/...`

### Referência

https://www.notion.so/catarse/Trocar-local-da-mensagem-de-IRRF-do-popup-de-saque-para-a-tela-de-saldo-080fedfe61d648f18685ad6ebda623dd

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
