### PR TITLE
🐞 Corrige regex de validação de e-mail

### DIFF
--- a/services/catarse/app/models/user.rb
+++ b/services/catarse/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ActiveRecord::Base
   validates :permalink, exclusion: { in: %w[api cdn secure suporte],
                                      message: 'Endereço já está em uso.' }
   validates_format_of :email,
-    with:  /\A[a-zA-Z0-9!#\\&$%'*+=?^`{}|~_-](\.?[a-zA-Z0-9\\!#$&%'*+=?^`{}|~_-]){0,}@[a-zA-Z0-9]+\.(?!-)([a-zA-Z0-9]?((-?[a-zA-Z0-9]+)+\.(?!-))){0,}[a-zA-Z0-9]{2,8}\z/,
+    with:  /\A[a-zA-Z0-9!#\\&$%'*+=?^`{}|~_-](\.?[a-zA-Z0-9\\!#$&%'*+=?^`{}|~_-]){0,}@[a-zA-Z0-9]+(?:\.|\-)(?!-)([a-zA-Z0-9]?((-?[a-zA-Z0-9]+)+\.(?!-))){0,}[a-zA-Z0-9]{2,8}\z/,
     allow_blank: true,
     if: :email_changed?
 


### PR DESCRIPTION
### Descrição
Os usuários que tinham email com `-` após o `@` (ex.: `fulano@algum-site.com`) não estavam conseguindo se cadastrar na nossa plataforma. Ajustei a regex de validação de e-mail para permitir 

### Referência
https://www.notion.so/catarse/Corrigir-regex-de-valida-o-do-e-mail-40c4e72755bd4a488f966447308b930f

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
