### PR TITLE
🔧 Habilita Style/FrozenStringLiteralComment

### DIFF
--- a/services/catarse/.rubocop.yml
+++ b/services/catarse/.rubocop.yml
@@ -19,12 +19,16 @@ AllCops:
     - 'node_modules/**/*'
     - 'catarse.js/**/*'
     - 'engines/**/*'
+    - 'public/**/*'
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/CaseIndentation:
   EnforcedStyle: end
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: start_of_line
@@ -59,7 +63,7 @@ Style/Documentation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
 
 Style/StringLiterals:
   AutoCorrect: true

--- a/services/catarse/spec/support/carrierwave.rb
+++ b/services/catarse/spec/support/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Rails.env.test?
   module CarrierWave
     module Downloader


### PR DESCRIPTION
### Descrição
Força que seja adicionado o `# frozen_string_literal: true` no início dos arquivos .rb. Isso ajuda a reduzir o consumo de memória: https://bugs.ruby-lang.org/issues/8976#note-30

### Referência
Não tem atividade.

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
