### PR TITLE
💚 Ajusta função public.is_expired não utiliza mais da validação de 365 dias

### DIFF
--- a/services/catarse/db/migrate/20210211230938_adjust_is_expired_to_not_look_over_fixed_days.rb
+++ b/services/catarse/db/migrate/20210211230938_adjust_is_expired_to_not_look_over_fixed_days.rb
@@ -1,0 +1,71 @@
+class AdjustIsExpiredToNotLookOverFixedDays < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.is_expired(project projects)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+AS $function$
+            select
+            case when $1.mode = 'sub' then
+               false
+            else
+              public.is_past($1.expires_at)
+            end;
+        $function$
+;
+---
+
+CREATE OR REPLACE FUNCTION public.is_expired(project "1".projects)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+AS $function$ 
+            select
+            case when $1.mode = 'sub' then
+               false
+            else
+              public.is_past($1.expires_at)
+            end;
+        $function$
+
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.is_expired(project projects)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+AS $function$
+            select
+            case when $1.mode = 'aon' then
+               public.is_past($1.expires_at)
+            when $1.mode = 'sub' then
+               false
+            else
+              public.is_past($1.expires_at) OR current_timestamp > $1.online_at + '365 days'::interval
+            end;
+        $function$
+;
+---
+
+CREATE OR REPLACE FUNCTION public.is_expired(project "1".projects)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+AS $function$ 
+            select
+            case when $1.mode = 'aon' then
+               public.is_past($1.expires_at)
+            when $1.mode = 'sub' then
+               false
+            else
+              public.is_past($1.expires_at) OR current_timestamp > $1.online_date + '365 days'::interval
+            end;
+        $function$
+
+    SQL
+  end
+end


### PR DESCRIPTION
### Descrição
Atualmente existe uma validação que um projeto flex so pode ficar no maximo 365 dias no ar, alguns projetos estão sendo finalizados por causa desse problema bem antes do prazo de expiração definido

### Referência
https://www.notion.so/catarse/Consertar-valida-o-de-prazo-de-365-dias-em-projetos-Flex-095b4bf1f32143439faf2584bb8ac78d

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
