### PR TITLE
🐞 redesenha a tela de questionário após carregar a recompensa e/ou detalhes do projeto

### DIFF
--- a/services/catarse/catarse.js/legacy/src/root/survey-create.js
+++ b/services/catarse/catarse.js/legacy/src/root/survey-create.js
@@ -37,8 +37,20 @@ const surveyCreate = {
             l = loader(models.projectDetail.getRowOptions(filterVM.parameters()));
 
         const reward = prop([]);
-        l.load().then(projectDetails);
-        rewardVM.load().then(reward);
+
+
+        l
+            .load()
+            .then(projectDetailsResponse => {
+                projectDetails(projectDetailsResponse);
+                h.redraw();
+            });
+        rewardVM
+            .load()
+            .then(rewardResponse => {
+                reward(rewardResponse);
+                h.redraw();
+            });
 
         const choice = (type) => {
 
@@ -72,7 +84,6 @@ const surveyCreate = {
         };
 
         const choiceDropdown = question => {
-            console.log('question to drop down', question);
             return m('.w-col.w-col-4.w-sub-col',
                 m('.text-field.w-dropdown', {
                     onclick: () => {
@@ -146,7 +157,7 @@ const surveyCreate = {
         const project = _.first(state.projectDetails());
         const reward = _.first(state.reward());
         return [
-            project ? 
+            project ?
                 m('.project-surveys', [
                     (
                         project.is_owner_or_admin &&
@@ -154,7 +165,7 @@ const surveyCreate = {
                             project: prop(project)
                         })
                     ),
-                    state.showPreview() ? 
+                    state.showPreview() ?
                         m(surveyCreatePreview, {
                             confirmAddress: state.confirmAddress(),
                             showPreview: state.showPreview,
@@ -162,7 +173,7 @@ const surveyCreate = {
                             reward,
                             sendQuestions: state.sendQuestions
                         })
-                        : 
+                        :
                         [
                             (
                                 reward &&
@@ -225,7 +236,7 @@ const surveyCreate = {
                                                         m(dashboardOpenQuestion, {
                                                             question,
                                                             index
-                                                        })                
+                                                        })
                                                 ),
                                                 m('button.btn.btn-inline.btn-no-border.btn-small.btn-terciary.fa.fa-lg.fa-trash.u-right', {
                                                     onclick: state.deleteDashboardQuestion(question)


### PR DESCRIPTION
### Descrição
Tela de questionário não está sendo redesenhada após carregamento dos detalhes do projeto e/ou recompensa.

### Referência
https://www.notion.so/catarse/Renderiza-o-invalida-quando-atualiza-a-pagina-de-cadastro-de-pesquisa-em-recompensa-72bcda12d5a8445eaebf7cda40e8ab1f

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
