### PR TITLE
✨ Adiciona nova tradução para erro de processamento no cartão.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/vms/common-payment-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/common-payment-vm.js
@@ -136,7 +136,7 @@ const getPaymentInfoUntilNoError = (paymentMethod, isEdit) => ({ id, catalog_pay
 let creditCardRetries = 5;
 const waitForSavedCreditCard = promise => (creditCardId) => {
     if (creditCardRetries <= 0) {
-        return promise.reject({ message: 'Could not save card' });
+        return promise.reject({ message: I18n.t('submission.card_processing_failure', I18nScope()) });
     }
 
     creditCardInfo(creditCardId).then(([infoR]) => {

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.en.yml
@@ -200,6 +200,7 @@ en:
               few moments.
             card_invalid: Credit card information is not valid. Please review your
               credit card info and try again.
+            card_processing_failure: 'Houve um erro no processamento do seu pagamento. Tente novamente mais tarde e, caso o problema persista, entre em contato com a nossa Central de Suporte através do link: <a class="alt-link" target="_blank" href="https://suporte.catarse.me/hc/pt-br/requests/new" style="color: #fff">https://suporte.catarse.me/hc/pt-br/requests/new</a>'
             error: "<span>An error occurred while trying to process your payment.</span>
               <br><br> Error: <i> %{message}</i>"
           validation:
@@ -290,6 +291,7 @@ en:
               in a few moments.
             card_invalid: Invalid credit card data. Please review your credit card
               information and try again.
+            card_processing_failure: 'Houve um erro no processamento do seu pagamento. Tente novamente mais tarde e, caso o problema persista, entre em contato com a nossa Central de Suporte através do link: <a class="alt-link" target="_blank" href="https://suporte.catarse.me/hc/pt-br/requests/new" style="color: #fff">https://suporte.catarse.me/hc/pt-br/requests/new</a>'
             error: "<span>There was a problem processing your payment.</span> <br><br>
               Error: <i> %{message}</i>"
           validation:

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.pt.yml
@@ -168,6 +168,7 @@ pt:
             encryption_error: 'Please try again in a few moments.'
             payment_failed: 'Please review your credit card info and try again in a few moments.'
             card_invalid: 'Credit card information is not valid. Please review your credit card info and try again.'
+            card_processing_failure: 'Houve um erro no processamento do seu pagamento. Tente novamente mais tarde e, caso o problema persista, entre em contato com a nossa Central de Suporte através do link: <a class="alt-link" target="_blank" href="https://suporte.catarse.me/hc/pt-br/requests/new" style="color: #fff">https://suporte.catarse.me/hc/pt-br/requests/new</a>'
             error: '<span>An error ocurred while trying to process your payment.</span><br><br>Error: <i>%{message}</i>'
           validation:
             empty_field: 'The field cannot be empty.'
@@ -242,6 +243,7 @@ pt:
             slip_submission: 'Ocorreu um erro ao tentar gerar o boleto. Por favor, tente novamente em alguns instantes.'
             slip_validation: 'Erro ao validar dados do formulário. Por favor, revise-os e tente novamente.'
             encryption_error: 'Por favor, tente novamente em alguns instantes.'
+            card_processing_failure: 'Houve um erro no processamento do seu pagamento. Tente novamente mais tarde e, caso o problema persista, entre em contato com a nossa Central de Suporte através do link: <a class="alt-link" target="_blank" href="https://suporte.catarse.me/hc/pt-br/requests/new" style="color: #fff">https://suporte.catarse.me/hc/pt-br/requests/new</a>'
             payment_failed: 'Por favor, revise os dados de seu cartão de crédito e tente novamente em alguns instantes.'
             card_invalid: 'Dados de cartão de crédito inválidos. Por favor, revise os dados de seu cartão de crédito e tente novamente.'
             error: '<span>Ocorreu um problema ao processar o seu pagamento.</span><br><br>Erro: <i>%{message}</i>'
@@ -333,7 +335,7 @@ pt:
       thank_you:
         subscription_edit:
           thank_you: "Quase lá!"
-          text_html: "<div class='fontsize-base'>A alteração de sua assinatura foi processada, mas só será efetivada na sua próxima cobrança. Enviamos uma mensagem com detalhes para o email abaixo:</div><div class='fontsize-large u-marginbottom-10'>%{email}</div><a class='alt-link fontsize-small' href='%{link_email}'>Se esse não é seu email de contato, altere aqui</a>" 
+          text_html: "<div class='fontsize-base'>A alteração de sua assinatura foi processada, mas só será efetivada na sua próxima cobrança. Enviamos uma mensagem com detalhes para o email abaixo:</div><div class='fontsize-large u-marginbottom-10'>%{email}</div><a class='alt-link fontsize-small' href='%{link_email}'>Se esse não é seu email de contato, altere aqui</a>"
         thank_you_error: 'Ocorreu um erro ao solicitar os dados do seu pagamento. Tente novamente em alguns instantes.'
         thank_you: 'Valeu! Seu apoio está sendo processado.'
         thank_you_text_html: "<div class='fontsize-base'>Assim que o pagamento for concluído, enviaremos a confirmação do seu apoio para o email cadastrado:</div><div class='fontsize-large u-marginbottom-10'>%{email}</div><a class='alt-link fontsize-small' href='%{link_email}'>Se esse não é seu email de contato, altere aqui</a>"
@@ -358,6 +360,6 @@ pt:
           acontecer.
         title: Muito obrigado
       subscription_start_title: Escolha a recompensa e em seguida o valor do apoio mensal
-      subscription_edit_title: Você está editando uma assinatura já existente 
+      subscription_edit_title: Você está editando uma assinatura já existente
       subscription_reactivation_title: Você está reativando uma assinatura inativa
       subscription_edit_subtitle: Escolha sua recompensa e o valor de sua assinatura


### PR DESCRIPTION
### Descrição
Nos pagamentos para projetos de assinatura, quando é identificada mais de 5 tentativas falhas no cartão de crédito é mostrada a seguinte mensagem de erro: 'Could not save card'. Portanto será adicionado uma melhor explicação e uma nova tradução. 

### Referência
https://www.notion.so/catarse/Traduzir-mensagem-de-Could-not-save-card-no-frontend-para-portugu-s-f7f74f2efad841ce9ebdcf3838790e5a

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
