### PR TITLE
🔧 Configura inicialização do Sentry

### DIFF
--- a/services/catarse/config/application.rb
+++ b/services/catarse/config/application.rb
@@ -19,6 +19,7 @@ module Catarse
 
       Raven.configure do |config|
         config.dsn = CatarseSettings.get_without_cache(:sentry_dsn) || ''
+        config.secret_key = config.public_key
         config.environments = %w[sandbox production]
         config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
       end


### PR DESCRIPTION
### Descrição
O Sentry não está coletando erros desde a migração para servidores próprios. O erro é falta da `secret_key`, e agora essa `secret_key` será inicializada com o mesmo valor da `public_key`.

### Referência
https://www.notion.so/catarse/Configurar-inicializa-o-do-Sentry-no-Catarse-Back-end-cb47715bf0ff409483b998a4908a8434

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
