### PR TITLE
🐞 Remove verificação de navegadores antigos

### DIFF
--- a/services/catarse/app/controllers/application_controller.rb
+++ b/services/catarse/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   include AnalyticsHelpersHandler
   include PixelHelpersHandler
   include KondutoHandler
-  include OldBrowserChecker
+  # include OldBrowserChecker
   include Pundit
   before_action :redirect_when_zendesk_session, unless: :devise_controller?
 
@@ -25,7 +25,8 @@ class ApplicationController < ActionController::Base
   helper_method :referral, :render_projects, :is_projects_home?,
                 :render_feeds, :public_settings
 
-  before_action :detect_old_browsers, :force_www
+  before_action :force_www
+  # before_action :detect_old_browsers
 
   def referral
     #ctrse_origin is created on frontend (analytics.js).

--- a/services/catarse/spec/controllers/application_controller_spec.rb
+++ b/services/catarse/spec/controllers/application_controller_spec.rb
@@ -12,26 +12,25 @@ RSpec.describe ApplicationController, type: :controller do
     allow(controller).to receive(:params).and_return(params)
   end
 
-  describe '#detect_old_browsers' do
+  # describe '#detect_old_browsers' do
+  #   let(:browser) { Browser.new('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18') }
 
-    let(:browser) { Browser.new('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18') }
+  #   before do
+  #     allow(controller).to receive(:browser).and_return(browser)
+  #     allow(controller).to receive(:detect_old_browsers).and_call_original
+  #     get :redirect_to_user_contributions
+  #   end
 
-    before do
-      allow(controller).to receive(:browser).and_return(browser)
-      allow(controller).to receive(:detect_old_browsers).and_call_original
-      get :redirect_to_user_contributions
-    end
+  #   context 'when browser is IE 9' do
+  #     let(:browser) { Browser.new('Mozilla/3.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)') }
+  #     it { is_expected.to redirect_to page_path('bad_browser') }
+  #   end
 
-    context 'when browser is IE 9' do
-      let(:browser) { Browser.new('Mozilla/3.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)') }
-      it { is_expected.to redirect_to page_path('bad_browser') }
-    end
-
-    context 'when browser is old' do
-      let(:browser) { Browser.new('Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Sensation_4G Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/5.0 Safari/533.16') }
-      it { is_expected.to redirect_to page_path('bad_browser') }
-    end
-  end
+  #   context 'when browser is old' do
+  #     let(:browser) { Browser.new('Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Sensation_4G Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/5.0 Safari/533.16') }
+  #     it { is_expected.to redirect_to page_path('bad_browser') }
+  #   end
+  # end
 
   describe '#referral_it!' do
     before do

--- a/services/catarse/spec/support/hooks.rb
+++ b/services/catarse/spec/support/hooks.rb
@@ -37,7 +37,7 @@ RSpec.configure do |config|
 
   %i[controller feature].each do |spec_type|
     config.before(:each, type: spec_type) do
-      %i[detect_old_browsers render_facebook_sdk render_facebook_like render_twitter].each do |method|
+      %i[render_facebook_sdk render_facebook_like render_twitter].each do |method|
         allow_any_instance_of(ApplicationController).to receive(method)
       end
     end


### PR DESCRIPTION
### Descrição
Nossa checklist de browser modernos estava furada, fazendo com que navegadores modernos fossem bloqueados. Esse PR remove essa verificação.

### Referência
https://www.notion.so/catarse/Remover-restri-es-de-navegadores-antigos-6145e07c20b54b03832dc5195ddd0838

### Antes de criar esse pull request confira se:
- [ ] Testes estão desimplementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
