### PR TITLE
🐞 Corrige teste de recompensa

### DIFF
--- a/services/catarse/app/models/reward.rb
+++ b/services/catarse/app/models/reward.rb
@@ -59,7 +59,7 @@ class Reward < ApplicationRecord
   after_save :index_on_common
 
   def log_changes
-    self.last_changes = changes
+    self.last_changes = changes.to_json
   end
 
   def to_s

--- a/services/catarse/spec/models/reward_spec.rb
+++ b/services/catarse/spec/models/reward_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Reward, type: :model do
       end
 
       it 'should save the last changes' do
-        expect(reward.last_changes).to eq('{"description":["envie um email para foo@bar.com","foo"]}')
+        expect(reward.last_changes).to eq({"description" => ["envie um email para foo@bar.com","foo"]}.to_json)
       end
     end
   end


### PR DESCRIPTION
### Descrição
Teste de recompensa passou a quebrar depois dos hotfix feitos para corrigir problemas do deploy do Rails 6.1.
