### PR TITLE
✨ Bloqueia valores menores que o permitido na simulação de parcelamento. 

### DIFF
--- a/services/catarse/app/api/catarse/v2/billing/installment_simulations_api.rb
+++ b/services/catarse/app/api/catarse/v2/billing/installment_simulations_api.rb
@@ -10,7 +10,7 @@ module Catarse
 
         get '/installment_simulations' do
           total_amount_cents = params['total_amount_cents']
-          result = ::Billing::InstallmentSimulator.calculate(total_amount_cents)
+          result = ::Billing::InstallmentSimulator.new.calculate(total_amount_cents)
 
           result
         end

--- a/services/catarse/lib/billing/installment_simulator.rb
+++ b/services/catarse/lib/billing/installment_simulator.rb
@@ -2,18 +2,34 @@
 
 module Billing
   class InstallmentSimulator
-    def self.calculate(amount)
-      max_installments = CatarseSettings.get_without_cache(:pagarme_max_installments).to_i
-      interest_rate = CatarseSettings.get_without_cache(:pagarme_interest_rate).to_f
-      (2..max_installments).map do |i|
-        total_amount = amount.to_i * (1 + interest_rate * i / 100)
-        installment_amount = total_amount / i
-        {
-          installments_count: i,
-          total_amount_cents: total_amount.round(0),
-          installment_amount_cents: installment_amount.round(0)
-        }
+    attr_accessor :interest_rate, :max_installments, :minimum_value_for_installment
+
+    def initialize
+      @interest_rate = CatarseSettings.get_without_cache(:pagarme_interest_rate).to_f
+      @max_installments = CatarseSettings.get_without_cache(:pagarme_max_installments).to_i
+      @minimum_value_for_installment = CatarseSettings.get_without_cache(:pagarme_minimum_value_for_installment).to_i
+    end
+
+    def calculate(amount)
+      @max_installments = 1 if amount < minimum_value_for_installment
+
+      (1..@max_installments).map { |i| calculate_amount_for_installments(amount, i) }
+    end
+
+    private
+
+    def calculate_amount_for_installments(amount, installment_count)
+      total_amount = if installment_count == 1
+        amount
+      else
+        amount * (1 + interest_rate * installment_count / 100)
       end
+      installment_amount = total_amount / installment_count
+      {
+        installments_count: installment_count,
+        total_amount_cents: total_amount.round(0),
+        installment_amount_cents: installment_amount.round(0)
+      }
     end
   end
 end

--- a/services/catarse/spec/api/catarse/v2/billing/installment_simulations_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/billing/installment_simulations_api_spec.rb
@@ -11,13 +11,26 @@ RSpec.describe Catarse::V2::Billing::InstallmentSimulationsAPI, type: :api do
     before do
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_max_installments).and_return(6)
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_interest_rate).and_return(2.5)
+      allow(CatarseSettings).to receive(:get_without_cache)
+        .with(:pagarme_minimum_value_for_installment).and_return(1500)
     end
 
-    it 'returns installment_simulations' do
-      get '/v2/billing/installment_simulations', params: params
-      result = Billing::InstallmentSimulator.calculate(params['total_amount_cents']).to_json
+    context 'when the amount is greater than the minimum amount for installation' do
+      it 'returns installment_simulations' do
+        get '/v2/billing/installment_simulations', params: params
+        result = Billing::InstallmentSimulator.new.calculate(params['total_amount_cents']).to_json
 
-      expect(response.body).to eq(result)
+        expect(response.body).to eq(result)
+      end
+    end
+
+    context 'when the amount is less than the minimum amount for installation' do
+      it 'returns installment_simulations' do
+        get '/v2/billing/installment_simulations', params: { 'total_amount_cents' => 1000 }
+        expected_response = { installments_count: 1, total_amount_cents: 1000, installment_amount_cents: 1000 }
+
+        expect(response.body).to eq([expected_response].to_json)
+      end
     end
 
     it 'return status 200 - ok' do

--- a/services/catarse/spec/lib/billing/installment_simulator_spec.rb
+++ b/services/catarse/spec/lib/billing/installment_simulator_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Billing::InstallmentSimulator, type: :lib do
-  describe '.calculate' do
-    subject(:simulations) { described_class.calculate(amount) }
+  describe '#calculate' do
+    subject(:simulations) { described_class.new.calculate(amount) }
 
     let(:amount) { 2000 }
     let(:max_installments) { 10 }
@@ -13,21 +13,35 @@ RSpec.describe Billing::InstallmentSimulator, type: :lib do
     before do
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_max_installments).and_return(max_installments)
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_interest_rate).and_return(interest_rate)
+      allow(CatarseSettings).to receive(:get_without_cache)
+        .with(:pagarme_minimum_value_for_installment).and_return(1500)
     end
 
-    it 'returns simulations for each installment count' do
-      installments_count = simulations.pluck(:installments_count)
-      expect(installments_count).to eq [2, 3, 4, 5, 6, 7, 8, 9, 10]
+    context 'when the amount is greater than the minimum amount for installation' do
+      it 'returns simulations for each installment count' do
+        installments_count = simulations.pluck(:installments_count)
+        expect(installments_count).to eq [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      end
+
+      it 'calculates total amount applying interest rate for each installment count' do
+        total_amounts = simulations.pluck(:total_amount_cents)
+        expect(total_amounts).to eq [2000, 2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000]
+      end
+
+      it 'calculates each installment amount applying interest rate' do
+        installment_amounts = simulations.pluck(:installment_amount_cents)
+        expect(installment_amounts).to eq [2000, 1200, 867, 700, 600, 533, 486, 450, 422, 400]
+      end
     end
 
-    it 'calculates total amount applying interest rate for each installment count' do
-      total_amounts = simulations.pluck(:total_amount_cents)
-      expect(total_amounts).to eq [2400, 2600, 2800, 3000, 3200, 3400, 3600, 3800, 4000]
-    end
+    context 'when the amount is less than the minimum amount for installation' do
+      subject(:simulations) { described_class.new.calculate(1000) }
 
-    it 'calculates each installment amount applying interest rate' do
-      installment_amounts = simulations.pluck(:installment_amount_cents)
-      expect(installment_amounts).to eq [1200, 867, 700, 600, 533, 486, 450, 422, 400]
+      let(:expected_response) { { installments_count: 1, total_amount_cents: 1000, installment_amount_cents: 1000 } }
+
+      it 'returns simulation just for immediate payment' do
+        expect(simulations).to eq([expected_response])
+      end
     end
   end
 end


### PR DESCRIPTION
### Descrição
Ao simular um parcelamento menor que valor minimo deveremos retornar apenas a simulação do pagamento à vista e não a simulação completa.

### Referência
https://www.notion.so/catarse/Bloquear-simula-o-de-parcelamento-com-valores-menores-que-o-permitido-1b43f391d76548108cc7162703205d79

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
