### PR TITLE
🐞 Altera link no footer da Retrospectiva para a página de 2020

### DIFF
--- a/services/catarse/catarse.js/legacy/src/root/footer.js
+++ b/services/catarse/catarse.js/legacy/src/root/footer.js
@@ -35,8 +35,8 @@ const footer = {
                                                 m(`a.link-footer[href=\'https://www.catarse.me/${window.I18n.locale}/press?ref=ctrse_footer\']`,
                                                     ' Imprensa'
                                                 ),
-                                                m('a.u-marginbottom-30.link-footer[href=\'http://ano.catarse.me/2019?ref=ctrse_footer\']',
-                                                    ' Retrospectiva 2019'
+                                                m('a.u-marginbottom-30.link-footer[href=\'http://ano.catarse.me/2020?ref=ctrse_footer\']',
+                                                    ' Retrospectiva 2020'
                                                 ),
                                                 m('.footer-full-signature-text.fontsize-small',
                                                     'Redes Sociais'


### PR DESCRIPTION
### Descrição
O link no footer do Catarse ainda está divulgando a Retrospectiva de 2019

### Referência
https://www.notion.so/catarse/Ajusta-link-no-footer-para-a-Retrospectiva-2020-f5e468586c4e46b5a3f6bf4944e2a302

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
