### PR TITLE
✨ Permitir admin banir projetos

### DIFF
--- a/services/catarse/app/actions/banish_project_action.rb
+++ b/services/catarse/app/actions/banish_project_action.rb
@@ -1,0 +1,87 @@
+class BanishProjectAction
+
+  def initialize(project_id:)
+    @project = Project.find project_id
+  rescue => e
+    Raven.capture_exception(e, level: 'fatal')
+  end
+
+  def call
+    if @project.is_sub?
+      project_sub
+    end
+
+    # deletar projeto
+    @project.push_to_trash
+
+    # banir usuario
+    @project.user.update_columns(banned_at: DateTime.now)
+    BlacklistDocument.find_or_create_by number: @project.user.cpf
+  rescue => e
+    Raven.capture_exception(e, level: 'fatal')
+  end
+
+  def project_sub
+    # Pedir o cancelamento de todas as assinaturas
+    cw = CommonWrapper.new
+
+    @project.subscriptions.each do |sub|
+      cw.cancel_subscription(sub) if sub.status != "canceled" && sub.user.present?
+    end
+
+    refund_all_with_credit_card
+    create_balance_transaction_for_boleto_payments
+  end
+
+  def refund_all_with_credit_card
+    # Reembolsar usuarios com cartão crédito
+    @project.subscription_payments.where("data ->> 'payment_method' = 'credit_card' ").find_each do |payment|
+      if payment.status == 'paid'
+        begin
+          PagarMe.api_key = CatarseSettings[:pagarme_api_key]
+          t = PagarMe::Transaction.find payment.gateway_general_data['gateway_id']
+          t.refund if t.status == 'paid'
+          balance_transaction_for_project_user(payment)
+        rescue Exception => e
+          Raven.capture_exception(e)
+        end
+      end
+    end
+  end
+
+  def create_balance_transaction_for_boleto_payments
+    # boleto bancario
+    @project.subscription_payments.where("data ->> 'payment_method' = 'boleto' ").find_each do |payment|
+      if payment.status == 'paid'
+        begin
+          balance_transaction_for_project_user(payment)
+          # Remover saldo do apoiador de assinaturas
+          BalanceTransaction.create!(
+            user_id: payment.user.id,
+            event_name: 'subscription_payment_refunded',
+            amount: payment.amount,
+            subscription_payment_uuid: payment.id,
+            project_id: payment.project.id
+          ) if !BalanceTransaction.where(event_name: 'subscription_payment_refunded', subscription_payment_uuid: payment.id, user_id: payment.user.id).present?
+          payment.refund
+        rescue Exception => e
+          Raven.capture_exception(e)
+        end
+      end
+    end
+  end
+
+  # Remover saldo do realizador de assinaturas
+  def balance_transaction_for_project_user(payment)
+    BalanceTransaction.create!(
+      user_id: payment.project.user_id,
+      event_name: 'subscription_payment_refunded',
+      amount: ((payment.amount - (payment.amount * payment.project.service_fee)) * -1),
+      subscription_payment_uuid: payment.id,
+      project_id: payment.project.id
+    ) if !BalanceTransaction.where(event_name: 'subscription_payment_refunded',
+                                   subscription_payment_uuid: payment.id,
+                                   user_id: payment.project.user_id
+                                  ).present?
+  end
+end

--- a/services/catarse/app/controllers/projects_controller.rb
+++ b/services/catarse/app/controllers/projects_controller.rb
@@ -109,6 +109,11 @@ class ProjectsController < ApplicationController
     authorize resource, :update?
   end
 
+  def banish_report
+    authorize resource, :update?
+    BanishProjectWorker.perform_async(@project.id)
+  end
+
   def subscriptions_monthly_report_for_project_owners
     authorize resource, :update?
     report = SubscriptionMonthlyReportForProjectOwner.project_id(resource.common_id).to_csv

--- a/services/catarse/app/workers/banish_project_worker.rb
+++ b/services/catarse/app/workers/banish_project_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class BanishProjectWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: 5
+
+  def perform(project_id)
+    BanishProjectAction.new(project_id: project_id).call()
+  end
+end

--- a/services/catarse/catarse.js/legacy/src/c/admin-project-detail.js
+++ b/services/catarse/catarse.js/legacy/src/c/admin-project-detail.js
@@ -105,6 +105,30 @@ const adminProjectDetail = {
             }
         };
 
