### PR TITLE
🐞 Renomear arquivo de imagem ao fazer upload

### DIFF
--- a/services/catarse/app/models/concerns/project/video_handler.rb
+++ b/services/catarse/app/models/concerns/project/video_handler.rb
@@ -8,7 +8,7 @@ module Project::VideoHandler
     mount_uploader :video_thumbnail, ProjectUploader
 
     def download_video_thumbnail
-      self.video_thumbnail = open(video.thumbnail_large) if video_valid?
+      self.video_thumbnail = URI.open(video.thumbnail_large) if video_valid?
       save
     rescue OpenURI::HTTPError, TypeError => e
       Rails.logger.info "-----> #{e.inspect}"

--- a/services/catarse/app/uploaders/image_uploader.rb
+++ b/services/catarse/app/uploaders/image_uploader.rb
@@ -23,4 +23,14 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   process quality: 80
+
+  def filename
+    "#{secure_token}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+  end
 end

--- a/services/catarse/spec/models/concerns/project/video_handler_spec.rb
+++ b/services/catarse/spec/models/concerns/project/video_handler_spec.rb
@@ -4,18 +4,23 @@ require 'rails_helper'
 
 RSpec.describe Project::VideoHandler, type: :model do
   let(:project) { create(:project) }
+  let(:uuid_regexp) { /[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}/ }
 
   describe '#download_video_thumbnail' do
     before do
       expect(project).to receive(:download_video_thumbnail).and_call_original
-      expect(project).to receive(:open).and_return(File.open('spec/fixtures/files/image.png'))
+
       stub_request(:any, 'https://vimeo.com/17298435')
           .to_return(body: file_fixture('vimeo_default_request.txt'))
+      stub_request(:any, 'https://i.vimeocdn.com/video/107328495_640.jpg')
+          .to_return(body: file_fixture('image.png').read)
+
       project.download_video_thumbnail
     end
 
     it 'should open the video_url and store it in video_thumbnail' do
-      expect(project.video_thumbnail.url).to eq("/uploads/project/video_thumbnail/#{project.id}/image.png")
+      url_regexp = Regexp.new("/uploads/project/video_thumbnail/#{project.id}/#{uuid_regexp}")
+      expect(project.video_thumbnail.url).to match(url_regexp)
     end
   end
 end

--- a/services/catarse/spec/models/contribution_detail_spec.rb
+++ b/services/catarse/spec/models/contribution_detail_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe ContributionDetail, type: :model do
+
+  let(:uuid_regexp) { /[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}/ }
+
   describe 'associations' do
     it { should belong_to :user }
     it { should belong_to :project }
@@ -168,7 +171,10 @@ RSpec.describe ContributionDetail, type: :model do
       CatarseSettings[:aws_bucket] = 'bucket'
     end
 
-    it { is_expected.to eq "https://#{CatarseSettings[:aws_host]}/#{CatarseSettings[:aws_bucket]}/uploads/project/uploaded_image/#{contribution.project.id}/project_thumb_small_testimg.png" }
+    it do
+      url_regexp = Regexp.new("https\://#{CatarseSettings[:aws_host]}/#{CatarseSettings[:aws_bucket]}/uploads/project/uploaded_image/#{contribution.project.id}/project_thumb_small_#{uuid_regexp}\.png")
+      is_expected.to match(url_regexp)
+    end
   end
 
   describe '#user_profile_img' do
@@ -180,6 +186,9 @@ RSpec.describe ContributionDetail, type: :model do
       CatarseSettings[:aws_bucket] = 'bucket'
     end
 
-    it { is_expected.to eq "https://#{CatarseSettings[:aws_host]}/#{CatarseSettings[:aws_bucket]}/uploads/user/uploaded_image/#{contribution.user.id}/thumb_avatar_testimg.png" }
+    it do
+      url_regexp = Regexp.new("https://#{CatarseSettings[:aws_host]}/#{CatarseSettings[:aws_bucket]}/uploads/user/uploaded_image/#{contribution.user.id}/thumb_avatar_#{uuid_regexp}\.png")
+      is_expected.to match(url_regexp)
+    end
   end
 end


### PR DESCRIPTION
### Descrição
Muda o nome do arquivo de imagem quando faz o upload. Copiei as instruções do CarrierWave: https://github.com/carrierwaveuploader/carrierwave/wiki/How-to%3A-Create-random-and-unique-filenames-for-all-versioned-files

OBS: Este PR está sendo feito em cima da mesma branch com uma correção para o teste do `concern/project/video_handler_spec.rb`.

### Referência
https://www.notion.so/catarse/Adicionar-etapa-para-tirar-caracteres-especiais-quando-fizer-o-upload-de-imagens-839ce49d5d264634af684982d954b101

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
