### PR TITLE
🐞 Esconde botão de compartilhamento via Messenger no mobile

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-share-box.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/project-share-box.tsx
@@ -9,6 +9,7 @@ const projectShareBox = {
         };
     },
     view: function({state, attrs}) {
+        const showMessengerButton = false;
         const utm = attrs.utm || 'ctrse_project_share';
         const ref = attrs.ref || 'ctrse_project_share';
         const embedUrl = `https://www.catarse.me/pt/projects/${attrs.project().project_id}/embed`;
@@ -45,7 +46,7 @@ const projectShareBox = {
                 mobile: true,
                 url: facebookUrl
             }) : '',
-            attrs.project().permalink ? m(facebookButton, {
+            attrs.project().permalink && showMessengerButton ? m(facebookButton, {
                 mobile: true,
                 messenger: true,
                 url: facebookMessengerUrl


### PR DESCRIPTION
### Descrição
O botão de compatilhamento de projeto via messenger no celular não está funcionando corretamente. Ele redireciona para uma página de erro do Facebook. Aparentemente o erro provém do próprio Messenger.

### Referência
https://www.notion.so/catarse/Esconder-remover-bot-o-de-compartilhar-projeto-via-Messenger-no-mobile-496a3cb344ea49d89114048ab10e3ece

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
