### PR TITLE
✨ Adiciona rotina de baixar dados do pagarme

### DIFF
--- a/services/catarse/lib/tasks/gateway_payment_sync.rake
+++ b/services/catarse/lib/tasks/gateway_payment_sync.rake
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class GatewayPaymentSync
+  include Rake::DSL
+  def initialize
+    namespace :cache do
+      task gateway_payments_sync: :environment do
+        PagarMe.api_key = CatarsePagarme.configuration.api_key
+        ActiveRecord::Base.connection_pool.with_connection do
+          call
+        end
+      end
+    end
+  end
+
+  private
+
+  def call
+    page = 1
+    loop do
+      transactions = fetch_transactions(page: page, per_page: 500)
+      break if transactions.blank? || Rails.env.test?
+
+      import_gateway_payments(transaction)
+      page += 1
+      sleep 1
+    end
+  rescue StandardError => e
+    handle_error(e)
+  end
+
+  def fetch_transactions(page:, per_page:)
+    Rails.logger.info "[GatewayPayment SYNC] -> running on page #{page}"
+    transactions = PagarMe::Transaction.all(page, per_page)
+
+    if transactions.empty?
+      Rails.logger.info '[GatewayPayment SYNC] -> exiting no transactions returned'
+      nil
+    else
+      Rails.logger.info "[GatewayPayment SYNC] - transactions synced on page #{page}"
+      transactions
+    end
+  end
+
+  def import_gateway_payments(transactions)
+    transactions.each do |transaction|
+      update_or_create_gateway_payment(transaction)
+    end
+  end
+
+  def update_or_create_gateway_payment(transaction)
+    gateway_payment = GatewayPayment.find_or_create_by transaction_id: transaction.id.to_s
+    gateway_payment.update(
+      gateway_data: transaction.to_json,
+      postbacks: parse_json(transaction.postbacks),
+      payables: parse_json(transaction.payables),
+      events: parse_json(transaction.events),
+      operations: parse_json(transaction.operations),
+      last_sync_at: Time.zone.now
+    )
+  end
+
+  def parse_json(data)
+    data.to_json
+  rescue StandardError
+    nil
+  end
+
+  def handle_error(error)
+    Raven.extra_context(task: :gateway_payments_sync)
+    Raven.capture_exception(error)
+    Raven.extra_context({})
+  end
+end
+
+GatewayPaymentSync.new


### PR DESCRIPTION
### Descrição
Atualmente não temos uma forma fácil identificar pagamentos que estão autorizados no pagar.me, a solução seria voltar a coletar os registros de pagamentos na tabela de GatewayPayments.

### Referência
https://www.notion.so/catarse/Retornar-rotina-de-baixar-os-dados-do-pagar-me-56fa3d2df1be42a6aab0a047a4c81330

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
