### PR TITLE
🐞 Ajusta o reenvio de notificação para apoiadores que ainda não respo…

### DIFF
--- a/services/catarse/lib/tasks/cron.rake
+++ b/services/catarse/lib/tasks/cron.rake
@@ -116,9 +116,9 @@ namespace :cron do
   desc 'Notify who have not answered the survey after a week'
   task notify_unanswered_surveys: :environment do
     Survey.where(finished_at: nil).each do |survey|
-      survey.reward.contributions.was_confirmed.each do |contribution|
-        if !contribution.survey_answered_at && ContributionNotification.where(contribution: contribution, template_name: 'answer_survey').where("created_at > current_timestamp - '1 week'::interval ").empty?
-          survey.notify_to_contributors(:answer_survey)
+      survey.reward.contributions.where(survey_answered_at: nil).was_confirmed.each do |contribution|
+        if !contribution.survey_answered_at && contribution.notifications.where(template_name: 'answer_survey').where("created_at > current_timestamp - '1 week'::interval ").empty?
+          contribution.notify(:answer_survey, contribution.user, contribution, {})
         end
       end
     end


### PR DESCRIPTION
…nderam a pesquisa enviada pelo projeto

### Descrição

Ajusta para o envio ser feito apenas para a contribuição que ainda não tem o campo preenchido, antes mesmo com as verificações o envio era chamado sobre o objeto de pesquisa, que burlava essas verificações.

### Referência

https://www.notion.so/catarse/Ajustar-rotina-de-envio-de-notifica-es-para-usu-rios-que-n-o-responderam-as-pesquisas-2911ae79e9ad413697756e6ea3921393

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
