### PR TITLE
✨ Adiciona ID de pagamento (id de gateway) ao histórico de apoios

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/dashboard-subscription-card-detail-payment-history-entry.js
+++ b/services/catarse/catarse.js/legacy/src/c/dashboard-subscription-card-detail-payment-history-entry.js
@@ -23,33 +23,35 @@ const dashboardSubscriptionCardDetailPaymentHistoryEntry = {
         };
     },
     view: function({state, attrs}) {
-        const 
+        const
             captalize = (str) => str.charAt(0).toUpperCase() + str.slice(1),
             paymentStatus = attrs.payment.status,
             paymentAmount = attrs.payment.amount,
             paymentMethod = attrs.payment ? attrs.payment.payment_method : '',
             paymentDate = attrs.payment.created_at,
             paymentDetails = attrs.payment.payment_method_details,
+            gatewayId = attrs.payment.gateway_id,
             paymentMethodText = I18n.t(`${paymentMethod}`, I18nScopePaymentMethod()),
             isSlipWithExpiration = (paymentMethod === 'boleto' &&  !_.isNull(paymentDetails.expiration_date)),
             isCreditCardWithDetails = (paymentMethod === 'credit_card' && !_.isNull(paymentDetails.brand) && !_.isNull(paymentDetails.last_digits)),
             paymentStatusText = I18n.t(`last_status.${paymentMethod}.${paymentStatus}`, I18nScopePayment()),
             paymentMethodEndText = ( isSlipWithExpiration ?
-                ` com venc. ${h.momentify(paymentDetails.expiration_date, 'DD/MM')}` : 
+                ` com venc. ${h.momentify(paymentDetails.expiration_date, 'DD/MM')}` :
                 ( isCreditCardWithDetails ?
                     ` ${captalize(paymentDetails.brand)} final ${paymentDetails.last_digits}` :
                     ''));
 
         return m('.fontsize-smallest.w-row',
             [
-                m('.w-col.w-col-3', m('.fontcolor-secondary', h.momentify(paymentDate, 'DD/MM/YYYY'))),
-                m('.w-col.w-col-9', 
-                    m('div',
-                        [
-                            m(`span.fa.fa-circle${state.statusClass[paymentStatus]}`, m.trust('&nbsp;')),
-                            `R$${paymentAmount / 100} ${paymentStatusText} - ${captalize(paymentMethodText)} ${paymentMethodEndText}`
-                        ]
-                    )
+                m('div', [
+                    m('span.fontcolor-secondary', h.momentify(paymentDate, 'DD/MM/YYYY')),
+                    m.trust('&nbsp;&nbsp;&nbsp;&nbsp;'),
+                    m(`span.fa.fa-circle${state.statusClass[paymentStatus]}`, m.trust('&nbsp;')),
+                    `R$${paymentAmount / 100} ${paymentStatusText} - ${captalize(paymentMethodText)} ${paymentMethodEndText}`,
+                    m.trust('&nbsp;&nbsp;&nbsp;&nbsp;'),
+                    m('span.fontcolor-secondary', `( ID ${gatewayId} ) `)
+                    ]
+
                 )
             ]
         );

--- a/services/catarse/catarse.js/legacy/src/c/user-contributed-box.js
+++ b/services/catarse/catarse.js/legacy/src/c/user-contributed-box.js
@@ -90,8 +90,13 @@ const userContributedBox = {
                                 ]),
                                 m('.fontsize-smallest',
                                     (contribution.installments > 1 ? (`${contribution.installments} x R$ ${ h.formatNumber(contribution.installment_value, 2) } `) : ''),
-                                    (contribution.payment_method === 'BoletoBancario' ? 'Boleto Bancário' : 'Cartão de Crédito')
+                                    (contribution.payment_method === 'BoletoBancario' ? window.I18n.t('bank_slip', contributionScope()) : window.I18n.t('credit_card', contributionScope()))
                                 ),
+                                (contribution.gateway_id ?
+                                    m('.fontsize-smallest',
+                                    ` ${window.I18n.t('id_payment_gateway', contributionScope())} ${contribution.gateway_id}`
+                                    ) : ''),
+
                                 (
                                     contribution.installments > 1 ?
                                         m(".fontsize-smallest.fontweight-semibold.u-marginbottom-10",
@@ -165,18 +170,18 @@ const userContributedBox = {
                                         ''
                                     ),
                                     m.trust('&nbsp;'),
-                                    'Questionário',
+                                    window.I18n.t('survey', contributionScope()),
                                     m('br'),
-                                    'Não respondido'
+                                    window.I18n.t('not_answered', contributionScope())
                                 ])
                             )
                         ) : answeredAt ?
                         m('.u-text-center.w-col.w-col-2', [
                             m('.fontsize-smaller.fontweight-semibold.lineheight-tighter',
                                 m(`a.link-hidden-dark[href='/contributions/${contribution.contribution_id}/surveys/${contribution.survey.survey_id}'][target='_blank']`, [
-                                    'Questionário',
+                                    window.I18n.t('survey', contributionScope()),
                                     m('br'),
-                                    'Respondido'
+                                    window.I18n.t('answered', contributionScope())
                                 ])
                             ),
                             m('.fontcolor-secondary.fontsize-smallest',

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
@@ -103,6 +103,12 @@ en:
       delivery_estimate: 'Estimated delivery:'
       delivery_status: 'Delivery Status:'
       answer_survey: Answer the questionnaire
+      id_payment_gateway: "Contribution ID:"
+      survey: "Survey"
+      not_answered: "Not answered"
+      answered: "Answered"
+      bank_slip: "Bank Slip"
+      credit_card: "Credit Card"
     card:
       twitter_profile: Twitter Profile
       facebook_profile: Facebook profile

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
@@ -106,6 +106,12 @@ pt:
       delivery_estimate: "Estimativa de entrega:"
       delivery_status: "Status da entrega:"
       answer_survey: "Responda o questionário"
+      id_payment_gateway: "ID do Apoio:"
+      survey: "Questionário"
+      not_answered: "Não respondido"
+      answered: "Respondido"
+      bank_slip: "Boleto Bancário"
+      credit_card: "Cartão de Crédito"
     subscription_row:
       anonymous_sub: 'Quero que minha assinatura não seja pública'
       anonymous_sub_title: 'Assinatura anônima'


### PR DESCRIPTION
### Descrição
Para facilitar a solicitação de ajuda do usuário para o realizador e/ou para a equipe do Catarse com mais eficiência, o ID de pagamento (ID de Gateway) do apoio ficará visível no histórico de apoios e não somente dentro do recibo do apoio.

### Referência
https://www.notion.so/catarse/Garantir-consist-ncia-nos-termos-id-do-apoio-e-id-do-gateway-entre-recibo-de-apoio-e-hist-rico-de-ap-6c6a7750079246859e33e47654536ebe

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
