### PR TITLE
✨ Recebe e processa webhooks na nova arquitetura

### DIFF
--- a/services/catarse/.rubocop.yml
+++ b/services/catarse/.rubocop.yml
@@ -45,6 +45,9 @@ Layout/MultilineMethodCallBraceLayout:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/services/catarse/app/actions/billing/payments/authorize_transaction.rb
+++ b/services/catarse/app/actions/billing/payments/authorize_transaction.rb
@@ -6,15 +6,15 @@ module Billing
       include Helpers::ErrorHandler
 
       input :payment, type: Billing::Payment
-      input :pagarme_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
+      input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
 
       def call
-        response = pagarme_client.create_transaction(transaction_params)
+        response = pagar_me_client.create_transaction(transaction_params)
 
         next_state = evalute_next_state(response)
 
         payment.transition_to!(next_state, response)
-        payment.update!(gateway: 'pagarme', gateway_id: response['id'])
+        payment.update!(gateway: 'pagar_me', gateway_id: response['id'])
         create_credit_card(response)
       end
 

--- a/services/catarse/app/actions/billing/payments/capture_or_refund_transaction.rb
+++ b/services/catarse/app/actions/billing/payments/capture_or_refund_transaction.rb
@@ -4,13 +4,13 @@ module Billing
   module Payments
     class CaptureOrRefundTransaction < Actor
       input :payment, type: Billing::Payment
-      input :pagarme_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
+      input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
 
       def call
         if payment.in_state?(:authorized, :approved_on_antifraud)
-          pagarme_client.capture_transaction(payment.gateway_id)
+          pagar_me_client.capture_transaction(payment.gateway_id)
         elsif payment.in_state?(:declined_on_antifraud)
-          pagarme_client.refund_transaction(payment.gateway_id)
+          pagar_me_client.refund_transaction(payment.gateway_id)
         end
       end
     end

--- a/services/catarse/app/actions/billing/payments/chargeback.rb
+++ b/services/catarse/app/actions/billing/payments/chargeback.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class Chargeback < Actor
+      input :payment, type: Billing::Payment
+      input :metadata, type: Hash, default: {}
+
+      def call
+        fail!(error: 'Payment cannot transition to charged_back') unless payment.can_transition_to?(:charged_back)
+
+        payment.transition_to!(:charged_back, metadata)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/billing/payments/generate_boleto.rb
+++ b/services/catarse/app/actions/billing/payments/generate_boleto.rb
@@ -6,15 +6,15 @@ module Billing
       include Helpers::ErrorHandler
 
       input :payment, type: Billing::Payment
-      input :pagarme_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
+      input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
 
       def call
         # TODO: check if payment method is boleto
-        response = pagarme_client.create_transaction(transaction_params)
+        response = pagar_me_client.create_transaction(transaction_params)
 
         if response['status'] == 'waiting_payment'
           payment.transition_to!(:waiting_payment, response)
