### PR TITLE
🐞 ajusta o próximo método de pagamento no histórico de assinaturas

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/payment-method-icon.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/payment-method-icon.tsx
@@ -8,10 +8,11 @@ export default {
 
 export type PaymentMethodIconProps = {
     subscription: Subscription
+    paymentMethodOverride?: string
 }
 
-function PaymentMethodIcon({subscription} : PaymentMethodIconProps) {
-    const lastPaymentMethod = subscription?.last_payment_data?.payment_method || subscription.payment_method
+function PaymentMethodIcon({subscription, paymentMethodOverride} : PaymentMethodIconProps) {
+    const lastPaymentMethod = paymentMethodOverride || subscription?.last_payment_data?.payment_method || subscription.payment_method
     const paymentClass = { boleto: 'fa-barcode', credit_card: 'fa-credit-card' }[lastPaymentMethod]
     return (
         <span>

--- a/services/catarse/catarse.js/legacy/src/c/user-subscription-box.js
+++ b/services/catarse/catarse.js/legacy/src/c/user-subscription-box.js
@@ -124,7 +124,7 @@ const userSubscriptionBox = {
                     m('span.badge.badge-attention.fontweight-semibold', [
                         m('span.fa.fa-arrow-right', ''),
                         m.trust('&nbsp;'),
-                        m(paymentMethodIcon, { subscription }),
+                        m(paymentMethodIcon, { subscription, paymentMethodOverride: subscription.payment_method }),
                     ]),
                 ];
             }


### PR DESCRIPTION
Reabrindo PR do @grpse pois refiz o sandbox a partir do main.

### Descrição
No histórico de assinaturas do usuário não estava sendo exibido o próximo método de pagamento após ser feita a edição de uma assinatura.

![image](https://user-images.githubusercontent.com/5807336/106267962-2e8aad00-6209-11eb-9871-b250eddff4b9.png)

### Referência
https://www.notion.so/catarse/Edi-o-de-assinatura-do-meio-de-pagamento-de-Cart-o-Boleto-n-o-est-sendo-exibido-no-Hist-rico-de--65ecb56e82fd4b84bac1e3847f117d4a

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
