### PR TITLE
🐞 valida cep no evento onblur do campo

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/address-form-national.js
+++ b/services/catarse/catarse.js/legacy/src/c/address-form-national.js
@@ -8,6 +8,7 @@ const I18nScope = _.partial(h.i18nScope, 'activerecord.attributes.address');
 
 const addressFormNational = {
     view: function ({ attrs }) {
+        const validateZipCode = attrs.validateZipCode;
         const disableInternational = attrs.disableInternational;
         const countryName = attrs.countryName;
         const fields = attrs.fields;
@@ -49,6 +50,7 @@ const addressFormNational = {
                                 oninput: e => {
                                     lookupZipCode(e.target.value);
                                 },
+                                onblur: validateZipCode,
                             }),
                             errors.addressZipCode()
                                 ? m(inlineError, {

--- a/services/catarse/catarse.js/legacy/src/c/address-form.js
+++ b/services/catarse/catarse.js/legacy/src/c/address-form.js
@@ -23,7 +23,13 @@ export default class AddressForm {
             applyZipcodeMask = (value) => fields.addressZipCode(zipcodeMask(value)),
             applyPhoneMask = (value) => fields.phoneNumber(phoneMask(value)),
             internationalProp = vnode.attrs.international ? vnode.attrs.international : prop(false),
-            international = vnode.attrs.disableInternational ? prop(false) : internationalProp;
+            international = vnode.attrs.disableInternational ? prop(false) : internationalProp,
+            validateZipCode = () => {
+                const zipCodeOnlyNumbers = fields.addressZipCode().replace(/\D*/g, '');
+                if (zipCodeOnlyNumbers.length !== 8) {
+                    fields.errors.addressZipCode(true);
+                }
+            };
 
         const lookupZipCode = zipCode => {
             fields.addressZipCode(zipCode);
@@ -59,6 +65,7 @@ export default class AddressForm {
         });
 
         vnode.state = {
+            validateZipCode,
             lookupZipCode,
             zipCodeErrorMessage,
             applyPhoneMask,
@@ -102,7 +109,8 @@ export default class AddressForm {
             countryStates = state.states,
             disableInternational = attrs.disableInternational,
             hideNationality = attrs.hideNationality,
-            applyPhoneMask = state.applyPhoneMask;
+            applyPhoneMask = state.applyPhoneMask,
+            validateZipCode = state.validateZipCode;
 
         return m('#address-form.u-marginbottom-30.w-form', [
             !hideNationality
@@ -129,6 +137,7 @@ export default class AddressForm {
                     applyPhoneMask,
                 })
                 : m(addressFormNational, {
+                    validateZipCode,
                     disableInternational,
                     countryName,
                     fields,


### PR DESCRIPTION
### Descrição
Faz validação do CEP quando sai o foco do campo de texto.

### Referência
https://www.notion.so/catarse/Valida-o-do-CEP-no-checkout-de-pagamento-nacional-aceita-CEP-com-padr-o-diferente-do-brasileiro-d0bce45845f84b269c9f0e1fc3bcf440

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
