### PR TITLE
🐞 Ajusta to_param para aceitar somente ID do user

### DIFF
--- a/services/catarse/app/models/user.rb
+++ b/services/catarse/app/models/user.rb
@@ -360,11 +360,6 @@ class User < ActiveRecord::Base
     to_analytics.to_json
   end
 
-  def to_param
-    return id.to_s unless display_name
-    "#{id}-#{display_name.parameterize}"
-  end
-
   def project_unsubscribes
     contributed_projects.map do |project|
       unsubscribes.posts_unsubscribe(project.id)


### PR DESCRIPTION
### Descrição
Um erro está acontecendo ao ser acessar uma página do usuário com ID + user.name como parâmetro da rota (exemplo: https://www.catarse.me/pt/users/4374-thiago-neri). A solução é ajustar to_param do model user e permitir somente o ID do usuário.

### Referência
https://www.notion.so/catarse/ae4f80371ac34954be3b3aa78597f89e?v=64589b4e273447ec9022d48d82fa0df2&p=8028a2d22df743c28d1ae335532259e8

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
