### PR TITLE
✨ Bloquear cadastro de email com referencia a catarse.

### DIFF
--- a/services/catarse/app/models/concerns/user/custom_validators.rb
+++ b/services/catarse/app/models/concerns/user/custom_validators.rb
@@ -4,10 +4,18 @@ module User::CustomValidators
   extend ActiveSupport::Concern
 
   included do
-    validate :no_base64_images
+    validate :no_base64_images, :block_email_with_reference_to_catarse
 
     def no_base64_images
       errors.add(:about_html, :base64_images_not_allowed) if about_html.try(:match?, 'data:image/.*;base64')
+    end
+
+    def block_email_with_reference_to_catarse
+      return unless email.present? && email_changed?
+      if email.split('@').last.try(:include?, 'catarse')
+        errors.add(:email, :invalid)
+        raise ActiveRecord::Rollback
+      end
     end
   end
 end

--- a/services/catarse/app/models/user.rb
+++ b/services/catarse/app/models/user.rb
@@ -527,4 +527,3 @@ class User < ActiveRecord::Base
     end
   end
 end
-


### PR DESCRIPTION
### Descrição
Nossa plataforma não tem um meio de confirmar que o e-mail que o usuário está utilizando realmente é do usuário em questão. Isso leva a pessoas poderem criar contas com qualquer e-mail que não esteja cadastrada na plataforma, por exemplo: owner@catarse.me e isso abriu uma falha de segurança.

### Referência
https://www.notion.so/catarse/N-o-permitir-cria-es-de-conta-com-o-email-que-remeta-ao-catarse-97b3a7a20e6e4212bb18f543225cd3cc

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
