### PR TITLE
🐞 Corrige filtro de pesquisa no catarse_scripts

### DIFF
--- a/services/catarse/engines/catarse_scripts/app/models/catarse_scripts/script.rb
+++ b/services/catarse/engines/catarse_scripts/app/models/catarse_scripts/script.rb
@@ -41,8 +41,5 @@ module CatarseScripts
       self.status = :pending if with_error?
     end
 
-    ransacker :tags do
-      Arel.sql("array_to_string(tags, ',')")
-    end
   end
 end

--- a/services/catarse/engines/catarse_scripts/app/views/catarse_scripts/scripts/_script.html.slim
+++ b/services/catarse/engines/catarse_scripts/app/views/catarse_scripts/scripts/_script.html.slim
@@ -13,5 +13,5 @@
       = script.description.truncate(80)
       - script.tags.each do |tag|
         .tag.tag--link.text-gray-000.bg-purple-500
-          = link_to tag, scripts_path(q: { tags_cont: tag }), class: 'text-gray-000'
+          = link_to tag, scripts_path(q: { tags_contains_array: "[{\"value\":\"#{tag}\"}]" }), class: 'text-gray-000'
   .card-footer.level.content.mx-3(title=script.created_at) = time_ago_in_words(script.created_at)

--- a/services/catarse/engines/catarse_scripts/app/views/catarse_scripts/scripts/show.html.slim
+++ b/services/catarse/engines/catarse_scripts/app/views/catarse_scripts/scripts/show.html.slim
@@ -16,7 +16,8 @@
           = link_to 'Ticket URL', @script.ticket_url, target: '_blank'
       .col-4
         - @script.tags.each do |tag|
-          .tag.tag--link = tag
+          .tag.tag--link
+            = link_to tag, scripts_path(q: { tags_contains_array: "[{\"value\":\"#{tag}\"}]" }), class: 'text-gray-000'
 
     p = @script.description
 


### PR DESCRIPTION
### Descrição
O filtro de tags do catarse scripts está quebrando e não impede os usuários com acesso ao catarse scripts de pesquisarem pelas tags.

### Referência
https://www.notion.so/catarse/Corrigir-Filtro-de-Pesquisa-no-catarse-scripts-f4964e920e594d229823b921fa9a6256

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
