### PR TITLE
🐞 Corrigi exibição de bordas vermelhas somente em campos obrigatório e após a requisição.

### DIFF
--- a/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
+++ b/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
@@ -6911,3 +6911,11 @@ html.w-mod-js *[data-ix="display-0-on-load"] {
   -ms-grid-row-span: 1;
   grid-row-end: 3;
 }
+
+input:required {
+  box-shadow:none;
+}
+
+textarea:required {
+  box-shadow:none;
+}


### PR DESCRIPTION
### Descrição
Ao acessar nossa plataforma com o navegador Firefox, os campos obrigatórios estão sendo inicializados com borda vermelha. Isso é um bug presente no próprio firefox(exemplo: https://codepen.io/gabrielras/pen/LYRbNNQ). O resultado esperado dessa correção é que os campos do form sejam carregados com o estado inicial vazio e só fiquem com borda vermelha após alguma requisição. A solução usada foi utilizada por outros desenvolvedores no seguinte problema: https://github.com/react-toolbox/react-toolbox/issues/1639

### Referência
https://www.notion.so/catarse/Exibir-borda-vermelho-em-inputs-de-forms-somente-quando-eles-s-o-obrigat-rios-e-somente-ap-s-requisi-5a57e957027b4528906e03a5648cae4a

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
