### PR TITLE
🐞 Ajusta download de thumbnail dos vídeos dos projetos

### DIFF
--- a/services/catarse/app/models/concerns/project/video_handler.rb
+++ b/services/catarse/app/models/concerns/project/video_handler.rb
@@ -8,7 +8,7 @@ module Project::VideoHandler
     mount_uploader :video_thumbnail, ProjectUploader
 
     def download_video_thumbnail
-      self.video_thumbnail = open(video.thumbnail_large) if video_valid?
+      self.video_thumbnail = URI.open(video.thumbnail_large) if video_valid?
       save
     rescue OpenURI::HTTPError, TypeError => e
       Rails.logger.info "-----> #{e.inspect}"

--- a/services/catarse/spec/models/concerns/project/video_handler_spec.rb
+++ b/services/catarse/spec/models/concerns/project/video_handler_spec.rb
@@ -8,14 +8,17 @@ RSpec.describe Project::VideoHandler, type: :model do
   describe '#download_video_thumbnail' do
     before do
       expect(project).to receive(:download_video_thumbnail).and_call_original
-      expect(project).to receive(:open).and_return(File.open('spec/fixtures/files/image.png'))
+
       stub_request(:any, 'https://vimeo.com/17298435')
           .to_return(body: file_fixture('vimeo_default_request.txt'))
+      stub_request(:any, 'https://i.vimeocdn.com/video/107328495_640.jpg')
+          .to_return(body: file_fixture('image.png').read)
+
       project.download_video_thumbnail
     end
 
     it 'should open the video_url and store it in video_thumbnail' do
-      expect(project.video_thumbnail.url).to eq("/uploads/project/video_thumbnail/#{project.id}/image.png")
+      expect(project.video_thumbnail.url).to match("/uploads/project/video_thumbnail/#{project.id}/")
     end
   end
 end


### PR DESCRIPTION
### Descrição
Corrigindo problema de download de thumbnail dos vídeos dos projetos, agora é necessário utilizar `URI.open` para abrir URL remotas.

### Referência
https://www.notion.so/catarse/Corrigir-download-de-thumbnail-de-v-deos-dos-projetos-1298691043924e9db6beac37fa8ab143

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