-          payment.update!(gateway: 'pagarme', gateway_id: response['id'])
+          payment.update!(gateway: 'pagar_me', gateway_id: response['id'])
           create_boleto(response)
         else
           handle_fatal_error('Invalid gateway request',

--- a/services/catarse/app/actions/billing/payments/generate_pix.rb
+++ b/services/catarse/app/actions/billing/payments/generate_pix.rb
@@ -6,15 +6,15 @@ module Billing
       include Helpers::ErrorHandler
 
       input :payment, type: Billing::Payment
-      input :pagarme_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
+      input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
 
       def call
-        # TODO: check if payment method is boleto
-        response = pagarme_client.create_transaction(transaction_params)
+        # TODO: check if payment method is pix
+        response = pagar_me_client.create_transaction(transaction_params)
 
         if response['status'] == 'waiting_payment'
           payment.transition_to!(:waiting_payment, response)
-          payment.update!(gateway: 'pagarme', gateway_id: response['id'])
+          payment.update!(gateway: 'pagar_me', gateway_id: response['id'])
           create_pix(response)
         else
           handle_fatal_error('Invalid gateway request',

--- a/services/catarse/app/actions/billing/payments/refund.rb
+++ b/services/catarse/app/actions/billing/payments/refund.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class Refund < Actor
+      input :payment, type: Billing::Payment
+      input :metadata, type: Hash, default: {}
+
+      def call
+        fail!(error: 'Payment cannot transition to refunded') unless payment.can_transition_to?(:refunded)
+
+        payment.transition_to!(:refunded, metadata)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/billing/payments/refuse.rb
+++ b/services/catarse/app/actions/billing/payments/refuse.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class Refuse < Actor
+      input :payment, type: Billing::Payment
+      input :metadata, type: Hash, default: {}
+
+      def call
+        fail!(error: 'Payment cannot transition to refused') unless payment.can_transition_to?(:refused)
+
+        payment.transition_to!(:refused, metadata)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/billing/payments/settle.rb
+++ b/services/catarse/app/actions/billing/payments/settle.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class Settle < Actor
+      input :payment, type: Billing::Payment
+      input :metadata, type: Hash, default: {}
+
+      def call
+        fail!(error: 'Payment cannot transition to paid') unless payment.can_transition_to?(:paid)
+
+        payment.transition_to!(:paid, metadata)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/integrations/webhooks/create.rb
+++ b/services/catarse/app/actions/integrations/webhooks/create.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Webhooks
+    class Create < Actor
+      input :attributes, type: Hash
+
+      output :webhook, type: Integrations::Webhook
+
+      def call
+        initial_state = Integrations::WebhookStateMachine.initial_state
+        self.webhook = Integrations::Webhook.create!(attributes.merge(state: initial_state))
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/integrations/webhooks/dispatch_process_job.rb
+++ b/services/catarse/app/actions/integrations/webhooks/dispatch_process_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Webhooks
+    class DispatchProcessJob < Actor
+      input :webhook, type: Integrations::Webhook
+
+      def call
+        Integrations::ProcessWebhookJob.perform_later(webhook.id)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/integrations/webhooks/receive.rb
+++ b/services/catarse/app/actions/integrations/webhooks/receive.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Webhooks
+    class Receive < Actor
+      play ValidateSignature, Create, DispatchProcessJob
+    end
+  end
+end

--- a/services/catarse/app/actions/integrations/webhooks/validate_signature.rb
+++ b/services/catarse/app/actions/integrations/webhooks/validate_signature.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Webhooks
+    class ValidateSignature < Actor
+      input :attributes, type: Hash
+      input :raw_data, type: String
+
+      def call
+        signature_validator = provider_object.signature_validator
+
+        return if signature_validator.valid?(body: attributes[:body], headers: attributes[:headers], raw_data: raw_data)
+
+        extra = { data: attributes, raw_data: raw_data }
+        Sentry.capture_message('Invalid webhook signature', level: :fatal, extra: extra)
+        fail!(error: 'Invalid webhook signature')
+      end
+
+      def provider_object
+        Integrations::WebhookProviders.provider_object(attributes[:provider])
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/base_api.rb
+++ b/services/catarse/app/api/catarse/v2/base_api.rb
@@ -6,6 +6,8 @@ module Catarse
       format :json
       version :v2, using: :path
 
+      helpers Catarse::V2::Helpers::RequestHelpers
+
       rescue_from ActiveRecord::RecordInvalid do |e|
         error!({ errors: e.record.errors.messages }, 422)
       end
@@ -31,6 +33,7 @@ module Catarse
       end
 
       mount Catarse::V2::Billing::BaseAPI
+      mount Catarse::V2::Integrations::BaseAPI
       mount Catarse::V2::Shared::BaseAPI
     end
   end

--- a/services/catarse/app/api/catarse/v2/helpers/request_helpers.rb
+++ b/services/catarse/app/api/catarse/v2/helpers/request_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Catarse
+  module V2
+    module Helpers
+      module RequestHelpers
+        def raw_request_body
+          raw_data = env[Grape::Env::RACK_REQUEST_FORM_INPUT].read
+          env[Grape::Env::RACK_REQUEST_FORM_INPUT].rewind
+          raw_data
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/integrations/base_api.rb
+++ b/services/catarse/app/api/catarse/v2/integrations/base_api.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Catarse
+  module V2
+    module Integrations
+      class BaseAPI < Grape::API
+        namespace 'integrations' do
+          mount Catarse::V2::Integrations::WebhooksAPI
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/integrations/webhooks_api.rb
+++ b/services/catarse/app/api/catarse/v2/integrations/webhooks_api.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Catarse
+  module V2
+    module Integrations
+      class WebhooksAPI < Grape::API
+        helpers do
+          def webhook_params
+            { provider: params[:provider], body: params, headers: headers }
+          end
+        end
+
+        params do
+          requires :provider, type: String, values: ::Integrations::WebhookProviders.list
+        end
+
+        post '/webhooks/:provider' do
+          result = ::Integrations::Webhooks::Receive.result(attributes: webhook_params, raw_data: raw_request_body)
+
+          if result.success?
+            status :created
+            present :status, 'ok'
+          else
+            status :internal_server_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/clients/konduto/client.rb
+++ b/services/catarse/app/clients/konduto/client.rb
@@ -7,6 +7,7 @@ module Konduto
     base_uri 'https://api.konduto.com/v1'
 
     def create_order(order_params)
+      # TODO: Get api key from Vault
       api_key = CatarseSettings.get_without_cache(:konduto_test_api_key)
       headers = { 'Authorization' => "Basic #{Base64.encode64(api_key)}" }
       response = self.class.post('/orders', headers: headers, body: order_params.to_json)

--- a/services/catarse/app/clients/konduto/webhook_processor.rb
+++ b/services/catarse/app/clients/konduto/webhook_processor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Konduto
+  class WebhookProcessor
+    attr_reader :pagar_me_client, :webhook, :payment
+
+    def initialize(webhook:, pagar_me_client: PagarMe::Client.new)
+      @webhook = webhook
+      @pagar_me_client = pagar_me_client
+      @payment = Billing::Payment.find(webhook.body['order_id'])
+    end
+
+    def run
+      webhook.transition_to!(:processing)
+
+      gateway_response = capture_or_refund_transaction
+
+      raise 'Transaction cannot be captured or refunded' unless gateway_response.success?
+
+      webhook.transition_to!(:processed)
+    rescue StandardError => e
+      Sentry.capture_message(e.message, level: :fatal, extra: { webhook_id: webhook.id })
+      webhook.transition_to!(:failed) if webhook.can_transition_to?(:failed)
+    end
+
+    private
+
+    def capture_or_refund_transaction
+      case webhook.body['status']
+      when 'APPROVED'
+        pagar_me_client.capture_transaction(payment.gateway_id)
+      when 'DECLINED', 'NOT_AUTHORIZED', 'CANCELED', 'FRAUD'
+        pagar_me_client.refund_transaction(payment.gateway_id)
+      else
+        raise "Unknown order status: #{webhook.body['status']}"
+      end
+    end
+  end
+end

--- a/services/catarse/app/clients/konduto/webhook_signature_validator.rb
+++ b/services/catarse/app/clients/konduto/webhook_signature_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Konduto
+  class WebhookSignatureValidator
+    def self.valid?(body:, raw_data: '', headers: {})
+      # TODO: Get api key from Vault
+      api_key = CatarseSettings.get_without_cache(:konduto_test_api_key)
+      data = "#{body['order_id']}##{body['timestamp']}##{body['status']}"
+      digest = OpenSSL::Digest.new('sha256')
+
+      hmac = OpenSSL::HMAC.hexdigest(digest, api_key, data)
+      hmac == body['signature']
+    end
+  end
+end

--- a/services/catarse/app/clients/pagar_me/client.rb
+++ b/services/catarse/app/clients/pagar_me/client.rb
@@ -20,7 +20,7 @@ module PagarMe
         Sentry.capture_message('Transaction cannot be captured on gateway', error_options)
       end
 
-      response.parsed_response
+      response
     end
 
     def refund_transaction(transaction_id)
@@ -31,7 +31,7 @@ module PagarMe
         Sentry.capture_message('Transaction cannot be refunded on gateway', error_options)
       end
 
-      response.parsed_response
+      response
     end
 
     private

--- a/services/catarse/app/clients/pagar_me/transaction_params_builder.rb
+++ b/services/catarse/app/clients/pagar_me/transaction_params_builder.rb
@@ -24,6 +24,7 @@ module PagarMe
 
     def base_params
       {
+        reference_key: payment.id,
         payment_method: payment.payment_method,
         amount: payment.total_amount_cents,
         async: false,

--- a/services/catarse/app/clients/pagar_me/webhook_processor.rb
+++ b/services/catarse/app/clients/pagar_me/webhook_processor.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module PagarMe
+  class WebhookProcessor
+    attr_reader :webhook, :payment
+
+    def initialize(webhook:)
+      @webhook = webhook
+      @payment = Billing::Payment.find(webhook.body.dig('transaction', 'reference_key'))
+    end
+
+    def run
+      raise 'Event not expected' if webhook.body['event'] != 'transaction_status_changed'
+
+      webhook.transition_to!(:ignored) and return if can_be_ignored?
+
+      webhook.transition_to!(:processing)
+      handle_status_change
+      webhook.transition_to!(:processed)
+    rescue StandardError => e
+      handle_error(e)
+    end
+
+    private
+
+    def can_be_ignored?
+      %w[processing authorized waiting_payment pending_refund].include?(webhook.body['current_status'])
+    end
+
+    def handle_status_change
+      action = next_action
+
+      result = action.result(payment: payment, metadata: { webhook_id: webhook.id })
+
+      raise result.error if result.failure?
+    end
+
+    def next_action
+      action = mapped_actions[webhook.body['current_status']]
+      raise 'Unknown PagarMe transaction status' if action.nil?
+
+      action
+    end
+
+    def mapped_actions
+      {
+        'paid' => Billing::Payments::Settle,
+        'refunded' => payment.in_state?(:paid) ? Billing::Payments::Refund : Billing::Payments::Refuse,
+        'refused' => Billing::Payments::Refuse,
+        'chargedback' => Billing::Payments::Chargeback
+      }
+    end
+
+    def handle_error(error)
+      Sentry.capture_message(error.message, level: :fatal, extra: { webhook_id: webhook.id })
+      webhook.transition_to!(:failed) if webhook.can_transition_to?(:failed)
+    end
+  end
+end

--- a/services/catarse/app/clients/pagar_me/webhook_signature_validator.rb
+++ b/services/catarse/app/clients/pagar_me/webhook_signature_validator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PagarMe
+  class WebhookSignatureValidator
+    def self.valid?(headers:, raw_data:, body: {})
+      # TODO: Get api key from Vault
+      api_key = CatarseSettings.get_without_cache(:pagarme_test_api_key)
+      hash = OpenSSL::HMAC.hexdigest('sha1', api_key, raw_data)
+      raw_signature = headers['X-Hub-Signature'].to_s.split('=').second
+
+      hash == raw_signature
+    end
+  end
+end

--- a/services/catarse/app/enumerations/integrations/webhook_providers.rb
+++ b/services/catarse/app/enumerations/integrations/webhook_providers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Integrations
+  class WebhookProviders < EnumerateIt::Base
+    associate_values(:pagar_me, :konduto)
+
+    def self.provider_object(provider_name)
+      provider_object_class_name = provider_name.camelize
+      const_get(provider_object_class_name).new
+    end
+
+    class PagarMe
+      def signature_validator
+        ::PagarMe::WebhookSignatureValidator
+      end
+
+      def processor
+        ::PagarMe::WebhookProcessor
+      end
+    end
+
+    class Konduto
+      def signature_validator
+        ::Konduto::WebhookSignatureValidator
+      end
+
+      def processor
+        ::Konduto::WebhookProcessor
+      end
+    end
+  end
+end

--- a/services/catarse/app/jobs/integrations/process_webhook_job.rb
+++ b/services/catarse/app/jobs/integrations/process_webhook_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Integrations
+  class ProcessWebhookJob < ApplicationJob
+    def perform(webhook_id)
+      webhook = Integrations::Webhook.find(webhook_id)
+      processor = webhook.processor
+      processor.run
+    rescue StandardError => e
+      Sentry.capture_exception(e, level: :fatal, extra: { webhook_id: webhook_id })
+    end
+  end
+end

--- a/services/catarse/app/models/billing/boleto.rb
+++ b/services/catarse/app/models/billing/boleto.rb
@@ -7,7 +7,7 @@ module Billing
     validates :payment_id, presence: true
     validates :barcode, presence: true
     validates :url, presence: true
-    # TODO: Check if expires at is date or datetime
+    # TODO: Check attribute type. Investigate if expires at is date or datetime
     validates :expires_at, presence: true
   end
 end

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -2,8 +2,7 @@
 
 module Billing
   class Payment < ApplicationRecord
-    # TODO: Improve concern name
-    include Concerns::PaymentStateHelpers
+    include Utils::HasStateMachine
 
     belongs_to :user
 
@@ -22,11 +21,8 @@ module Billing
 
     validates :user_id, presence: true
     validates :billing_address_id, presence: true
-    validates :state, presence: true
     validates :gateway, presence: true
 
     validates :gateway_id, uniqueness: { scope: :gateway }, allow_nil: true
-
-    validates :state, inclusion: { in: Billing::PaymentStateMachine.states }
   end
 end

--- a/services/catarse/app/models/billing/payment_item.rb
+++ b/services/catarse/app/models/billing/payment_item.rb
@@ -2,18 +2,10 @@
 
 module Billing
   class PaymentItem < ApplicationRecord
-    include Statesman::Adapters::ActiveRecordQueries[
-      transition_class: Billing::PaymentItemStateTransition,
-      initial_state: :pending,
-      transition_name: :state_transitions
-    ]
-
-    after_create :create_inital_state_transition
+    include Utils::HasStateMachine
 
     belongs_to :payment, class_name: 'Billing::Payment'
     belongs_to :payable, polymorphic: true
-
-    has_many :state_transitions, class_name: 'Billing::PaymentItemStateTransition', dependent: :destroy, autosave: false
 
     monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
     monetize :shipping_fee_cents, numericality: { greater_than_or_equal_to: 0 }
@@ -22,23 +14,7 @@ module Billing
     validates :payment_id, presence: true
     validates :payable_id, presence: true
     validates :payable_type, presence: true
-    validates :state, presence: true
 
     validates :payable_id, uniqueness: { scope: %i[payable_type payment_id] }
-
-    validates :state, inclusion: { in: Billing::PaymentItemStateMachine.states }
-
-    def state_machine
-      @state_machine ||= Billing::PaymentItemStateMachine.new(self,
-        transition_class: Billing::PaymentItemStateTransition,
-        association_name: :state_transitions
-      )
-    end
-
-    private
-
-    def create_inital_state_transition
-      state_transitions.create(to_state: state, sort_key: 1, most_recent: true)
-    end
   end
 end

--- a/services/catarse/app/models/concerns/utils/has_state_machine.rb
+++ b/services/catarse/app/models/concerns/utils/has_state_machine.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Utils
+  module HasStateMachine
+    extend ActiveSupport::Concern
+
+    # To include this concern on your model, you need fill the following pre-requisites:
+    # Supposing you are including this concern on `Integrations::Webhook` model.
+    # - A state machine class. eg.: Integrations::WebhookStateMachine
+    # - A transition model class. eg.: Integrations::WebhookStateTransition
+    # - A initial state defined on Integrations::WebhookStateMachine
+    #
+    # Your model will get:
+    # - has_many :state_transition
+    # - state machine
+    # - delegate some state machine methods to state_machine
+    # - validation of presence and inclusion of state
+    # - create a new state transition when model is created
+    # - Some state machine related queries will be to class. eg.: Model.in_state(:processed)
+
+    included do |base|
+      state_machine_class = "#{base}StateMachine".constantize
+      transition_class = "#{base}StateTransition".constantize
+      transition_relation_name = :state_transitions
+
+      include Statesman::Adapters::ActiveRecordQueries[
+        transition_class: transition_class,
+        initial_state: state_machine_class.initial_state,
+        transition_name: transition_relation_name
+      ]
+
+      has_many transition_relation_name, class_name: "#{base}StateTransition", dependent: :destroy, autosave: false
+
+      validates :state, presence: true
+      validates :state, inclusion: { in: state_machine_class.states }
+
+      after_create :create_inital_state_transition
+
+      delegate :can_transition_to?, :current_state, :history, :last_transition, :transition_to!, :transition_to,
+        :in_state?, to: :state_machine
+
+      define_method :state_machine do
+        @state_machine ||= state_machine_class.new(self,
+          transition_class: transition_class,
+          association_name: transition_relation_name
+        )
+      end
+
+      private
+
+      define_method :create_inital_state_transition do
+        send(transition_relation_name).create(to_state: state, sort_key: 1, most_recent: true)
+      end
+    end
+  end
+end

--- a/services/catarse/app/models/integrations.rb
+++ b/services/catarse/app/models/integrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Integrations
+  def self.table_name_prefix
+    'integrations_'
+  end
+end

--- a/services/catarse/app/models/integrations/webhook.rb
+++ b/services/catarse/app/models/integrations/webhook.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Integrations
+  class Webhook < ApplicationRecord
+    include Utils::HasStateMachine
+
+    has_enumeration_for :provider,
+      with: Integrations::WebhookProviders,
+      required: true,
+      create_helpers: { polymorphic: true }
+
+    validates :body, presence: true
+
+    def processor
+      @processor ||= provider_object.processor.new(webhook: self)
+    end
+  end
+end

--- a/services/catarse/app/models/integrations/webhook_state_transition.rb
+++ b/services/catarse/app/models/integrations/webhook_state_transition.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Integrations
+  class WebhookStateTransition < ApplicationRecord
+    belongs_to :webhook, class_name: 'Integrations::Webhook', inverse_of: :state_transitions
+
+    after_destroy :update_most_recent, if: :most_recent?
+
+    private
+
+    def update_most_recent
+      last_transition = webhook.webhook_state_transitions.order(:sort_key).last
+      return if last_transition.blank?
+
+      last_transition.update(most_recent: true)
+    end
+  end
+end

--- a/services/catarse/app/state_machines/billing/payment_item_state_machine.rb
+++ b/services/catarse/app/state_machines/billing/payment_item_state_machine.rb
@@ -12,8 +12,7 @@ module Billing
     transition from: :pending, to: :paid
 
     after_transition(after_commit: true) do |payment_item, transition|
-      payment_item.state = transition.to_state
-      payment_item.save!
+      payment_item.update!(state: transition.to_state)
     end
   end
 end

--- a/services/catarse/app/state_machines/billing/payment_state_machine.rb
+++ b/services/catarse/app/state_machines/billing/payment_state_machine.rb
@@ -18,11 +18,11 @@ module Billing
     state :charged_back
 
     transition from: :created, to: %i[waiting_payment authorized refused]
-    transition from: :authorized, to: %i[approved_on_antifraud declined_on_antifraud waiting_review]
+    transition from: :authorized, to: %i[approved_on_antifraud declined_on_antifraud waiting_review paid]
+    transition from: :paid, to: %i[charged_back refunded]
 
     after_transition(after_commit: true) do |payment, transition|
-      payment.state = transition.to_state
-      payment.save!
+      payment.update!(state: transition.to_state)
     end
   end
 end

--- a/services/catarse/app/state_machines/integrations/webhook_state_machine.rb
+++ b/services/catarse/app/state_machines/integrations/webhook_state_machine.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Integrations
+  class WebhookStateMachine
+    include Statesman::Machine
+
+    state :received, initial: true
+    state :processing
+    state :processed
+    state :failed
+    state :ignored
+
+    transition from: :received, to: %i[processing failed ignored]
+    transition from: :processing, to: %i[processed failed]
+    transition from: :failed, to: %i[processing ignored]
+
+    after_transition(after_commit: true) do |webhook, transition|
+      webhook.update!(state: transition.to_state)
+    end
+  end
+end

--- a/services/catarse/config/locales/webhook_providers.yml
+++ b/services/catarse/config/locales/webhook_providers.yml
@@ -1,0 +1,5 @@
+en:
+  enumerations:
+    webhook_providers:
+      pagar_me: 'Pagar.me'
+      konduto: 'Konduto'

--- a/services/catarse/db/migrate/20210427141428_create_integrations_webhooks.rb
+++ b/services/catarse/db/migrate/20210427141428_create_integrations_webhooks.rb
@@ -1,0 +1,12 @@
+class CreateIntegrationsWebhooks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :integrations_webhooks, id: :uuid do |t|
+      t.string :provider, null: false
+      t.jsonb :body, default: {}
+      t.jsonb :headers, default: {}
+      t.string :state, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/catarse/db/migrate/20210427142438_create_integrations_webhook_state_transitions.rb
+++ b/services/catarse/db/migrate/20210427142438_create_integrations_webhook_state_transitions.rb
@@ -1,0 +1,23 @@
+class CreateIntegrationsWebhookStateTransitions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :integrations_webhook_state_transitions, id: :uuid do |t|
+      t.string :to_state, null: false
+      t.jsonb :metadata, default: {}
+      t.integer :sort_key, null: false
+      t.references :webhook, null: false, foreign_key: { to_table: :integrations_webhooks }, type: :uuid
+      t.boolean :most_recent, null: false
+
+      t.timestamps
+    end
+
+    add_index(:integrations_webhook_state_transitions,
+      %i(webhook_id sort_key),
+      unique: true,
+      name: 'index_webhook_state_transitions_parent_sort')
+    add_index(:integrations_webhook_state_transitions,
+      %i(webhook_id most_recent),
+      unique: true,
+      where: 'most_recent',
+      name: 'index_webhook_state_transitions_parent_most_recent')
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/authorize_transaction_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/authorize_transaction_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
 
     it { is_expected.to include(payment: { type: Billing::Payment }) }
 
-    it 'injects pagarme_client dependency' do
-      proc = inputs.dig(:pagarme_client, :default)
+    it 'injects pagar_me_client dependency' do
+      proc = inputs.dig(:pagar_me_client, :default)
 
       expect(proc.call).to be_an_instance_of(PagarMe::Client)
     end
@@ -22,10 +22,10 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
   end
 
   describe '#call' do
-    subject(:result) { described_class.result(payment: payment, pagarme_client: pagarme_client) }
+    subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
 
     let(:payment) { create(:billing_payment, :created) }
-    let(:pagarme_client) { PagarMe::Client.new }
+    let(:pagar_me_client) { PagarMe::Client.new }
     let(:transaction_params) { PagarMe::TransactionParamsBuilder.new(payment: payment).build }
     let(:gateway_response) do
       {
@@ -44,11 +44,11 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
     end
 
     before do
-      allow(pagarme_client).to receive(:create_transaction).with(transaction_params).and_return(gateway_response)
+      allow(pagar_me_client).to receive(:create_transaction).with(transaction_params).and_return(gateway_response)
     end
 
     it 'creates transaction on gateway' do
-      expect(pagarme_client).to receive(:create_transaction).with(transaction_params)
+      expect(pagar_me_client).to receive(:create_transaction).with(transaction_params)
 
       result
     end
@@ -68,7 +68,7 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
         it 'updates payment gateway and gateway id' do
           result
 
-          expect(payment.reload.attributes).to include('gateway' => 'pagarme', 'gateway_id' => gateway_response['id'])
+          expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
         end
 
         it 'creates credit card' do

--- a/services/catarse/spec/actions/billing/payments/capture_or_refund_transaction_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/capture_or_refund_transaction_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Billing::Payments::CaptureOrRefundTransaction, type: :action do
 
     it { is_expected.to include(payment: { type: Billing::Payment }) }
 
-    it 'injects pagarme_client dependency' do
-      proc = inputs.dig(:pagarme_client, :default)
+    it 'injects pagar_me_client dependency' do
+      proc = inputs.dig(:pagar_me_client, :default)
 
       expect(proc.call).to be_an_instance_of(PagarMe::Client)
     end
@@ -22,9 +22,9 @@ RSpec.describe Billing::Payments::CaptureOrRefundTransaction, type: :action do
   end
 
   describe '#call' do
-    subject(:result) { described_class.result(payment: payment, pagarme_client: pagarme_client) }
+    subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
 
-    let(:pagarme_client) { PagarMe::Client.new }
+    let(:pagar_me_client) { PagarMe::Client.new }
     let(:gateway_response) do
       { id: Faker::Internet.uuid }
     end
@@ -34,7 +34,7 @@ RSpec.describe Billing::Payments::CaptureOrRefundTransaction, type: :action do
         let(:payment) { create(:billing_payment, :credit_card, payment_state) }
 
         it 'captures transaction on gateway' do
-          expect(pagarme_client).to receive(:capture_transaction).with(payment.gateway_id)
+          expect(pagar_me_client).to receive(:capture_transaction).with(payment.gateway_id)
 
           result
         end
@@ -45,7 +45,7 @@ RSpec.describe Billing::Payments::CaptureOrRefundTransaction, type: :action do
       let(:payment) { create(:billing_payment, :credit_card, :declined_on_antifraud) }
 
       it 'refunds transaction on gateway' do
-        expect(pagarme_client).to receive(:refund_transaction).with(payment.gateway_id)
+        expect(pagar_me_client).to receive(:refund_transaction).with(payment.gateway_id)
 
         result
       end

--- a/services/catarse/spec/actions/billing/payments/chargeback_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/chargeback_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Payments::Chargeback, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to include(payment: { type: Billing::Payment }) }
+
+    it 'includes metadata with a empty hash as default value' do
+      expect(inputs.dig(:metadata, :default)).to eq({})
+    end
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(payment: payment, metadata: { data: 'example' }) }
+
+    let(:payment) { create(:billing_payment, :paid) }
+
+    context 'when payment state cannot transition to charged_back' do
+      before { allow(payment).to receive(:can_transition_to?).with(:charged_back).and_return(false) }
+
+      it { is_expected.to be_failure }
+
+      it 'returns error message' do
+        expect(result.error).to eq 'Payment cannot transition to charged_back'
+      end
+
+      it 'doesn`t transition payment state' do
+        result
+
+        expect(payment.reload).to be_in_state(:paid)
+      end
+    end
+
+    context 'when payment state can transition to charged_back' do
+      it { is_expected.to be_success }
+
+      it 'transitions payment state to charged_back' do
+        result
+
+        expect(payment.reload).to be_in_state(:charged_back)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/checkout_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/checkout_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe Billing::Payments::Checkout, type: :action do
 
   describe 'Play actors' do
     subject(:play_actors) do
-      described_class.play_actors.map do |play_actor|
-        play_actor[:actor] if play_actor[:if].blank? || play_actor[:if].call(result)
-      end.compact
+      filtered_play_configs = described_class.play_actors.select do |play_config|
+        play_config[:if].blank? || play_config[:if].call(result)
+      end
+      filtered_play_configs.pluck(:actor)
     end
 
     let(:result) { ServiceActor::Result.new(payment: payment) }

--- a/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
 
     it { is_expected.to include(payment: { type: Billing::Payment }) }
 
-    it 'injects pagarme_client dependency' do
-      proc = inputs.dig(:pagarme_client, :default)
+    it 'injects pagar_me_client dependency' do
+      proc = inputs.dig(:pagar_me_client, :default)
       expect(proc.call).to be_an_instance_of(PagarMe::Client)
     end
   end
@@ -21,10 +21,10 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
   end
 
   describe '#call' do
-    subject(:result) { described_class.result(payment: payment, pagarme_client: pagarme_client) }
+    subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
 
     let(:payment) { create(:billing_payment, :created, :boleto) }
-    let(:pagarme_client) { PagarMe::Client.new }
+    let(:pagar_me_client) { PagarMe::Client.new }
     let(:transaction_params) { PagarMe::TransactionParamsBuilder.new(payment: payment).build }
     let(:gateway_response) do
       {
@@ -37,11 +37,11 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
     end
 
     before do
-      allow(pagarme_client).to receive(:create_transaction).with(transaction_params).and_return(gateway_response)
+      allow(pagar_me_client).to receive(:create_transaction).with(transaction_params).and_return(gateway_response)
     end
 
     it 'creates transaction on gateway' do
-      expect(pagarme_client).to receive(:create_transaction).with(transaction_params)
+      expect(pagar_me_client).to receive(:create_transaction).with(transaction_params)
 
       result
     end
@@ -58,7 +58,7 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
       it 'updates payment gateway and gateway_id' do
         result
 
-        expect(payment.reload.attributes).to include('gateway' => 'pagarme', 'gateway_id' => gateway_response['id'])
+        expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
       end
 
       it 'creates a new boleto' do
@@ -78,7 +78,7 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
       it { is_expected.to be_failure }
 
       it 'handles error as fatal error' do
-        action = described_class.new(payment: payment, pagarme_client: pagarme_client)
+        action = described_class.new(payment: payment, pagar_me_client: pagar_me_client)
 
         expect(action).to receive(:handle_fatal_error)
           .with('Invalid gateway request', { data: gateway_response, payment_id: payment.id, user_id: payment.user_id })

--- a/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
 
     it { is_expected.to include(payment: { type: Billing::Payment }) }
 
-    it 'injects pagarme_client dependency' do
-      proc = inputs.dig(:pagarme_client, :default)
+    it 'injects pagar_me_client dependency' do
+      proc = inputs.dig(:pagar_me_client, :default)
       expect(proc.call).to be_an_instance_of(PagarMe::Client)
     end
   end
@@ -21,10 +21,10 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
   end
 
   describe '#call' do
-    subject(:result) { described_class.result(payment: payment, pagarme_client: pagarme_client) }
+    subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
 
     let(:payment) { create(:billing_payment, :created, :pix) }
-    let(:pagarme_client) { PagarMe::Client.new }
+    let(:pagar_me_client) { PagarMe::Client.new }
     let(:transaction_params) { PagarMe::TransactionParamsBuilder.new(payment: payment).build }
     let(:gateway_response) do
       {
@@ -36,11 +36,11 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
     end
 
     before do
-      allow(pagarme_client).to receive(:create_transaction).with(transaction_params).and_return(gateway_response)
+      allow(pagar_me_client).to receive(:create_transaction).with(transaction_params).and_return(gateway_response)
     end
 
     it 'creates transaction' do
-      expect(pagarme_client).to receive(:create_transaction).with(transaction_params)
+      expect(pagar_me_client).to receive(:create_transaction).with(transaction_params)
 
       result
     end
@@ -57,7 +57,7 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
       it 'updates gateway and gateway_id' do
         result
 
-        expect(payment.reload.attributes).to include('gateway' => 'pagarme', 'gateway_id' => gateway_response['id'])
+        expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
       end
 
       it 'creates a new pix' do
@@ -76,7 +76,7 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
       it { is_expected.to be_failure }
 
       it 'handles error as fatal error' do
-        action = described_class.new(payment: payment, pagarme_client: pagarme_client)
+        action = described_class.new(payment: payment, pagar_me_client: pagar_me_client)
 
         expect(action).to receive(:handle_fatal_error)
           .with('Invalid gateway request', { data: gateway_response, payment_id: payment.id, user_id: payment.user_id })

--- a/services/catarse/spec/actions/billing/payments/refund_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/refund_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Payments::Refund, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to include(payment: { type: Billing::Payment }) }
+
+    it 'includes metadata with a empty hash as default value' do
+      expect(inputs.dig(:metadata, :default)).to eq({})
+    end
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(payment: payment, metadata: { data: 'example' }) }
+
+    let(:payment) { create(:billing_payment, :paid) }
+
+    context 'when payment state cannot transition to refunded' do
+      before { allow(payment).to receive(:can_transition_to?).with(:refunded).and_return(false) }
+
+      it { is_expected.to be_failure }
+
+      it 'returns error message' do
+        expect(result.error).to eq 'Payment cannot transition to refunded'
+      end
+
+      it 'doesn`t transition payment state' do
+        result
+
+        expect(payment.reload).to be_in_state(:paid)
+      end
+    end
+
+    context 'when payment state can transition to refunded' do
+      it { is_expected.to be_success }
+
+      it 'transitions payment state to refunded' do
+        result
+
+        expect(payment.reload).to be_in_state(:refunded)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/refuse_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/refuse_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Payments::Refuse, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to include(payment: { type: Billing::Payment }) }
+
+    it 'includes metadata with a empty hash as default value' do
+      expect(inputs.dig(:metadata, :default)).to eq({})
+    end
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(payment: payment, metadata: { data: 'example' }) }
+
+    let(:payment) { create(:billing_payment, :created) }
+
+    context 'when payment state cannot transition to refused' do
+      before { allow(payment).to receive(:can_transition_to?).with(:refused).and_return(false) }
+
+      it { is_expected.to be_failure }
+
+      it 'returns error message' do
+        expect(result.error).to eq 'Payment cannot transition to refused'
+      end
+
+      it 'doesn`t transition payment state' do
+        result
+
+        expect(payment.reload).to be_in_state(:created)
+      end
+    end
+
+    context 'when payment state can transition to refused' do
+      it { is_expected.to be_success }
+
+      it 'transitions payment state to refused' do
+        result
+
+        expect(payment.reload).to be_in_state(:refused)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/integrations/webhooks/create_spec.rb
+++ b/services/catarse/spec/actions/integrations/webhooks/create_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Webhooks::Create, type: :action do
+  describe 'inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(attributes: { type: Hash }) }
+  end
+
+  describe 'outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(webhook: { type: Integrations::Webhook }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(attributes: attributes) }
+
+    let(:attributes) { attributes_for(:integrations_webhook, state: nil).stringify_keys }
+
+    it { is_expected.to be_success }
+
+    it 'creates a new webhook' do
+      expect { result }.to change(Integrations::Webhook, :count).by(1)
+    end
+
+    it 'creates webhook with given attributes and initial state' do
+      webhook = result.webhook
+      initial_state = Integrations::WebhookStateMachine.initial_state
+
+      expect(webhook.reload.attributes).to include(attributes.merge('state' => initial_state))
+    end
+  end
+end

