### PR TITLE
🐞 Ajusta row order para apoio sem recompensa

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
@@ -39,7 +39,7 @@ const rewardSelectCard = {
                     const currentRewardId = rewardVM.selectedReward().id;
                     h.navigateTo(`/projects/${projectVM.currentProject().project_id}/subscriptions/checkout?contribution_value=${valueFloat}${currentRewardId ? `&reward_id=${currentRewardId}` : ''}${isEdit() ? `&subscription_id=${m.route.param('subscription_id')}` : ''}${isReactivation() ? `&subscription_status=${subscriptionStatus}` : ''}`);
                 } else {
-                    const valueUrl = window.encodeURIComponent(String(valueFloat).replace('.', ',')); 
+                    const valueUrl = window.encodeURIComponent(String(valueFloat).replace('.', ','));
                     h.navigateTo(`/projects/${projectVM.currentProject().project_id}/contributions/fallback_create?contribution%5Breward_id%5D=${rewardVM.selectedReward().id}&contribution%5Bvalue%5D=${valueUrl}&contribution%5Bshipping_fee_id%5D=${shippingFee.id}`);
                 }
             }
@@ -65,7 +65,7 @@ const rewardSelectCard = {
                     description: '',
                     minimum_value: 5,
                     shipping_options: null,
-                    row_order: -999999
+                    row_order: Number.NEGATIVE_INFINITY
                 };
             }
 
@@ -174,10 +174,10 @@ const rewardSelectCard = {
                 ),
                 m('.back-reward-reward-description', [
                     (
-                        reward.uploaded_image ? 
+                        reward.uploaded_image ?
                             (
                                 m("div.u-marginbottom-20.w-row", [
-                                    m("div.w-col.w-col-8", 
+                                    m("div.w-col.w-col-8",
                                         m(`img[src='${reward.uploaded_image}'][alt='']`)
                                     ),
                                     m("div.w-col.w-col-4")

--- a/services/catarse/catarse.js/legacy/src/root/projects-subscription-contribution.js
+++ b/services/catarse/catarse.js/legacy/src/root/projects-subscription-contribution.js
@@ -13,20 +13,20 @@ const I18nScope = _.partial(h.i18nScope, 'projects.contributions');
 
 const projectsSubscriptionContribution = {
     oninit: function(vnode) {
-        
+
         const {
             ViewContentEvent,
         } = projectVM;
-        
+
         projectVM.sendPageViewForCurrentProject(null, [ ViewContentEvent() ]);
-        
+
         const rewards = () => _.union(
             [{
                 id: null,
                 description: '',
                 minimum_value: 5,
                 shipping_options: null,
-                row_order: -9999999
+                row_order: Number.NEGATIVE_INFINITY
             }],
             projectVM.rewardDetails()
         );


### PR DESCRIPTION
### Descrição
Coloca a recompensa "Sem Recompensa" com row order para infinito negativo, permitindo que ela seja sempre a primeira no ordenamento (removi o número fixo, pois há algumas recompensas com ou order menor que -999999).

### Referência
https://www.notion.so/catarse/Ajustar-ordenamento-de-recompensas-em-projetos-de-Assinatura-no-fluxo-de-pagamento-subscription-st-51a81dd84ea14e7db7b28d7b76eeba71

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
