### PR TITLE
🐞 Corrigir valor do apoio ao escolher local da entrega

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-reward-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-reward-card.js
@@ -34,7 +34,11 @@ const projectRewardCard = {
                 ? Number(vm.shippingFeeForCurrentReward(selectedDestination).value)
                 : 0;
             const rewardMinValue = Number(vm.selectedReward().minimum_value);
-            vm.applyMask(`${h.formatNumber(shippingFee + rewardMinValue, 2, 3)}`);
+            const numberValueFloat = h.monetaryToFloat(vm.contributionValue);
+            const valueFloat = _.isNaN(numberValueFloat) ? MINIMUM_VALUE : numberValueFloat;
+            if (valueFloat < rewardMinValue + shippingFee) {
+              vm.applyMask(`${h.formatNumber(shippingFee + rewardMinValue, 2, 3)}`);
+            }
         };
 
         // @TODO: move submit, fee & value logic to VM
@@ -49,7 +53,7 @@ const projectRewardCard = {
                 vm.error(`O valor de apoio para essa recompensa deve ser de no mínimo R$${vm.selectedReward().minimum_value} ${projectVM.isSubscription(projectVM.currentProject()) ? '' : `+ frete R$${h.formatNumber(shippingFee.value, 2, 3)}`} `);
             } else {
                 vm.error('');
-                
+
                 const valueUrl = window.encodeURIComponent(String(valueFloat).replace('.', ','));
 
                 if (projectVM.isSubscription(projectVM.currentProject())) {

--- a/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
@@ -39,7 +39,7 @@ const rewardSelectCard = {
                     const currentRewardId = rewardVM.selectedReward().id;
                     h.navigateTo(`/projects/${projectVM.currentProject().project_id}/subscriptions/checkout?contribution_value=${valueFloat}${currentRewardId ? `&reward_id=${currentRewardId}` : ''}${isEdit() ? `&subscription_id=${m.route.param('subscription_id')}` : ''}${isReactivation() ? `&subscription_status=${subscriptionStatus}` : ''}`);
                 } else {
-                    const valueUrl = window.encodeURIComponent(String(valueFloat).replace('.', ',')); 
+                    const valueUrl = window.encodeURIComponent(String(valueFloat).replace('.', ','));
                     h.navigateTo(`/projects/${projectVM.currentProject().project_id}/contributions/fallback_create?contribution%5Breward_id%5D=${rewardVM.selectedReward().id}&contribution%5Bvalue%5D=${valueUrl}&contribution%5Bshipping_fee_id%5D=${shippingFee.id}`);
                 }
             }
@@ -55,7 +55,11 @@ const rewardSelectCard = {
                 Number(rewardVM.shippingFeeForCurrentReward(selectedDestination).value) :
                 0;
             const rewardMinValue = Number(rewardVM.selectedReward().minimum_value);
-            rewardVM.applyMask(`${h.formatNumber(shippingFee + rewardMinValue, 2, 3)}`);
+            const numberValue = h.monetaryToFloat(rewardVM.contributionValue)
+            const valueFloat = _.isNaN(numberValue) ? MINIMUM_VALUE : numberValue;
+            if (valueFloat < rewardMinValue + shippingFee) {
+              rewardVM.applyMask(`${h.formatNumber(shippingFee + rewardMinValue, 2, 3)}`);
+            }
         };
 
         const normalReward = (reward) => {
@@ -174,10 +178,10 @@ const rewardSelectCard = {
                 ),
                 m('.back-reward-reward-description', [
                     (
-                        reward.uploaded_image ? 
+                        reward.uploaded_image ?
                             (
                                 m("div.u-marginbottom-20.w-row", [
-                                    m("div.w-col.w-col-8", 
+                                    m("div.w-col.w-col-8",
                                         m(`img[src='${reward.uploaded_image}'][alt='']`)
                                     ),
                                     m("div.w-col.w-col-4")


### PR DESCRIPTION
### Descrição
No card de recompensa, na página de projeto, quanto no card de recompensa na tela de contributions/new, em projetos pontuais, o valor de apoio sempre é o padrão ao selecionar o valor o local de entrega. O comportamento esperado deveria ser de corrigir  apenas se o valor estiver inferior ao minimo.

### Referência
https://www.notion.so/catarse/Ao-escolher-um-local-de-entrega-o-valor-do-apoio-volta-para-o-default-independente-de-qual-valor-t-36c318e180fc4b97adaea6fa0773708d

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
