### PR TITLE
✨ Adiciona evento de revert_balance_expired

### DIFF
--- a/services/catarse/app/models/balance_transaction.rb
+++ b/services/catarse/app/models/balance_transaction.rb
@@ -17,6 +17,7 @@ class BalanceTransaction < ApplicationRecord
     contribution_chargedback
     subscription_payment_chargedback
     balance_expired
+    revert_balance_expired
     contribution_refunded_after_successful_pledged
     subscription_payment_refunded
     balance_transferred_to
@@ -90,6 +91,21 @@ class BalanceTransaction < ApplicationRecord
       )
     end
   end
+
+  def self.insert_revert_balance_expired(balance_expired_transaction_id)
+    expired_transaction = find(balance_expired_transaction_id)
+    return if 'balance_expired' != expired_transaction.event_name
+    create!(
+      user_id: expired_transaction.user_id,
+      balance_transaction_id: expired_transaction.id,
+      event_name: 'revert_balance_expired',
+      amount: expired_transaction.amount.abs,
+      project_id: expired_transaction.project_id,
+      contribution_id: expired_transaction.contribution_id,
+      subscription_payment_uuid: expired_transaction.subscription_payment_uuid
+    )
+  end
+
 
   def self.insert_balance_expired(balance_transaction_id)
 		transaction = self.find balance_transaction_id

--- a/services/catarse/db/migrate/20210406210041_add_revert_balance_expired_to_balance_transactions.rb
+++ b/services/catarse/db/migrate/20210406210041_add_revert_balance_expired_to_balance_transactions.rb
@@ -1,0 +1,13 @@
+class AddRevertBalanceExpiredToBalanceTransactions < ActiveRecord::Migration[6.1]
+  def up
+    execute %Q{
+      create unique index idx_revert_balance_expired_evt_uniq on balance_transactions (event_name, balance_transaction_id) where event_name = 'revert_balance_expired';
+    }
+  end
+
+  def down 
+    execute %Q{
+      drop index if exists idx_revert_balance_expired_evt_uniq;
+    }
+  end
+end


### PR DESCRIPTION
### Descrição

Para reverter os eventos de saldo expirado do saldo do usuário e manter o historico dos acontecimentos

### Referência
https://www.notion.so/catarse/Adiciona-evento-de-revert_balance_expired-a7bfb7753f7b44d4b24798d6421d8bce

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
