### PR TITLE
🐞 Libera acesso do firefox ios e da webview do instagram

### DIFF
--- a/services/catarse/app/controllers/concerns/old_browser_checker.rb
+++ b/services/catarse/app/controllers/concerns/old_browser_checker.rb
@@ -8,10 +8,11 @@ module OldBrowserChecker
       browser.chrome?(">= 65"), # 03/2018
       browser.safari?(">= 10"), # 09/2016
       browser.firefox?(">= 52"), # 03/2017
+      browser.platform.ios? && browser.firefox?(">= 19"),
       browser.ie?(">= 11") && !browser.compatibility_view?, #10/2013
       browser.edge?(">= 15"),
       browser.opera?(">= 50"), # 01/2018
-      browser.facebook? && browser.safari_webapp_mode? && browser.webkit_full_version.to_i >= 602 # 09/2016
+      (browser.facebook? || browser.instagram?) && browser.safari_webapp_mode? && browser.webkit_full_version.to_i >= 602, # 09/2016
     ].any?
   end
 


### PR DESCRIPTION
### Descrição
Links acessados a partir do instagram estavam erroneamente sendo redirecionados para a página de bad_browser. O mesmo estava acontecendo com o Firefox mais recente do iOS. Esse PR libera o acesso desses dois navegadores.

### Referência


### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