+        const banishProject = {
+            toggler: h.toggleProp(false, true),
+            submit: () => {
+                banishProject.complete(false);
+                m.request({
+                    method: 'PUT',
+                    url: `/projects/${project_id}/banish_report`,
+                    config: h.setCsrfToken,
+                    }).then(() => {
+                        banishProject.complete(true);
+                        banishProject.success(true);
+                        banishProject.error(false);
+                    }).catch(() => {
+                        banishProject.complete(true);
+                        banishProject.success(true);
+                        banishProject.error(true);
+                    });
+                return false;
+            },
+            complete: prop(false),
+            error: prop(false),
+            success: prop(false),
+        };
+
         if (vnode.attrs.item.mode === 'sub') {
             commonAnalytics.loaderWithToken(models.projectSubscribersInfo.postOptions({
                 id: vnode.attrs.item.common_id
@@ -116,6 +140,7 @@ const adminProjectDetail = {
             bankAccount: loadBank(),
             subscriberInfo: projectSubscriberInfo,
             actions: {
+                banishProject,
                 changeUserAction,
                 projectRevert
             },
@@ -139,7 +164,7 @@ const adminProjectDetail = {
                     m('button.btn.btn-small.btn-terciary', {
                         onclick: state.actions.changeUserAction.toggler.toggle
                     }, 'Trocar realizador'),
-                    (state.actions.changeUserAction.toggler() ? 
+                    (state.actions.changeUserAction.toggler() ?
                         m('.dropdown-list.card.u-radius.dropdown-list-medium.zindex-10', {
                             oncreate: state.actionUnload(state.actions.changeUserAction)
                         }, [
@@ -165,6 +190,33 @@ const adminProjectDetail = {
                             ])
                         ]) : '')
                 ]),
+                m('.w-row.u-marginbottom-30', [
+                    m('.w-col.w-col-2', [
+                        m('button.btn.btn-small.btn-terciary', {
+                            onclick: state.actions.banishProject.toggler.toggle
+                        }, 'Banir Projeto'),
+                        (state.actions.banishProject.toggler() ?
+                            m('.dropdown-list.card.u-radius.dropdown-list-medium.zindex-10', {
+                                oncreate: state.actionUnload(state.actions.banishProject)
+                            }, [
+                                m('form.w-form',
+                                (!state.actions.banishProject.complete()) ? [
+                                    m('label', 'Você realmente deseja banir esse projeto?'),
+                                    m('input.w-button.btn.btn-small[type="submit"][value="Confirmar"]', {
+                                        onclick: state.actions.banishProject.submit
+                                    })
+                                ] : (!state.actions.banishProject.error()) ? [
+                                    m('.w-form-done[style="display:block;"]', [
+                                        m('p', 'O Processo de banimento foi iniciado com sucesso.')
+                                    ])
+                                ] : [
+                                    m('.w-form-error[style="display:block;"]', [
+                                        m('p', 'Houve um problema na requisição.')
+                                    ])
+                                ])
+                            ]) : '')
+                    ]),
+                ]),
                 m('.w-col.w-col-2', [
                     (item.mode === 'sub' ?
                         m('a.btn.btn-small.btn-terciary', { href: `/projects/${item.project_id}/subscriptions_report` }, 'Base de assinantes')
@@ -175,7 +227,7 @@ const adminProjectDetail = {
                         m('button.btn.btn-small.btn-terciary', {
                             onclick: state.actions.projectRevert.toggler.toggle
                         }, (totalSubscriptions > 0 ? 'Encerrar projeto' : 'Virar projeto para Draft')),
-                        (state.actions.projectRevert.toggler() ? 
+                        (state.actions.projectRevert.toggler() ?
                             (state.actions.projectRevert.loading() ? h.loader()
                                 : m('.dropdown-list.card.u-radius.dropdown-list-medium.zindex-10', [
                                     m('form.w-form', {

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -131,6 +131,7 @@ Catarse::Application.routes.draw do
         get 'video', on: :collection
         member do
           post :upload_image
+          put :banish_report
           get 'insights'
           get 'posts'
           get 'surveys'

--- a/services/catarse/spec/controllers/projects_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects_controller_spec.rb
@@ -339,6 +339,13 @@ RSpec.describe ProjectsController, type: :controller do
     end
   end
 
+  describe 'PUT banish_report' do
+    before do
+      put :banish_report, params: { id: project }
+    end
+    it { is_expected.to have_http_status(302) }
+  end
+
   describe 'Solidarity project' do
     let(:integrations_attributes) { [{ name: 'SOLIDARITY_SERVICE_FEE', data: { name: 'SOLIDARITY FEE NAME' } }] }
 

--- a/services/catarse/spec/workers/banish_project_worker_spec.rb
+++ b/services/catarse/spec/workers/banish_project_worker_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BanishProjectWorker do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+
+  before do
+    Sidekiq::Testing.inline!
+  end
+
+  context 'when project exist' do
+    context "when project is flex" do
+      let(:confirmed_contribution) { create(:confirmed_contribution, project_id: project.id, user_id: user.id) }
+      let(:payment) { confirmed_contribution.payments.first }
+
+      before do
+        expect(BalanceTransaction).to receive(:insert_contribution_refund).with(payment.contribution_id)
+        expect(BalanceTransaction).to receive(:insert_contribution_refunded_after_successful_pledged).with(payment.contribution_id)
+        expect(project.user.banned_at).to eq(nil)
+        expect(project.push_to_trash).to be_truthy
+      end
+
+      it 'should refund on balance' do
+        BanishProjectWorker.perform_async(project.id)
+      end
+    end
+
+    context "when project is sub" do
+      before do
+        allow(project).to receive(:is_sub?).and_return(true)
+        expect(project.user.banned_at).to eq(nil)
+        expect(project.push_to_trash).to be_truthy
+      end
+
+      it 'should refund on balance' do
+        BanishProjectWorker.perform_async(project.id)
+      end
+    end
+  end
+
+  context 'when project not exist' do
+    it 'should return an error' do
+      BanishProjectWorker.perform_async(11111111111)
+      expect { raise StandardError }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
### Descrição
Adicionar o processo de exclusão de projeto de fraude (flex ou sub) no admin de projetos, pois atualmente precisamos de um dev toda vez para remover um projeto de fraude da plataforma.

### Referência
https://www.notion.so/catarse/Poder-encerrar-projetos-como-fraude-e31e5a29a9d1419d8d6fd5f7c8243a45

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
