### PR TITLE
Corrige rotina de virar pagamentos que considera mais dias que o necessário

### DIFF
--- a/services/catarse/app/models/payment.rb
+++ b/services/catarse/app/models/payment.rb
@@ -21,7 +21,7 @@ class Payment < ActiveRecord::Base
   attr_accessor :generating_second_slip
 
   scope :all_boleto_that_should_be_refused, -> {
-    where('payments.slip_expires_at + \'3 days\'::interval < current_timestamp and payment_method = \'BoletoBancario\' and state = \'pending\'')
+    where('payments.slip_expires_at < current_timestamp and payment_method = \'BoletoBancario\' and state = \'pending\'')
   }
 
   scope :with_missing_payables, lambda {


### PR DESCRIPTION
### Descrição
A rotina que recusa os boletos que passaram do prazo de vencimento já utiliza uma função que considera o prazo de vencimento, mas está adicionando 3 dias além do necessário.

### Referência
https://www.notion.so/catarse/Rotina-de-virar-pagamentos-de-boleto-para-recusado-esta-considerando-3-alem-do-necess-rio-75bb02694a39497c95fa06f373990d89

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [x] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
