### PR TITLE
🐞 Válida imagens de base64 nas novidades

### DIFF
--- a/services/catarse/app/models/project_post.rb
+++ b/services/catarse/app/models/project_post.rb
@@ -17,10 +17,14 @@ class ProjectPost < ApplicationRecord
   after_save :index_on_common
 
   validates_presence_of :user_id, :project_id, :comment_html, :title
-
+  validate :no_base64_images
   before_validation :reference_user
 
   scope :ordered, ->() { order('created_at desc') }
+
+  def no_base64_images
+    errors.add(:comment_html, :base64_images_not_allowed) if comment_html.try(:match?, 'data:image/.*;base64')
+  end
 
   def reference_user
     self.user_id = project.try(:user_id)

--- a/services/catarse/spec/models/project_post_spec.rb
+++ b/services/catarse/spec/models/project_post_spec.rb
@@ -19,4 +19,30 @@ RSpec.describe ProjectPost, type: :model do
     subject { create(:project_post, comment_html: 'this is a comment') }
     it { expect(subject.comment_html).to eq 'this is a comment' }
   end
+
+  describe '#no_base64_images' do
+    let(:project_post) { create(:project_post) }
+
+    context 'when comment_html has base64 images' do
+      before do
+        project_post.update comment_html: "<img src='data:image/png;base64'></img>"
+        project_post.valid?
+      end
+
+      it 'adds error message to comment_html' do
+        expect(project_post.errors[:comment_html]).to include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+
+    context 'when comment_html hasn`t base64 images' do
+      before do
+        project_post.update comment_html: "<img src='image.png'></img>"
+        project_post.valid?
+      end
+
+      it 'don`t add error message to comment_html' do
+        expect(project_post.errors[:comment_html]).to_not include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Descrição
Ao adicionar ma imagem na novidade arrastando ela pelo editor, a imagem é enviada como base64. O problema é que os clientes de e-mail como gmail não renderiza a imagem internamente. A solução é adicionar uma validação em project_post.

### Referência
https://www.notion.so/catarse/Valida-o-de-imagem-base64-nas-novidades-948f4c57e59e48e590fe066fe6a18342

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
