### PR TITLE
🐞 ajusta carregamento do header com o usuário logado no admin

### DIFF
--- a/services/catarse/catarse.js/legacy/src/admin-wrap.tsx
+++ b/services/catarse/catarse.js/legacy/src/admin-wrap.tsx
@@ -1,0 +1,39 @@
+import { ComponentConstructor, useEffect, withHooks } from 'mithril-hooks'
+import c from './c'
+import h from './h'
+import { HeaderMenu } from './root/header-menu'
+import { If } from './shared/components/if'
+import userVM from './vms/user-vm'
+
+export function AdminWrap(Component : ComponentConstructor<any>, customAttr: { [key:string] : any }) {
+    return withHooks<AdminWrapProps>(_AdminWrap, { Component, customAttr })
+}
+
+type AdminWrapProps = {
+    Component: ComponentConstructor<any>
+    customAttr: { [key:string] : any }
+};
+
+function _AdminWrap(props : AdminWrapProps) {
+    const {
+        Component,
+        customAttr,
+    } = props
+
+    const hideFooter = customAttr.hideFooter
+    const Footer = c.root.Footer as any as ComponentConstructor<{}>
+
+    useEffect(() => {
+        userVM.getMyUser().then(h.redraw)
+    }, [])
+
+    return (
+        <div id='app'>
+            <HeaderMenu {...customAttr} user={userVM.myUser()}/>
+            <Component />
+            <If condition={!hideFooter}>
+                <Footer />
+            </If>
+        </div>
+    )
+}

--- a/services/catarse/catarse.js/legacy/src/app.js
+++ b/services/catarse/catarse.js/legacy/src/app.js
@@ -4,6 +4,7 @@ import _ from 'underscore';
 import c from './c';
 import Chart from 'chart.js';
 import { Wrap } from './wrap';
+import { AdminWrap } from './admin-wrap';
 
 m.originalTrust = m.trust;
 m.trust = (text) => h.trust(text);
@@ -36,35 +37,16 @@ m.trust = (text) => h.trust(text);
     const adminRoot = document.getElementById('new-admin');
 
     if (adminRoot) {
-        const adminWrap = function (component, customAttr) {
-            return {
-                oninit: function (vnode) {
-                    const attr = customAttr;
-
-                    vnode.state = {
-                        attr,
-                    };
-                },
-                view: function ({ state }) {
-                    const { attr } = state;
-                    return m('#app', [
-                        m(c.root.HeaderMenu, attr),
-                        m(component, attr),
-                        attr.hideFooter ? '' : m(c.root.Footer, attr)
-                    ]);
-                },
-            };
-        };
         m.route.prefix('#');
 
         m.route(adminRoot, '/', {
-            '/': adminWrap(c.root.AdminContributions, { root: adminRoot, menuTransparency: false, hideFooter: true }),
-            '/home-banners': adminWrap(c.root.AdminHomeBanners, { menuTransparency: false, hideFooter: true }),
-            '/users': adminWrap(c.root.AdminUsers, { menuTransparency: false, hideFooter: true }),
-            '/subscriptions': adminWrap(c.root.AdminSubscriptions, { menuTransparency: false, hideFooter: true }),
-            '/projects': adminWrap(c.root.AdminProjects, { menuTransparency: false, hideFooter: true }),
-            '/notifications': adminWrap(c.root.AdminNotifications, { menuTransparency: false, hideFooter: true }),
-            '/balance-transfers': adminWrap(c.root.AdminBalanceTranfers, { menuTransparency: false, hideFooter: true }),
+            '/': AdminWrap(c.root.AdminContributions, { root: adminRoot, menuTransparency: false, hideFooter: true }),
+            '/home-banners': AdminWrap(c.root.AdminHomeBanners, { menuTransparency: false, hideFooter: true }),
+            '/users': AdminWrap(c.root.AdminUsers, { menuTransparency: false, hideFooter: true }),
+            '/subscriptions': AdminWrap(c.root.AdminSubscriptions, { menuTransparency: false, hideFooter: true }),
+            '/projects': AdminWrap(c.root.AdminProjects, { menuTransparency: false, hideFooter: true }),
+            '/notifications': AdminWrap(c.root.AdminNotifications, { menuTransparency: false, hideFooter: true }),
+            '/balance-transfers': AdminWrap(c.root.AdminBalanceTranfers, { menuTransparency: false, hideFooter: true }),
         });
     }
 


### PR DESCRIPTION
### Descrição
Ajusta header do admin para exibir o usuário logado.

### Referência
https://www.notion.so/catarse/Header-n-o-atualiza-com-menu-de-usu-rio-logado-dando-a-impress-o-que-o-usu-rio-esta-deslogado-e0ca57ca79b143ecbae883e599d5dc3a

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
