### PR TITLE
🐞 Detecta navegadores antigos em todas as páginas.

### DIFF
--- a/services/catarse/app/controllers/application_controller.rb
+++ b/services/catarse/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   helper_method :referral, :render_projects, :is_projects_home?,
                 :render_feeds, :public_settings
 
-  before_action :force_www
+  before_action :detect_old_browsers, :force_www
 
   def referral
     #ctrse_origin is created on frontend (analytics.js).

--- a/services/catarse/app/controllers/concerns/old_browser_checker.rb
+++ b/services/catarse/app/controllers/concerns/old_browser_checker.rb
@@ -16,7 +16,7 @@ module OldBrowserChecker
   end
 
   def detect_old_browsers
-    return if modern_browser?(browser)
+    return if modern_browser?(browser) || request.original_fullpath.include?('bad_browser')
 
     redirect_to page_path('bad_browser')
   end

--- a/services/catarse/app/controllers/projects/contributions_controller.rb
+++ b/services/catarse/app/controllers/projects/contributions_controller.rb
@@ -7,7 +7,6 @@ class Projects::ContributionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:moip]
   after_action :verify_authorized, except: [:index]
   belongs_to :project
-  before_action :detect_old_browsers, only: %i[new create]
 
   helper_method :engine
 

--- a/services/catarse/spec/controllers/application_controller_spec.rb
+++ b/services/catarse/spec/controllers/application_controller_spec.rb
@@ -12,6 +12,27 @@ RSpec.describe ApplicationController, type: :controller do
     allow(controller).to receive(:params).and_return(params)
   end
 
+  describe '#detect_old_browsers' do
+
+    let(:browser) { Browser.new('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18') }
+
+    before do
+      allow(controller).to receive(:browser).and_return(browser)
+      allow(controller).to receive(:detect_old_browsers).and_call_original
+      get :redirect_to_user_contributions
+    end
+
+    context 'when browser is IE 9' do
+      let(:browser) { Browser.new('Mozilla/3.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)') }
+      it { is_expected.to redirect_to page_path('bad_browser') }
+    end
+
+    context 'when browser is old' do
+      let(:browser) { Browser.new('Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Sensation_4G Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/5.0 Safari/533.16') }
+      it { is_expected.to redirect_to page_path('bad_browser') }
+    end
+  end
+
   describe '#referral_it!' do
     before do
       cookies[:referral_link] = initial_session_value

--- a/services/catarse/spec/controllers/projects/contributions_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects/contributions_controller_spec.rb
@@ -127,24 +127,11 @@ RSpec.describe Projects::ContributionsController, type: :controller do
     let(:secure_review_host) { nil }
     let(:user) { create(:user) }
     let(:open_for_contributions) { true }
-    let(:browser) { Browser.new('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18') }
 
     before do
       CatarseSettings[:secure_review_host] = secure_review_host
       allow_any_instance_of(Project).to receive(:open_for_contributions?).and_return(open_for_contributions)
-      allow(controller).to receive(:browser).and_return(browser)
-      allow_any_instance_of(ApplicationController).to receive(:detect_old_browsers).and_call_original
       get :new, params: { locale: :pt, project_id: project.id }
-    end
-
-    context 'when browser is IE 9' do
-      let(:browser) { Browser.new('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)') }
-      it { is_expected.to redirect_to page_path('bad_browser') }
-    end
-
-    context 'when browser is old' do
-      let(:browser) { Browser.new('Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Sensation_4G Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/5.0 Safari/533.16') }
-      it { is_expected.to redirect_to page_path('bad_browser') }
     end
 
     context 'when no user is logged' do


### PR DESCRIPTION
### Descrição
É preciso redirecionar para o /bad_browser em qualquer página do Catarse, caso o usuário estiver acessando o site com um browser não suportado. Atualmente isso acontece apenas na página de contribuição.

### Referência
https://www.notion.so/catarse/Detectar-navegadores-antigos-em-todas-as-p-ginas-do-Catarse-77288fcce70e4fe4b75bbf2df5113227


### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
