### PR TITLE
🔧 Configura merge automático do main com o sandbox

### DIFF
--- a/.github/workflows/merge_main_into_sandbox.yml
+++ b/.github/workflows/merge_main_into_sandbox.yml
@@ -1,0 +1,23 @@
+name: 'Merge main into sandbox'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge_main_into_sandbox:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Nightly Merge
+      uses: robotology/gh-action-nightly-merge@v1.3.1
+      with:
+        stable_branch: 'main'
+        development_branch: 'sandbox'
+        allow_ff: false
+        user_name: Github Action
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Descrição
Para evitar o trabalho manual de jogar os commits de merge que aparecem no main para o sandbox toda vez que quisermos criar um pull request para sandbox.

### Referência
Não se aplica

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
