### PR TITLE
🐞 Atualizacao de cache para novos status do projeto.

### DIFF
--- a/services/catarse/app/state_machine/flex_project_machine.rb
+++ b/services/catarse/app/state_machine/flex_project_machine.rb
@@ -154,6 +154,7 @@ class FlexProjectMachine
 
   # put project in successful or waiting_funds state
   def finish
+    ProjectMetricStorageRefreshWorker.perform_async(self.object.id)
     transition_to(:waiting_funds, to_state: 'waiting_funds') || transition_to(:failed, to_state: 'failed') || transition_to(:successful, to_state: 'successful')
   end
 end

--- a/services/catarse/app/state_machine/sub_project_machine.rb
+++ b/services/catarse/app/state_machine/sub_project_machine.rb
@@ -98,6 +98,7 @@ class SubProjectMachine
   end
 
   def finish
+    ProjectMetricStorageRefreshWorker.perform_async(self.object.id)
     transition_to(:successful, to_state: 'successful')
   end
 end

--- a/services/catarse/lib/tasks/dispatch_project_metric_storage_refresh_task.rake
+++ b/services/catarse/lib/tasks/dispatch_project_metric_storage_refresh_task.rake
@@ -24,7 +24,7 @@ class DispatchProjectMetricStorageRefreshTask
     ProjectMetricStorage
       .joins(:project)
       .where("refreshed_at < now() - '5 minutes'::interval")
-      .where(projects: {state: 'online'})
+      .where(projects: { state: %i[online waiting_funds] })
       .pluck(:project_id)
       .each do |id|
       ProjectMetricStorageRefreshWorker.perform_async(id)

--- a/services/catarse/lib/tasks/dispatch_reward_metric_storage_refresh_task.rake
+++ b/services/catarse/lib/tasks/dispatch_reward_metric_storage_refresh_task.rake
@@ -24,7 +24,7 @@ class DispatchRewardMetricStorageRefreshTask
     RewardMetricStorage
       .joins(reward: :project)
       .where("refreshed_at < now() - '5 minutes'::interval")
-      .where(projects: { state: 'online' })
+      .where(projects: { state: %i[online waiting_funds] })
       .pluck(:reward_id)
       .each do |id|
       RewardMetricStorageRefreshWorker.perform_async(id)


### PR DESCRIPTION
### Descrição
Depois que o projeto sai do status online, os cache de recompensa e projeto param de atualizar. Precisamos colocar os status waiting_funds, failed, successful na rotina em que atualiza os cache.

### Referência
https://www.notion.so/catarse/Atualizar-rake-de-atualiza-o-de-cache-para-atualizar-tamb-m-projetos-finalizados-5930ff429a8840bb9df8f821e27efa4d

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