--- a/services/catarse/spec/actions/integrations/webhooks/dispatch_process_job_spec.rb
+++ b/services/catarse/spec/actions/integrations/webhooks/dispatch_process_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Webhooks::DispatchProcessJob, type: :action do
+  describe 'inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(webhook: { type: Integrations::Webhook }) }
+  end
+
+  describe 'outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(webhook: webhook) }
+
+    let(:webhook) { Integrations::Webhook.new(id: Faker::Internet.uuid) }
+
+    it { is_expected.to be_success }
+
+    it 'dispatches process webhook job' do
+      expect(Integrations::ProcessWebhookJob).to receive(:perform_later).with(webhook.id)
+
+      result
+    end
+  end
+end

--- a/services/catarse/spec/actions/integrations/webhooks/receive_spec.rb
+++ b/services/catarse/spec/actions/integrations/webhooks/receive_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Webhooks::Receive, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe 'Outputs' do
+    subject(:outputs) { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe 'Play actors' do
+    subject(:play_actors) { described_class.play_actors.pluck(:actor) }
+
+    let(:expected_actors) do
+      [
+        Integrations::Webhooks::ValidateSignature,
+        Integrations::Webhooks::Create,
+        Integrations::Webhooks::DispatchProcessJob
+      ]
+    end
+
+    it { is_expected.to eq expected_actors }
+  end
+end

--- a/services/catarse/spec/actions/integrations/webhooks/validate_signature_spec.rb
+++ b/services/catarse/spec/actions/integrations/webhooks/validate_signature_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Webhooks::ValidateSignature, type: :action do
+  describe 'inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(attributes: { type: Hash }) }
+    it { is_expected.to include(raw_data: { type: String }) }
+  end
+
+  describe 'outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(attributes: attributes, raw_data: raw_data) }
+
+    let(:attributes) { attributes_for(:integrations_webhook, state: nil).slice(:body, :headers, :provider) }
+    let(:raw_data) { Faker::Lorem.paragraph }
+    let(:signature_validator) do
+      Integrations::WebhookProviders.provider_object(attributes[:provider]).signature_validator
+    end
+
+    it 'validates webhook signature' do
+      expect(signature_validator).to receive(:valid?)
+        .with(body: attributes[:body], headers: attributes[:headers], raw_data: raw_data)
+
+      result
+    end
+
+    context 'when webhook signature is valid' do
+      before do
+        allow(signature_validator).to receive(:valid?)
+          .with(body: attributes[:body], headers: attributes[:headers], raw_data: raw_data)
+          .and_return(true)
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context 'when webhook signature is invalid' do
+      before do
+        allow(signature_validator).to receive(:valid?)
+          .with(body: attributes[:body], headers: attributes[:headers], raw_data: raw_data)
+          .and_return(false)
+      end
+
+      it { is_expected.to be_failure }
+
+      it 'sends message error to Sentry' do
+        data = { level: :fatal, extra: { data: attributes, raw_data: raw_data } }
+        expect(Sentry).to receive(:capture_message).with('Invalid webhook signature', data)
+
+        result
+      end
+    end
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/base_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/base_api_spec.rb
@@ -12,14 +12,4 @@ RSpec.describe Catarse::V2::BaseAPI, type: :api do
       expect(described_class.version).to eq :v2
     end
   end
-
-  describe 'Mounted apps' do
-    it 'mounts Catarse::V2::Billing::BaseAPI app' do
-      expect(described_class.routes.to_a).to include(*Catarse::V2::Billing::BaseAPI.routes.to_a)
-    end
-
-    it 'mounts Catarse::V2::Shared::BaseAPI app' do
-      expect(described_class.routes.to_a).to include(*Catarse::V2::Shared::BaseAPI.routes.to_a)
-    end
-  end
 end

--- a/services/catarse/spec/api/catarse/v2/helpers/request_helpers_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/helpers/request_helpers_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Catarse::V2::Helpers::RequestHelpers, type: :api do
+  subject(:dummy) do
+    dummy_class = Class.new do
+      attr_accessor :env
+
+      include Catarse::V2::Helpers::RequestHelpers
+    end
+
+    dummy_class.new
+  end
+
+  describe '#raw_request_body' do
+    let(:file_content) { Faker::Lorem.paragraph }
+    let(:rack_request_form_input) do
+      file = Tempfile.new
+      file << file_content
+      file.rewind
+      file
+    end
+
+    before { dummy.env = { Grape::Env::RACK_REQUEST_FORM_INPUT => rack_request_form_input } }
+
+    after do
+      rack_request_form_input.close
+      rack_request_form_input.unlink
+    end
+
+    it 'returns content from rack request form input file' do
+      expect(dummy.raw_request_body).to eq file_content
+    end
+
+    it 'rewinds rack request form input file' do
+      dummy.raw_request_body
+      expect(rack_request_form_input.read).not_to be_blank
+    end
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/integrations/webhooks_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/integrations/webhooks_api_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Catarse::V2::Integrations::WebhooksAPI, type: :api do
+  describe 'POST /v2/integrations/webhooks' do
+    let(:webhook) { build(:integrations_webhook) }
+    let(:request_params) { webhook.body.merge('provider' => webhook.provider) }
+    let(:webhook_attributes) { { provider: webhook.provider, body: request_params, headers: webhook.headers } }
+    let(:raw_data) { request_params.to_json }
+
+    before do
+      Grape::Endpoint.before_each do |endpoint|
+        allow(endpoint).to receive(:raw_request_body).and_return(raw_data)
+        allow(endpoint).to receive(:headers).and_return(webhook.headers)
+      end
+    end
+
+    after do
+      Grape::Endpoint.before_each nil
+    end
+
+    context 'when webhook is received with success' do
+      before do
+        allow(Integrations::Webhooks::Receive).to receive(:result)
+          .with(attributes: webhook_attributes, raw_data: raw_data)
+          .and_return(ServiceActor::Result.new(failure?: false))
+      end
+
+      it 'returns created address' do
+        post "/v2/integrations/webhooks/#{webhook.provider}", params: request_params
+
+        expect(response.body).to eq({ status: :ok }.to_json)
+      end
+
+      it 'return status 201 - created' do
+        post "/v2/integrations/webhooks/#{webhook.provider}", params: request_params
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'when webhook isn`t received with success' do
+      before do
+        allow(Integrations::Webhooks::Receive).to receive(:result)
+          .with(attributes: webhook_attributes, raw_data: raw_data)
+          .and_return(ServiceActor::Result.new(failure?: true))
+      end
+
+      it 'return status 500 - internal server error' do
+        post "/v2/integrations/webhooks/#{webhook.provider}", params: request_params
+
+        expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/clients/konduto/webhook_processor_spec.rb
+++ b/services/catarse/spec/clients/konduto/webhook_processor_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Konduto::WebhookProcessor, type: :client do
+  describe '#run' do
+    subject(:webhook_processor) { described_class.new(webhook: webhook, pagar_me_client: pagar_me_client) }
+
+    let(:webhook) do
+      create(:integrations_webhook, :received, body: { 'status' => webhook_status, 'order_id' => payment.id })
+    end
+    let(:pagar_me_client) { PagarMe::Client.new }
+    let(:payment) { Billing::Payment.new(id: Faker::Internet.uuid, gateway_id: Faker::Internet.uuid) }
+    let(:webhook_status) { 'APPROVED' }
+
+    before do
+      allow(Billing::Payment).to receive(:find).with(payment.id).and_return(payment)
+      allow(pagar_me_client).to receive(:capture_transaction)
+        .with(payment.gateway_id)
+        .and_return(instance_double(HTTParty::Response, success?: true))
+    end
+
+    context 'when webhook state cannot transition to processing' do
+      let(:webhook) { create(:integrations_webhook, :processed, body: { 'order_id' => payment.id }) }
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_message)
+          .with("Cannot transition from 'processed' to 'processing'", level: :fatal, extra: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+
+      it 'doesn`t change webhook state' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:processed)
+      end
+    end
+
+    it 'transitions webhook state to processing' do
+      expect { webhook_processor.run }.to change(webhook.history.where(to_state: 'processing'), :count).by(1)
+    end
+
+    context 'when webhook status is APPROVED' do
+      let(:webhook_status) { 'APPROVED' }
+
+      it 'captures transaction on gateway' do
+        expect(pagar_me_client).to receive(:capture_transaction).with(payment.gateway_id)
+
+        webhook_processor.run
+      end
+    end
+
+    %w[DECLINED NOT_AUTHORIZED CANCELED FRAUD].each do |status|
+      context "when webhook status is #{status}" do
+        let(:webhook_status) { status }
+
+        it 'refunds transition on gateway' do
+          expect(pagar_me_client).to receive(:refund_transaction).with(payment.gateway_id)
+
+          webhook_processor.run
+        end
+      end
+    end
+
+    context 'when webhook status is unknown' do
+      let(:webhook_status) { Faker::Lorem.word }
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_message)
+          .with("Unknown order status: #{webhook_status}", level: :fatal, extra: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+
+      it 'transisions webhook state to failed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:failed)
+      end
+    end
+
+    context 'when capture or refund on gateway fails' do
+      before do
+        allow(pagar_me_client).to receive(:capture_transaction)
+          .with(payment.gateway_id)
+          .and_return(instance_double(HTTParty::Response, success?: false))
+      end
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_message)
+          .with('Transaction cannot be captured or refunded', level: :fatal, extra: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+
+      it 'transisions webhook state to failed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:failed)
+      end
+    end
+
+    context 'when capture or refund on gateway is successful' do
+      before do
+        allow(pagar_me_client).to receive(:capture_transaction)
+          .with(payment.gateway_id)
+          .and_return(instance_double(HTTParty::Response, success?: true))
+      end
+
+      it 'transitions webhook state to processed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:processed)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/clients/konduto/webhook_signature_validator_spec.rb
+++ b/services/catarse/spec/clients/konduto/webhook_signature_validator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Konduto::WebhookSignatureValidator, type: :lib do
+  describe '.valid?' do
+    let(:api_key) { Faker::Lorem.word }
+    let(:body) do
+      { 'order_id' => Faker::Lorem.word, 'timestamp' => Faker::Lorem.word, 'status' => Faker::Lorem.word }
+    end
+    let(:string) { "#{body['order_id']}##{body['timestamp']}##{body['status']}" }
+
+    before do
+      allow(CatarseSettings).to receive(:get_without_cache).with(:konduto_test_api_key).and_return(api_key)
+      body['signature'] = signature
+    end
+
+    context 'when signature is valid' do
+      let(:signature) { OpenSSL::HMAC.hexdigest('SHA256', api_key, string) }
+
+      it 'returns true' do
+        expect(described_class.valid?(body: body)).to be(true)
+      end
+    end
+
+    context 'when signature is invalid' do
+      let(:signature) { 'FAKE SIGNATURE' }
+
+      it 'returns false' do
+        expect(described_class.valid?(body: body)).to be(false)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/clients/pagar_me/client_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/client_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe PagarMe::Client, type: :client do
     it 'captures transaction' do
       response = client.capture_transaction(transaction_id)
 
-      expect(response).to eq JSON.parse(request_response)
+      expect(response.parsed_response).to eq JSON.parse(request_response)
     end
 
     context 'when request is successfull' do
@@ -87,7 +87,7 @@ RSpec.describe PagarMe::Client, type: :client do
     it 'refunds transaction' do
       response = client.refund_transaction(transaction_id)
 
-      expect(response).to eq JSON.parse(request_response)
+      expect(response.parsed_response).to eq JSON.parse(request_response)
     end
 
     context 'when request is successfull' do

--- a/services/catarse/spec/clients/pagar_me/transaction_params_builder_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/transaction_params_builder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe PagarMe::TransactionParamsBuilder, type: :params_builder do
 
       it 'returns credit card transaction params' do
         expect(result).to eq(
+          reference_key: payment.id,
           payment_method: Billing::PaymentMethods::CREDIT_CARD,
           amount: payment.total_amount_cents,
           async: false,
@@ -26,6 +27,7 @@ RSpec.describe PagarMe::TransactionParamsBuilder, type: :params_builder do
 
       it 'returns boleto transaction params' do
         expect(result).to eq(
+          reference_key: payment.id,
           payment_method: Billing::PaymentMethods::BOLETO,
           amount: payment.total_amount_cents,
           async: false,
@@ -50,6 +52,7 @@ RSpec.describe PagarMe::TransactionParamsBuilder, type: :params_builder do
 
       it 'returns pix transaction params' do
         expect(result).to eq(
+          reference_key: payment.id,
           payment_method: Billing::PaymentMethods::PIX,
           amount: payment.total_amount_cents,
           async: false,

--- a/services/catarse/spec/clients/pagar_me/webhook_processor_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/webhook_processor_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PagarMe::WebhookProcessor, type: :client do
+  describe '#run' do
+    subject(:webhook_processor) { described_class.new(webhook: webhook) }
+
+    let(:webhook) do
+      create(:integrations_webhook, :received,
+        body: {
+          'event' => webhook_event,
+          'current_status' => webhook_status,
+          'transaction' => { 'reference_key' => payment.id }
+        }
+      )
+    end
+    let(:payment) { Billing::Payment.new(id: Faker::Internet.uuid) }
+    let(:webhook_event) { 'transaction_status_changed' }
+    let(:webhook_status) { 'paid' }
+
+    before { allow(Billing::Payment).to receive(:find).with(payment.id).and_return(payment) }
+
+    context 'when webhook event isn`t transaction_status_changed' do
+      let(:webhook_event) { Faker::Lorem.word }
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_message)
+          .with('Event not expected', level: :fatal, extra: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+
+      it 'transitions webhook state to failed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:failed)
+      end
+    end
+
+    %w[processing authorized waiting_payment pending_refund].each do |status|
+      context "when webhook current status is #{status}" do
+        let(:webhook_status) { status }
+
+        it 'transitions webhook state to ignored' do
+          webhook_processor.run
+
+          expect(webhook.reload).to be_in_state(:ignored)
+        end
+      end
+    end
+
+    it 'transitions webhook state to processing' do
+      expect { webhook_processor.run }.to change(webhook.history.where(to_state: 'processing'), :count).by(1)
+    end
+
+    context 'when webhook current status is paid' do
+      let(:webhook_status) { 'paid' }
+
+      it 'settles payment' do
+        expect(Billing::Payments::Settle).to receive(:result)
+          .with(payment: payment, metadata: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+    end
+
+    context 'when webhook current status is refunded and payment is paid' do
+      let(:webhook_status) { 'refunded' }
+
+      before { allow(payment).to receive(:in_state?).with(:paid).and_return(true) }
+
+      it 'refunds payment' do
+        expect(Billing::Payments::Refund).to receive(:result)
+          .with(payment: payment, metadata: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+    end
+
+    context 'when webhook current status is refunded and payment isn`t paid' do
+      let(:webhook_status) { 'refunded' }
+
+      before { allow(payment).to receive(:in_state?).with(:paid).and_return(false) }
+
+      it 'refuses payment' do
+        expect(Billing::Payments::Refuse).to receive(:result)
+          .with(payment: payment, metadata: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+    end
+
+    context 'when webhook current status is chargedback' do
+      let(:webhook_status) { 'chargedback' }
+
+      it 'charges back payment' do
+        expect(Billing::Payments::Chargeback).to receive(:result)
+          .with(payment: payment, metadata: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+    end
+
+    context 'when webhook current status is unknown' do
+      let(:webhook_status) { Faker::Lorem.word }
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_message)
+          .with('Unknown PagarMe transaction status', level: :fatal, extra: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+
+      it 'transitions webhook state to failed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:failed)
+      end
+    end
+
+    context 'when action processing fails' do
+      let(:error_message) { Faker::Lorem.paragraph }
+
+      before do
+        allow(Billing::Payments::Settle).to receive(:result)
+          .with(payment: payment, metadata: { webhook_id: webhook.id })
+          .and_return(ServiceActor::Result.new(failure?: true, error: error_message))
+      end
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_message)
+          .with(error_message, level: :fatal, extra: { webhook_id: webhook.id })
+
+        webhook_processor.run
+      end
+
+      it 'transitions webhook state to failed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:failed)
+      end
+    end
+
+    context 'when action processing is successful' do
+      before do
+        allow(Billing::Payments::Settle).to receive(:result)
+          .with(payment: payment, metadata: { webhook_id: webhook.id })
+          .and_return(ServiceActor::Result.new(failure?: false))
+      end
+
+      it 'transitions webhook state to processed' do
+        webhook_processor.run
+
+        expect(webhook.reload).to be_in_state(:processed)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/clients/pagar_me/webhook_signature_validator_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/webhook_signature_validator_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PagarMe::WebhookSignatureValidator, type: :lib do
+  describe '.valid?' do
+    let(:api_key) { Faker::Lorem.word }
+    let(:headers) { { 'X-Hub-Signature' => signature } }
+    let(:raw_data) { Faker::Lorem.paragraph }
+
+    before do
+      allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_test_api_key).and_return(api_key)
+    end
+
+    context 'when signature is valid' do
+      let(:signature) { "sha1=#{OpenSSL::HMAC.hexdigest('sha1', api_key, raw_data)}" }
+
+      it 'returns true' do
+        expect(described_class.valid?(headers: headers, raw_data: raw_data)).to be(true)
+      end
+    end
+
+    context 'when signature is invalid' do
+      let(:signature) { 'sha1=FAKE SIGNATURE' }
+
+      it 'returns false' do
+        expect(described_class.valid?(headers: headers, raw_data: raw_data)).to be(false)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/enumerations/integrations/webhook_providers_spec.rb
+++ b/services/catarse/spec/enumerations/integrations/webhook_providers_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::WebhookProviders, type: :enumeration do
+  describe '.list' do
+    subject { described_class.list }
+
+    it { is_expected.to include('pagar_me') }
+    it { is_expected.to include('konduto') }
+  end
+
+  describe '.provider_object' do
+    it 'returns a new instance from polymorphic provider object' do
+      expect(described_class.provider_object('pagar_me')).to be_an_instance_of(Integrations::WebhookProviders::PagarMe)
+    end
+  end
+
+  describe Integrations::WebhookProviders::PagarMe do
+    subject(:provider_object) { described_class.new }
+
+    describe '#signature_validator' do
+      it 'returns pagar_me webhook signature validator' do
+        expect(provider_object.signature_validator).to eq PagarMe::WebhookSignatureValidator
+      end
+    end
+
+    describe '#processor' do
+      it 'returns pagar_me webhook processor' do
+        expect(provider_object.processor).to eq PagarMe::WebhookProcessor
+      end
+    end
+  end
+
+  describe Integrations::WebhookProviders::Konduto do
+    subject(:provider_object) { described_class.new }
+
+    describe '#signature_validator' do
+      it 'returns konduto webhook signature validator' do
+        expect(provider_object.signature_validator).to eq Konduto::WebhookSignatureValidator
+      end
+    end
+
+    describe '#processor' do
+      it 'returns konduto webhook processor' do
+        expect(provider_object.processor).to eq Konduto::WebhookProcessor
+      end
+    end
+  end
+end

--- a/services/catarse/spec/factories/integrations/webhooks_factories.rb
+++ b/services/catarse/spec/factories/integrations/webhooks_factories.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :integrations_webhook, class: 'Integrations::Webhook' do
+    provider { Integrations::WebhookProviders.list.sample }
+    body { Hash[*Faker::Lorem.words(number: 8)] }
+    headers { Hash[*Faker::Lorem.words(number: 8)] }
+
+    state { Integrations::WebhookStateMachine.states.sample }
+    traits_for_enum :state, Integrations::WebhookStateMachine.states
+  end
+end

--- a/services/catarse/spec/factories/project_invites_factories.rb
+++ b/services/catarse/spec/factories/project_invites_factories.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :project_invite do
-    association :project
-    user_email { generate(:user_email) }
-  end
-end

--- a/services/catarse/spec/factories/users_oauth_providers_factories.rb
+++ b/services/catarse/spec/factories/users_oauth_providers_factories.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :users_oauth_provider, class: 'UsersOauthProviders' do
-    oauth_provider { 1 }
-    user_id { 1 }
-    uid { 'MyText' }
-  end
-end

--- a/services/catarse/spec/jobs/integrations/process_webhook_job_spec.rb
+++ b/services/catarse/spec/jobs/integrations/process_webhook_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::ProcessWebhookJob, type: :job do
+  describe '#perform' do
+    let(:webhook) { create(:integrations_webhook) }
+    let(:processor) { instance_double(webhook.provider_object.processor) }
+
+    before do
+      allow(webhook.provider_object.processor).to receive(:new).with(webhook: webhook).and_return(processor)
+    end
+
+    it 'processes webhook with its own processor' do
+      expect(processor).to receive(:run)
+
+      described_class.perform_now(webhook.id)
+    end
+
+    context 'when an error happens' do
+      let(:error) { StandardError.new('some error') }
+
+      before { allow(processor).to receive(:run).and_raise(error) }
+
+      it 'captures error with Sentry' do
+        expect(Sentry).to receive(:capture_exception).with(error, level: :fatal, extra: { webhook_id: webhook.id })
+
+        described_class.perform_now(webhook.id)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/models/billing/payment_item_spec.rb
+++ b/services/catarse/spec/models/billing/payment_item_spec.rb
@@ -3,17 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Billing::PaymentItem, type: :model do
+  it_behaves_like 'has state machine'
+
   describe 'Relations' do
     it { is_expected.to belong_to :payment }
     it { is_expected.to belong_to :payable }
-    it { is_expected.to have_many(:state_transitions).class_name('Billing::PaymentItemStateTransition') }
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :payment_id }
     it { is_expected.to validate_presence_of :payable_id }
     it { is_expected.to validate_presence_of :payable_type }
-    it { is_expected.to validate_presence_of :state }
 
     it do
       payment_item = create(:billing_payment_item)
@@ -23,19 +23,5 @@ RSpec.describe Billing::PaymentItem, type: :model do
     it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
     it { is_expected.to validate_numericality_of(:shipping_fee).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_numericality_of(:total_amount).is_greater_than_or_equal_to(1) }
-
-    it { is_expected.to validate_inclusion_of(:state).in_array(Billing::PaymentItemStateMachine.states) }
-  end
-
-  describe 'Callbacks' do
-    describe '#after_create' do
-      it 'creates a state transition' do
-        payment_item = create(:billing_payment_item)
-
-        expect(payment_item.state_transitions.last.attributes).to include(
-          'to_state' => payment_item.state, 'sort_key' => 1, 'most_recent' => true
-        )
-      end
-    end
   end
 end

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Billing::Payment, type: :model do
+  it_behaves_like 'has state machine'
+
   describe 'Relations' do
     subject(:payment) { described_class.new }
 
@@ -11,13 +13,6 @@ RSpec.describe Billing::Payment, type: :model do
     it { is_expected.to belong_to(:shipping_address).class_name('Shared::Address').optional }
 
     it { is_expected.to have_many(:items).class_name('Billing::PaymentItem').dependent(:destroy) }
-
-    it do
-      expect(payment).to have_many(:state_transitions)
-        .class_name('Billing::PaymentStateTransition')
-        .dependent(:destroy)
-        .autosave(false)
-    end
   end
 
   describe 'Configurations' do
@@ -30,7 +25,6 @@ RSpec.describe Billing::Payment, type: :model do
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:billing_address_id) }
     it { is_expected.to validate_presence_of(:payment_method) }
-    it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:gateway) }
 
     it do
@@ -39,19 +33,5 @@ RSpec.describe Billing::Payment, type: :model do
     end
 
     it { is_expected.to validate_numericality_of(:total_amount).is_greater_than_or_equal_to(1) }
-
-    it { is_expected.to validate_inclusion_of(:state).in_array(Billing::PaymentStateMachine.states) }
-  end
-
-  describe 'Callbacks' do
-    describe '#after_create' do
-      it 'creates a state transition' do
-        payment = create(:billing_payment)
-
-        expect(payment.state_transitions.last.attributes).to include(
-          'to_state' => payment.state, 'sort_key' => 1, 'most_recent' => true
-        )
-      end
-    end
   end
 end

--- a/services/catarse/spec/models/billing_spec.rb
+++ b/services/catarse/spec/models/billing_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing, type: :model do
+  describe '.table_name_prefix' do
+    it 'returns `billing_`' do
+      expect(described_class.table_name_prefix).to eq 'billing_'
+    end
+  end
+end

--- a/services/catarse/spec/models/integrations/webhooks_spec.rb
+++ b/services/catarse/spec/models/integrations/webhooks_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Webhook, type: :model do
+  it_behaves_like 'has state machine'
+
+  describe 'Configurations' do
+    it 'setups provider with Integrations::WebhookProviders enum' do
+      expect(described_class.enumerations).to include(provider: Integrations::WebhookProviders)
+    end
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :body }
+    it { is_expected.to validate_presence_of :provider }
+  end
+
+  describe '#processor' do
+    subject(:webhook) { build(:integrations_webhook) }
+
+    let(:processor) { instance_double(webhook.provider_object.processor) }
+
+    before do
+      allow(webhook.provider_object.processor).to receive(:new).with(webhook: webhook).and_return(processor)
+    end
+
+    it 'returns a new processor instance from provider object' do
+      expect(webhook.processor).to eq processor
+    end
+  end
+end

