### PR TITLE
🐞 Adiciona tipo MEI no cálculo de IRRF

### DIFF
--- a/services/catarse/db/migrate/20201202192021_add_mei_to_irrf_tax_function.rb
+++ b/services/catarse/db/migrate/20201202192021_add_mei_to_irrf_tax_function.rb
@@ -1,0 +1,39 @@
+class AddMeiToIrrfTaxFunction < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.irrf_tax(project projects)
+      RETURNS numeric
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+            CASE
+            WHEN u.account_type IN ('pj', 'mei') AND p.total_catarse_fee_without_gateway_fee >= 666.66 THEN
+                0.015 * p.total_catarse_fee_without_gateway_fee
+            ELSE 0 END
+        FROM public.projects p
+        LEFT JOIN public.users u on u.id = p.user_id
+        WHERE p.id = project.id;
+      $function$;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.irrf_tax(project projects)
+      RETURNS numeric
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+            CASE
+            WHEN u.account_type = 'pj' AND p.total_catarse_fee_without_gateway_fee >= 666.66 THEN
+                0.015 * p.total_catarse_fee_without_gateway_fee
+            ELSE 0 END
+        FROM public.projects p
+        LEFT JOIN public.users u on u.id = p.user_id
+        WHERE p.id = project.id;
+      $function$;
+    SQL
+  end
+end


### PR DESCRIPTION
### Descrição
Não estávamos considerado os usuários do tipo MEI no cálculo de retenção de IRRF. Com as alterações, agora todos nossos usuários cadastrados como pessoa jurídica estarão incluídos nos cálculos de IRRF.

### Referência
Link para a atividade/card/issue/ticket

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
