### PR TITLE
🐞 Ajusta valor quebrado no card de recompensa.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/projects-payment-reward-detail.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/projects-payment-reward-detail.tsx
@@ -5,6 +5,7 @@ import { DateFormat } from "../shared/components/date-format"
 import { I18nText } from "../shared/components/i18n-text"
 import { If } from "../shared/components/if"
 import rewardVM from "../vms/reward-vm"
+import h from '../h'
 
 export const ProjectsPaymentRewardDetails = withHooks<ProjectsPaymentRewardDetailsProps>(_ProjectsPaymentRewardDetails)
 
@@ -59,7 +60,7 @@ function _ProjectsPaymentRewardDetails(props : ProjectsPaymentRewardDetailsProps
                     </If>
                     <If condition={!hasDescription}>
                         <I18nText trust={true} scope={`${scope}.selected_reward.review_without_reward_html`} params={{
-                            value: <CurrencyFormat label='R$' value={value} />
+                            value: `R$ ${h.formatNumber(Number(value), 2, 3)}`
                         }} />
                     </If>
                 </div>


### PR DESCRIPTION
### Descrição
Ao apoiar qualquer projeto pontual sem selecionar recompensa, no card que exibe os dados da recompensa não exibe o valor. Isso acontece pq o value não consegue reproduzir o componente.

### Referência
https://www.notion.so/catarse/Valor-quebrado-no-card-de-recompensa-selecionada-na-tela-de-confirma-o-de-pagamento-7ae28ee969d545889c27704279ee4ab8

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