--- a/services/catarse/spec/models/integrations_spec.rb
+++ b/services/catarse/spec/models/integrations_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations, type: :model do
+  describe '.table_name_prefix' do
+    it 'returns `integrations_`' do
+      expect(described_class.table_name_prefix).to eq 'integrations_'
+    end
+  end
+end

--- a/services/catarse/spec/state_machines/billing/payment_state_machine_spec.rb
+++ b/services/catarse/spec/state_machines/billing/payment_state_machine_spec.rb
@@ -61,6 +61,22 @@ RSpec.describe Billing::PaymentStateMachine, type: :state_machine do
     it 'allows transition to waiting_review' do
       expect { payment.transition_to!(:waiting_review) }.not_to raise_error
     end
+
+    it 'allows transition to paid' do
+      expect { payment.transition_to!(:paid) }.not_to raise_error
+    end
+  end
+
+  context 'when state is paid' do
+    let(:payment) { create(:billing_payment, :paid) }
+
+    it 'allows transition to charged_back' do
+      expect { payment.transition_to!(:charged_back) }.not_to raise_error
+    end
+
+    it 'allows transition to refunded' do
+      expect { payment.transition_to!(:refunded) }.not_to raise_error
+    end
   end
 
   describe '.after_transition' do

--- a/services/catarse/spec/state_machines/integrations/webhook_state_machine_spec.rb
+++ b/services/catarse/spec/state_machines/integrations/webhook_state_machine_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::WebhookStateMachine, type: :state_machine do
+  describe '.initial_state' do
+    it 'returns received' do
+      expect(described_class.initial_state).to eq 'received'
+    end
+  end
+
+  describe '.states' do
+    let(:states_list) do
+      %w[received processing processed failed ignored]
+    end
+
+    it 'returns webhook states list' do
+      expect(described_class.states).to eq states_list
+    end
+  end
+
+  context 'when state is received' do
+    let(:webhook) { create(:integrations_webhook, :received) }
+
+    it 'allows transition to processing' do
+      expect { webhook.transition_to!(:processing) }.not_to raise_error
+    end
+
+    it 'allows transition to failed' do
+      expect { webhook.transition_to!(:failed) }.not_to raise_error
+    end
+
+    it 'allows transition to ignored' do
+      expect { webhook.transition_to!(:ignored) }.not_to raise_error
+    end
+  end
+
+  context 'when state is processing' do
+    let(:webhook) { create(:integrations_webhook, :processing) }
+
+    it 'allows transition to processed' do
+      expect { webhook.transition_to!(:processed) }.not_to raise_error
+    end
+
+    it 'allows transition to failed' do
+      expect { webhook.transition_to!(:failed) }.not_to raise_error
+    end
+  end
+
+  context 'when state is failed' do
+    let(:webhook) { create(:integrations_webhook, :failed) }
+
+    it 'allows transition to processing' do
+      expect { webhook.transition_to!(:processing) }.not_to raise_error
+    end
+
+    it 'allows transition to ignored' do
+      expect { webhook.transition_to!(:ignored) }.not_to raise_error
+    end
+  end
+
+  describe '.after_transition' do
+    it 'updates webhook state to new state' do
+      webhook = create(:integrations_webhook, :received)
+      webhook.state_machine.transition_to!(:processing)
+
+      expect(webhook.reload.state).to eq 'processing'
+    end
+  end
+end

