### PR TITLE
🐞 Move a action banish_report para o controller do admin

### DIFF
--- a/services/catarse/app/controllers/admin/projects_controller.rb
+++ b/services/catarse/app/controllers/admin/projects_controller.rb
@@ -38,6 +38,11 @@ class Admin::ProjectsController < Admin::BaseController
     redirect_to admin_projects_path
   end
 
+  def banish_report
+    @project = Project.find params[:id]
+    BanishProjectWorker.perform_async(@project.id)
+  end
+
   def update
     resource.update(permitted_params)
     super

--- a/services/catarse/app/controllers/projects_controller.rb
+++ b/services/catarse/app/controllers/projects_controller.rb
@@ -109,11 +109,6 @@ class ProjectsController < ApplicationController
     authorize resource, :update?
   end
 
-  def banish_report
-    authorize resource, :update?
-    BanishProjectWorker.perform_async(@project.id)
-  end
-
   def subscriptions_monthly_report_for_project_owners
     authorize resource, :update?
     report = SubscriptionMonthlyReportForProjectOwner.project_id(resource.common_id).to_csv

--- a/services/catarse/catarse.js/legacy/src/c/admin-project-detail.js
+++ b/services/catarse/catarse.js/legacy/src/c/admin-project-detail.js
@@ -111,7 +111,7 @@ const adminProjectDetail = {
                 banishProject.complete(false);
                 m.request({
                     method: 'PUT',
-                    url: `/projects/${project_id}/banish_report`,
+                    url: `admin/projects/${project_id}/banish_report`,
                     config: h.setCsrfToken,
                     }).then(() => {
                         banishProject.complete(true);

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -131,7 +131,6 @@ Catarse::Application.routes.draw do
         get 'video', on: :collection
         member do
           post :upload_image
-          put :banish_report
           get 'insights'
           get 'posts'
           get 'surveys'
@@ -228,6 +227,7 @@ Catarse::Application.routes.draw do
             put 'reject'
             put 'push_to_draft'
             put 'push_to_trash'
+            put :banish_report
           end
         end
 

--- a/services/catarse/spec/controllers/admin/projects_controller_spec.rb
+++ b/services/catarse/spec/controllers/admin/projects_controller_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe Admin::ProjectsController, type: :controller do
     it { is_expected.to eq(true) }
   end
 
+  describe 'PUT banish_report' do
+    let(:project) { create(:project, state: 'online', mode: 'flex') }
+
+    before do
+      put :banish_report, params: { id: project }
+    end
+    it { is_expected.to have_http_status(204) }
+  end
+
   describe 'PUT push_to_draft' do
     let(:project) { create(:project, state: 'rejected') }
     subject { project.draft? }

--- a/services/catarse/spec/controllers/projects_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects_controller_spec.rb
@@ -339,13 +339,6 @@ RSpec.describe ProjectsController, type: :controller do
     end
   end
 
-  describe 'PUT banish_report' do
-    before do
-      put :banish_report, params: { id: project }
-    end
-    it { is_expected.to have_http_status(302) }
-  end
-
   describe 'Solidarity project' do
     let(:integrations_attributes) { [{ name: 'SOLIDARITY_SERVICE_FEE', data: { name: 'SOLIDARITY FEE NAME' } }] }
 


### PR DESCRIPTION
### Descrição
Atualmente a action banish_report está no controller projects e permite que o usuário, caso tenha acesso a essa rota, possa banir seu próprio projeto. A solução é mover essa action para o controller do admin.

### Referência
https://www.notion.so/catarse/Mover-a-action-banish_report-para-o-controller-do-admin-81d0aa827fb84032b47bb230d3f256f3

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
