### PR TITLE
🐞 Válida imagens de base64 nas novidades.

### DIFF
--- a/services/catarse/app/models/project_post.rb
+++ b/services/catarse/app/models/project_post.rb
@@ -17,10 +17,14 @@ class ProjectPost < ApplicationRecord
   after_save :index_on_common
 
   validates_presence_of :user_id, :project_id, :comment_html, :title
-
+  validate :no_base64_images
   before_validation :reference_user
 
   scope :ordered, ->() { order('created_at desc') }
+
+  def no_base64_images
+    errors.add(:comment_html, :base64_images_not_allowed) if comment_html.try(:match?, 'data:image/.*;base64')
+  end
 
   def reference_user
     self.user_id = project.try(:user_id)

--- a/services/catarse/catarse.js/legacy/src/c/pop-notification.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/pop-notification.tsx
@@ -4,6 +4,7 @@ import h from '../h';
 export type PopNotificationAttrs = {
     error: boolean
     message: string
+    time: number
     toggleOpt(newData? : boolean): boolean
 }
 
@@ -17,7 +18,7 @@ export default class PopNotification  {
     oninit(vnode : m.Vnode<PopNotificationAttrs, PopNotificationState>) {
         const displayNotification = vnode.attrs.toggleOpt || h.toggleProp(true, false),
             setPopTimeout = () => {
-                setTimeout(() => { displayNotification(false); m.redraw(); }, 3000);
+                setTimeout(() => { displayNotification(false); m.redraw(); }, (vnode.attrs.time || 3000));
             };
         vnode.state = {
             displayNotification,

--- a/services/catarse/catarse.js/legacy/src/root/posts.js
+++ b/services/catarse/catarse.js/legacy/src/root/posts.js
@@ -46,9 +46,9 @@ const posts = {
                         return fields
                             .get_selected_rewards()
                             .map(rc => `R$${h.formatNumber(parseInt(rc.reward.data.minimum_value))}${rc.reward.data.title ? ` - ${rc.reward.data.title}` : ''}`).join(', ');
-                    }                    
+                    }
                 },
-                get_selected_rewards: () => {                    
+                get_selected_rewards: () => {
                     return _.filter(fields.paid_rewards(), rc => rc.checked());
                 },
                 get_selected_reward_ids: () => {
@@ -56,7 +56,7 @@ const posts = {
                     const isSubscription = projectVM.isSubscription(project);
                     const getRewardId = (r) => isSubscription ? r.external_id : r.id;
                     return _.map(fields.get_selected_rewards(), rc => getRewardId(rc.reward));
-                }                    
+                }
             },
             filterVM = catarse.filtersVM({
                 project_id: 'eq'
@@ -77,6 +77,13 @@ const posts = {
 
                 return !commentHasError();
             },
+            validateCommentImage = () => {
+                const comment = String(fields.comment_html());
+                if (comment.search(/^[a-zA-Z ]*;base64/)) {
+                    commentHasError(true);
+                }
+                return !commentHasError();
+            },
             validateSelectedRewards = () => {
                 const wants_to_send_to_ones_who_paid_for_rewards = fields.recipients() === 'rewards';
                 const wants_to_send_to_backers_or_public = !wants_to_send_to_ones_who_paid_for_rewards;
@@ -92,6 +99,9 @@ const posts = {
                     showError(true);
                 } else if (!validateComment()) {
                     errors('Mensagem não pode ficar em branco.');
+                    showError(true);
+                } else if (!validateCommentImage()) {
+                    errors(window.I18n.t('errors.messages.base64_images_not_allowed'));
                     showError(true);
                 } else if (!validateSelectedRewards()) {
                     errors('É necessário selecionar pelo menos uma recompensa.');
@@ -121,7 +131,7 @@ const posts = {
                 } else if (post.rewards_that_can_access_post && post.rewards_that_can_access_post.length) {
                     const preText = project.mode === 'sub' ? 'Assinantes de ' : 'Apoiadores de ';
                     return preText + _.map(
-                        post.rewards_that_can_access_post, 
+                        post.rewards_that_can_access_post,
                         reward => `R$${h.formatNumber(reward.minimum_value)}${reward.title ? ` - ${reward.title}` : ''}`
                     ).join(', ');
                 } else {
@@ -161,21 +171,21 @@ const posts = {
         const createCheckboxesControlForRewardSelected = (rewards) => {
             const filteredRewards = _.filter(rewards, filterOnlyPaidRewards);
             const paidRewardsSorted = _.sortBy(filteredRewards, pr => parseInt(pr.data.minimum_value));
-            const checkboxesArray = paidRewardsSorted.map(pr => { 
+            const checkboxesArray = paidRewardsSorted.map(pr => {
                 return {
                     checked: h.toggleProp(false, true),
                     reward: pr
                 };
             });
-            
+
             fields.paid_rewards(checkboxesArray);
             h.redraw();
             return rewards;
         };
 
         const addDataFieldToNoCommonRewards = (rewards) => rewards ? rewards.map(r => _.extend(r, { data: r })) : [];
-        const remapMinimumValue = (rewards) => rewards.map(r => {            
-            r.data.minimum_value = parseInt(r.data.minimum_value) / 100; 
+        const remapMinimumValue = (rewards) => rewards.map(r => {
+            r.data.minimum_value = parseInt(r.data.minimum_value) / 100;
             return r;
         });
 
@@ -187,7 +197,7 @@ const posts = {
                     .then(remapMinimumValue)
                     .then(createCheckboxesControlForRewardSelected)
                     .then(() => h.redraw());
-                    
+
             } else {
                 rewardVM
                     .fetchRewards(project_id)
@@ -225,7 +235,7 @@ const posts = {
         };
     },
     view: function({state}) {
-        
+
         const project = _.first(state.projectDetails()),
             isSubscription = projectVM.isSubscription(project),
             recipients = state.fields.recipients;
@@ -254,7 +264,8 @@ const posts = {
                 }) : ''),
                 (state.showError() ? m(popNotification, {
                     message: state.errors(),
-                    error: true
+                    error: true,
+                    time: 6000
                 }) : ''),
                 m('.dashboard-header.u-text-center',
                     m('.w-container',
@@ -333,15 +344,15 @@ const posts = {
 
                                         // SOME SELECTION CHECKBOXES CONTRIBUTORS/SUBSCRIBERS
                                         (
-                                            recipients() !== 'rewards' ? '' : 
+                                            recipients() !== 'rewards' ? '' :
                                             m('.card.u-radius', {
                                                 class: state.selectedRewardsHasError() ? 'card-message-error' : '',
-                                                onclick: () => { 
+                                                onclick: () => {
                                                     state.selectedRewardsHasError(false);
                                                     state.showError(false);
                                                 }
                                             },
-                                                _.map(state.fields.paid_rewards(), 
+                                                _.map(state.fields.paid_rewards(),
                                                     pr => m(postForRewardCheckbox, {
                                                         reward_checkbox: pr.checked,
                                                         reward: pr.reward,

--- a/services/catarse/spec/models/project_post_spec.rb
+++ b/services/catarse/spec/models/project_post_spec.rb
@@ -19,4 +19,30 @@ RSpec.describe ProjectPost, type: :model do
     subject { create(:project_post, comment_html: 'this is a comment') }
     it { expect(subject.comment_html).to eq 'this is a comment' }
   end
+
+  describe '#no_base64_images' do
+    let(:project_post) { create(:project_post) }
+
+    context 'when comment_html has base64 images' do
+      before do
+        project_post.update comment_html: "<img src='data:image/png;base64'></img>"
+        project_post.valid?
+      end
+
+      it 'adds error message to comment_html' do
+        expect(project_post.errors[:comment_html]).to include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+
+    context 'when comment_html hasn`t base64 images' do
+      before do
+        project_post.update comment_html: "<img src='image.png'></img>"
+        project_post.valid?
+      end
+
+      it 'don`t add error message to comment_html' do
+        expect(project_post.errors[:comment_html]).to_not include(I18n.t("errors.messages.base64_images_not_allowed"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Descrição
Ao adicionar ma imagem na novidade arrastando ela pelo editor, a imagem é enviada como base64. O problema é que os clientes de e-mail como gmail não renderiza a imagem internamente. A solução é adicionar uma validação em project_post.

### Referência
https://www.notion.so/catarse/Valida-o-de-imagem-base64-nas-novidades-948f4c57e59e48e590fe066fe6a18342

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
