### PR TITLE
🐞 Corrige sincronização para o common de projetos deletados

### DIFF
--- a/services/catarse/lib/tasks/sync_deleted_projects_task.rake
+++ b/services/catarse/lib/tasks/sync_deleted_projects_task.rake
@@ -1,0 +1,24 @@
+class SyncDeletedProjectsTask
+  include Rake::DSL
+
+  def initialize
+    namespace :projects do
+      task sync_deleted_projects: :environment do
+        call
+      end
+    end
+  end
+
+  private
+
+  def call
+    ProjectTransition
+    .where("created_at > now() - '24 hours'::interval AND to_state = 'deleted'")
+    .pluck(:project_id).each do |pr|
+      p = Project.find pr
+      p.index_on_common
+    end
+  end
+end
+
+SyncDeletedProjectsTask.new


### PR DESCRIPTION
### Descrição
Quanto um projeto é deletado do catarse (`status = deleted`) o sistema não faz uma chamada para atualizar ele no comum, fazendo com que o permalink antigo continue sendo utilizado. Essa rake foi criada para resolver o problema de sincronização.

### Referência
[Atualizar dados do projeto no comum quando ele for deletado do catarse](https://www.notion.so/catarse/Atualizar-dados-do-projeto-no-comum-quando-ele-for-deletado-do-catarse-2480fe33172449498f45cca3cc4814ed)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
