### PR TITLE
🐞 Ajusta id de recompensa invalido ao atualizar cache.

### DIFF
--- a/services/catarse/lib/tasks/common.rake
+++ b/services/catarse/lib/tasks/common.rake
@@ -114,7 +114,7 @@ namespace :common do
       unless sp.already_in_balance?
         begin
           BalanceTransaction.insert_subscription_payment(sp.id)
-          RewardMetricStorageRefreshWorker.perform_async(sp.reward_id)
+          RewardMetricStorageRefreshWorker.perform_async(sp.reward.id) if sp.reward.present?
         rescue StandardError => e
           Raven.extra_context(task: :generate_subscription_balance, subscription_payment_id: sp.id)
           Raven.capture_exception(e)


### PR DESCRIPTION
### Descrição
Devemos ajustar id de recompensa invalido em rotina de atualizar cache de recompensas, pois ao utilizar sp.reward_id e não sp.reward.id ele é passado no formado do comum. 

### Referência
https://www.notion.so/catarse/Ajustar-id-de-recompensa-invalido-em-rotina-de-atualizar-cache-de-recompensas-7fb636fac0064b13ae5772f4d89c2313

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
