### PR TITLE
🔧 configurar facebook para sdk v9.0

### DIFF
--- a/services/catarse/app/models/concerns/user/omniauth_handler.rb
+++ b/services/catarse/app/models/concerns/user/omniauth_handler.rb
@@ -20,7 +20,7 @@ module User::OmniauthHandler
           locale: I18n.locale.to_s
         }
       ) do |user|
-        user.remote_uploaded_image_url = "https://graph.facebook.com/#{hash['uid']}/picture?type=large"
+        user.remote_uploaded_image_url = "https://graph.facebook.com/v9.0/#{hash['uid']}/picture?type=large"
       end
     end
 

--- a/services/catarse/app/views/catarse_bootstrap/layouts/_facebook_sdk.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/layouts/_facebook_sdk.html.slim
@@ -6,16 +6,15 @@ javascript:
       status     : true, // check login status
       cookie     : true, // enable cookies to allow the server to access the session
       xfbml      : true,  // parse XFBML
-      version    : 'v2.0'
+      version    : 'v9.0'
     });
-
   };
 
   // Load the SDK Asynchronously
   (function(d){
-     var js, id = 'facebook-jssdk', ref = d.getElementsByTagName('script')[0];
-     if (d.getElementById(id)) {return;}
-     js = d.createElement('script'); js.id = id; js.async = true;
-     js.src = "//connect.facebook.net/#{t('facebook_locale')}/sdk.js";
-     ref.parentNode.insertBefore(js, ref);
-   }(document));
+    var js, id = 'facebook-jssdk', ref = d.getElementsByTagName('script')[0];
+    if (d.getElementById(id)) {return;}
+    js = d.createElement('script'); js.id = id; js.async = true;
+    js.src = "//connect.facebook.net/#{t('facebook_locale')}/sdk.js";
+    ref.parentNode.insertBefore(js, ref);
+  }(document));


### PR DESCRIPTION
### Descrição

Atualiza versão do sdk para v9

### Referência

https://www.notion.so/catarse/Atualiza-o-da-GRAPH-API-do-Facebook-para-coletar-thumbnail-de-usu-rios-20eeb0d576494062a1debfadbaff47e7

### Antes de criar esse pull request confira se:

- [ ]  Testes estão implementados
- [x]  Descreveu o propósito do commit com o emoji no início da mensagem
- [x]  Mudanças estão unificadas em um único commit
- [x]  Revisou seu próprio código
- [ ]  A base de conhecimento foi atualizada (Isso para quando tivermos uma)
