### PR TITLE
🐞 Mostra mensagem de retenção de IRRF para MEI

### DIFF
--- a/services/catarse.js/legacy/src/root/users/edit/#balance/index.tsx
+++ b/services/catarse.js/legacy/src/root/users/edit/#balance/index.tsx
@@ -29,7 +29,7 @@ function _UserBalance({user} : UserBalanceProps) {
 const IrrfRetentionMessage = withHooks<UserBalanceProps>(_IrrfRetentionMessage)
 
 function _IrrfRetentionMessage({user}: UserBalanceProps) {
-    if (user.account_type === 'pj') {
+    if (user.account_type === 'pj' || user.account_type === 'mei') {
         return (
             <div class="w-container">
                 <div class="card card-message u-radius fontsize-small">


### PR DESCRIPTION
### Descrição
A mensagem que avisa sobre retenção de IRRF não estava sendo exibida para usuários MEI, apenas PJ. Com esse ajuste, todos os usuários PJ, sendo MEI ou não, irão ver o aviso de retenção de IRRF.

### Referência
https://www.notion.so/catarse/Incluir-MEI-PJ-no-popup-de-reten-o-de-IRRF-na-aba-Saldo-ed44cbaed41d435bb1d6ed3208f8ac7f

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