--- a/services/catarse/spec/support/shared_examples/has_state_machine_example.rb
+++ b/services/catarse/spec/support/shared_examples/has_state_machine_example.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'has state machine' do
+  describe 'Relations' do
+    subject(:record) { described_class.new }
+
+    it do
+      expect(record).to have_many(:state_transitions)
+        .class_name("#{described_class}StateTransition")
+        .dependent(:destroy)
+        .autosave(false)
+    end
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:state) }
+    it { is_expected.to validate_inclusion_of(:state).in_array("#{described_class}StateMachine".constantize.states) }
+  end
+
+  describe 'Delegations' do
+    subject { described_class.new }
+
+    %i[
+      can_transition_to? current_state history last_transition transition_to! transition_to in_state?
+    ].each do |method|
+      it { is_expected.to respond_to method }
+    end
+  end
+
+  describe 'Callbacks' do
+    describe '#after_create' do
+      it 'creates a state transition' do
+        factory_name = FactoryBot.factories.to_a.find { |f| f.build_class == described_class }.name
+        record = create(factory_name)
+
+        expect(record.state_transitions.last.attributes).to include(
+          'to_state' => record.state, 'sort_key' => 1, 'most_recent' => true
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Descrição
Recebe e processa os webhooks na nova arquitetura. 
Ao receber um webhook, primeiro validamos se ele tem uma assinatura válida, assim sabemos que podemos confiar naquele recebimento e processar o webhook com segurança.
Depois salvamos esse webhook numa tabela com o status `recebido`.
Dispachamos um job para processar esse webhook assíncronamente.
E sem esperar o fim do processamento, já retornamos uma reposta de sucesso na API.
Processamos o webhook e caso ocorra tudo bem, ele irá para o status `processado`, caso contrário ele irá para o status `falho` e será enviado um erro para o Sentry. Assim poderemos investigar melhor o que aconteceu , corrigir e retentar o processamento.
Foi criado até o momento 2 processadores de webhook, do Konduto e do PagarMe, mas a estrutura está pronta para evoluir para nos integrarmos com outros serviços.

### Referência
https://www.notion.so/catarse/Receber-e-processar-webhooks-ef98c13526e6416bafb1974f3eee47de

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
