### PR TITLE
🐞 Ajusta função que pega a data de status de um projeto para utilizar…

### DIFF
--- a/services/catarse/db/migrate/20210326160202_fix_get_date_from_project_transitions.rb
+++ b/services/catarse/db/migrate/20210326160202_fix_get_date_from_project_transitions.rb
@@ -1,0 +1,35 @@
+class FixGetDateFromProjectTransitions < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.get_date_from_project_transitions(project_id integer, state text)
+      RETURNS timestamp without time zone
+      LANGUAGE sql
+      STABLE
+      AS $function$
+            SELECT created_at
+            FROM "1".project_transitions
+            WHERE state = $2
+            AND project_id = $1
+            ORDER BY created_at DESC
+            LIMIT 1
+        $function$
+      ;
+    SQL
+  end
+
+  def down 
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.get_date_from_project_transitions(project_id integer, state text)
+      RETURNS timestamp without time zone
+      LANGUAGE sql
+      STABLE
+      AS $function$
+              SELECT created_at
+              FROM "1".project_transitions
+              WHERE state = $2
+              AND project_id = $1
+          $function$
+      ;
+    SQL
+  end
+end


### PR DESCRIPTION
… sempre a ultima data

### Descrição

A função que pega a data da transição de um status não considera a ultima transição daquele status.

### Referência
https://www.notion.so/catarse/ae4f80371ac34954be3b3aa78597f89e?v=428c1a58e552490589fca094d2e21b4b&p=456e81d172de41d88eb064eff6c94b17

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
