### PR TITLE
✨ Adiciona edição de assinatura para recompensa esgotada

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
@@ -97,108 +97,116 @@ const rewardSelectCard = {
     view: function({state, attrs}) {
         const reward = state.normalReward(attrs.reward);
 
-        return (h.rewardSouldOut(reward) ? m('') : m('span.radio.w-radio.w-clearfix.back-reward-radio-reward', {
-            class: state.isSelected(reward) ? 'selected' : '',
-            onclick: state.selectReward(reward)
-        },
-            m(`label[for="contribution_reward_id_${reward.id}"]`, [
-                m(`input.radio_buttons.optional.w-input.text-field.w-radio-input.back-reward-radio-button[id="contribution_reward_id_${reward.id}"][type="radio"][value="${reward.id}"]`, {
-                    checked: state.isSelected(reward),
-                    name: 'contribution[reward_id]'
-                }),
-                m(`label.w-form-label.fontsize-base.fontweight-semibold.u-marginbottom-10[for="contribution_reward_${reward.id}"]`, !reward.id ? 'Apoiar sem recompensa' :
-                    `R$ ${h.formatNumber(reward.minimum_value)} ou mais${attrs.isSubscription ? ' por mês' : ''}`
-                ), !state.isSelected(reward) ? '' : m('.w-row.back-reward-money', [
-                    rewardVM.hasShippingOptions(reward) ?
-                    m('.w-sub-col.w-col.w-col-4', [
-                        m('.fontcolor-secondary.u-marginbottom-10',
-                            'Local de entrega'
-                        ),
-                        m('select.positive.text-field.w-select', {
-                            onchange: m.withAttr('value', state.selectDestination)
-                        },
-                            _.map(state.locationOptions(reward, state.selectedDestination),
-                                option => m('option', {
-                                    value: option.value
-                                }, [
-                                    `${option.name} `,
-                                    option.value != '' ? `+R$${h.formatNumber(option.fee, 2, 3)}` : null
-                                ])
-                            )
-                        )
-                    ]) : '',
-                    m('.w-sub-col.w-col.w-clearfix', {
-                        class: rewardVM.hasShippingOptions(reward) ?
-                            'w-col-4' : 'w-col-8'
-                    }, [
-                        m('.fontcolor-secondary.u-marginbottom-10', `Valor do apoio${attrs.isSubscription ? ' mensal' : ''}`),
-                        m('.w-row.u-marginbottom-20', [
-                            m('.w-col.w-col-3.w-col-small-3.w-col-tiny-3',
-                                m('.back-reward-input-reward.medium.placeholder',
-                                    'R$'
+        if (state.isSelected(reward) || !h.rewardSouldOut(reward)) {
+            return(
+                m('span.radio.w-radio.w-clearfix.back-reward-radio-reward', {
+                    class: state.isSelected(reward) ? 'selected' : '',
+                    onclick: state.selectReward(reward)
+                },
+                    m(`label[for="contribution_reward_id_${reward.id}"]`, [
+                        m(`input.radio_buttons.optional.w-input.text-field.w-radio-input.back-reward-radio-button[id="contribution_reward_id_${reward.id}"][type="radio"][value="${reward.id}"]`, {
+                            checked: state.isSelected(reward),
+                            name: 'contribution[reward_id]'
+                        }),
+                        m(`label.w-form-label.fontsize-base.fontweight-semibold.u-marginbottom-10[for="contribution_reward_${reward.id}"]`, !reward.id ? 'Apoiar sem recompensa' :
+                            `R$ ${h.formatNumber(reward.minimum_value)} ou mais${attrs.isSubscription ? ' por mês' : ''}`
+                        ), !state.isSelected(reward) ? '' : m('.w-row.back-reward-money', [
+                            rewardVM.hasShippingOptions(reward) ?
+                            m('.w-sub-col.w-col.w-col-4', [
+                                m('.fontcolor-secondary.u-marginbottom-10',
+                                    'Local de entrega'
+                                ),
+                                m('select.positive.text-field.w-select', {
+                                    onchange: m.withAttr('value', state.selectDestination)
+                                },
+                                    _.map(state.locationOptions(reward, state.selectedDestination),
+                                        option => m('option', {
+                                            value: option.value
+                                        }, [
+                                            `${option.name} `,
+                                            option.value != '' ? `+R$${h.formatNumber(option.fee, 2, 3)}` : null
+                                        ])
+                                    )
                                 )
-                            ),
-                            m('.w-col.w-col-9.w-col-small-9.w-col-tiny-9',
-                                m('input.back-reward-input-reward.medium.w-input', {
-                                    autocomplete: 'off',
-                                    min: reward.minimum_value,
-                                    placeholder: reward.minimum_value,
-                                    type: 'tel',
-                                    oncreate: state.setInput,
-                                    onkeyup: m.withAttr('value', state.applyMask),
-                                    value: state.contributionValue()
-                                })
+                            ]) : '',
+                            m('.w-sub-col.w-col.w-clearfix', {
+                                class: rewardVM.hasShippingOptions(reward) ?
+                                    'w-col-4' : 'w-col-8'
+                            }, [
+                                m('.fontcolor-secondary.u-marginbottom-10', `Valor do apoio${attrs.isSubscription ? ' mensal' : ''}`),
+                                m('.w-row.u-marginbottom-20', [
+                                    m('.w-col.w-col-3.w-col-small-3.w-col-tiny-3',
+                                        m('.back-reward-input-reward.medium.placeholder',
+                                            'R$'
+                                        )
+                                    ),
+                                    m('.w-col.w-col-9.w-col-small-9.w-col-tiny-9',
+                                        m('input.back-reward-input-reward.medium.w-input', {
+                                            autocomplete: 'off',
+                                            min: reward.minimum_value,
+                                            placeholder: reward.minimum_value,
+                                            type: 'tel',
+                                            oncreate: state.setInput,
+                                            onkeyup: m.withAttr('value', state.applyMask),
+                                            value: state.contributionValue()
+                                        })
+                                    )
+                                ]),
+                                m('.fontsize-smaller.text-error.u-marginbottom-20.w-hidden', [
+                                    m('span.fa.fa-exclamation-triangle'),
+                                    ' O valor do apoio está incorreto'
+                                ])
+                            ]),
+                            m('.submit-form.w-col.w-col-4',
+                                m('button.btn.btn-medium.u-margintop-30', {
+                                    onclick: state.submitContribution
+                                }, [
+                                    'Continuar  ',
+                                    m('span.fa.fa-chevron-right')
+                                ])
                             )
                         ]),
-                        m('.fontsize-smaller.text-error.u-marginbottom-20.w-hidden', [
+                        state.error().length > 0 && state.isSelected(reward) ? m('.text-error', [
+                            m('br'),
                             m('span.fa.fa-exclamation-triangle'),
-                            ' O valor do apoio está incorreto'
-                        ])
-                    ]),
-                    m('.submit-form.w-col.w-col-4',
-                        m('button.btn.btn-medium.u-margintop-30', {
-                            onclick: state.submitContribution
-                        }, [
-                            'Continuar  ',
-                            m('span.fa.fa-chevron-right')
-                        ])
-                    )
-                ]),
-                state.error().length > 0 && state.isSelected(reward) ? m('.text-error', [
-                    m('br'),
-                    m('span.fa.fa-exclamation-triangle'),
-                    ` ${state.error()}`
-                ]) : '',
-                m('.fontsize-smaller.fontweight-semibold',
-                    reward.title
-                ),
-                m('.back-reward-reward-description', [
-                    (
-                        reward.uploaded_image ?
+                            ` ${state.error()}`
+                        ]) : '',
+                        m('.fontsize-smaller.fontweight-semibold',
+                            reward.title
+                        ),
+                        m('.back-reward-reward-description', [
                             (
-                                m("div.u-marginbottom-20.w-row", [
-                                    m("div.w-col.w-col-8",
-                                        m(`img[src='${reward.uploaded_image}'][alt='']`)
-                                    ),
-                                    m("div.w-col.w-col-4")
+                                reward.uploaded_image ?
+                                    (
+                                        m("div.u-marginbottom-20.w-row", [
+                                            m("div.w-col.w-col-8",
+                                                m(`img[src='${reward.uploaded_image}'][alt='']`)
+                                            ),
+                                            m("div.w-col.w-col-4")
+                                        ])
+                                    )
+                                :
+                                    ''
+                            ),
+                            m('.fontsize-smaller.u-marginbottom-10.fontcolor-secondary', reward.description),
+                            m('.u-marginbottom-20.w-row', [!reward.deliver_at || attrs.isSubscription ? '' : m('.w-col.w-col-6', [
+                                m('.fontsize-smallest.fontcolor-secondary', 'Entrega Prevista:'),
+                                m('.fontsize-smallest', h.momentify(reward.deliver_at, 'MMM/YYYY'))
+                            ]),
+                                attrs.isSubscription || (!rewardVM.hasShippingOptions(reward) && reward.shipping_options !== 'presential') ? '' : m('.w-col.w-col-6', [
+                                    m('.fontsize-smallest.fontcolor-secondary', 'Envio:'),
+                                    m('.fontsize-smallest', window.I18n.t(`shipping_options.${reward.shipping_options}`, I18nScope()))
+
                                 ])
-                            )
-                        :
-                            ''
-                    ),
-                    m('.fontsize-smaller.u-marginbottom-10.fontcolor-secondary', reward.description),
-                    m('.u-marginbottom-20.w-row', [!reward.deliver_at || attrs.isSubscription ? '' : m('.w-col.w-col-6', [
-                        m('.fontsize-smallest.fontcolor-secondary', 'Entrega Prevista:'),
-                        m('.fontsize-smallest', h.momentify(reward.deliver_at, 'MMM/YYYY'))
-                    ]),
-                        attrs.isSubscription || (!rewardVM.hasShippingOptions(reward) && reward.shipping_options !== 'presential') ? '' : m('.w-col.w-col-6', [
-                            m('.fontsize-smallest.fontcolor-secondary', 'Envio:'),
-                            m('.fontsize-smallest', window.I18n.t(`shipping_options.${reward.shipping_options}`, I18nScope()))
+                            ])
                         ])
                     ])
-                ])
-            ])
-        ));
+                )
+
+            );
+        } else {
+            return m('');
+        }
     }
 };
 


### PR DESCRIPTION
### Descrição
Um assinante com assinatura ativa, cuja recompensa esteja esgotada, tente editar sua assinatura, ele não consegue selecionar a recompensa que já está associada à sua assinatura, pois ele não visualiza a sua recompensa para ser selecionada. A implementação foi realizada para que o assinante possa visualizar o card da sua recompensa no fluxo de apoio, e a edição da assinatura seja feita com a recompensa que já era de fato associada à assinatura.

### Referência
https://www.notion.so/catarse/Editar-assinatura-com-recompensa-esgotada-d3fa4bd91b5143a3b32b109def34c88e

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
