### PR TITLE
✨ Adiciona valor de envio e valor sem envio no pagamento

### DIFF
--- a/services/catarse/app/actions/billing/payments/create.rb
+++ b/services/catarse/app/actions/billing/payments/create.rb
@@ -30,11 +30,15 @@ module Billing
       def build_payment_attributes(payment_items:)
         replicate_address
         initial_state = Billing::PaymentStateMachine.initial_state
+        amount_cents = payment_items.sum(&:amount_cents)
+        total_shipping_fee_cents = payment_items.sum(&:shipping_fee_cents)
         total_amount_cents = payment_items.sum(&:total_amount_cents)
 
         attributes.except(:payables).merge(
           user_id: user.id,
           state: initial_state,
+          amount_cents: amount_cents,
+          total_shipping_fee_cents: total_shipping_fee_cents,
           total_amount_cents: total_amount_cents
         )
       end

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -15,6 +15,8 @@ module Billing
 
     has_many :items, class_name: 'Billing::PaymentItem', dependent: :destroy
 
+    monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
+    monetize :total_shipping_fee_cents, numericality: { greater_than_or_equal_to: 0 }
     monetize :total_amount_cents, numericality: { greater_than_or_equal_to: 1 }
 
     has_enumeration_for :payment_method, with: Billing::PaymentMethods, required: true, create_helpers: true

--- a/services/catarse/db/migrate/20210427142439_add_amount_and_total_shipping_fee_to_billing_payments.rb
+++ b/services/catarse/db/migrate/20210427142439_add_amount_and_total_shipping_fee_to_billing_payments.rb
@@ -1,0 +1,6 @@
+class AddAmountAndTotalShippingFeeToBillingPayments < ActiveRecord::Migration[6.1]
+  def change
+    add_monetize :billing_payments, :total_shipping_fee
+    add_monetize :billing_payments, :amount
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/create_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/create_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe Billing::Payments::Create, type: :action do
         'gateway' => attributes[:gateway],
         'billing_address_id' => attributes[:billing_address_id],
         'state' => Billing::PaymentStateMachine.initial_state,
+        'amount_cents' => result.payment.items.sum(:amount_cents),
+        'total_shipping_fee_cents' => result.payment.items.sum(&:shipping_fee_cents),
         'total_amount_cents' => result.payment.items.sum(:total_amount_cents)
       )
     end

--- a/services/catarse/spec/factories/billing/payments_factories.rb
+++ b/services/catarse/spec/factories/billing/payments_factories.rb
@@ -30,6 +30,8 @@ FactoryBot.define do
     end
 
     after :build do |payment, evaluator|
+      payment.amount_cents = evaluator.payment_items.sum(&:amount_cents)
+      payment.total_shipping_fee_cents = evaluator.payment_items.sum(&:shipping_fee_cents)
       payment.total_amount_cents = evaluator.payment_items.sum(&:total_amount_cents)
     end
 

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -33,5 +33,7 @@ RSpec.describe Billing::Payment, type: :model do
     end
 
     it { is_expected.to validate_numericality_of(:total_amount).is_greater_than_or_equal_to(1) }
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
+    it { is_expected.to validate_numericality_of(:total_shipping_fee).is_greater_than_or_equal_to(0) }
   end
 end


### PR DESCRIPTION
### Descrição
Atualmente para consultar o valor total do frete e o valor total sem o custo do frete é necessário fazer uma consulta nos itens do pagamento. Para facilitar foi adicionado dois campos no billing_payment: **total_shipping_fee** e **amount** para armazenar esses valores.

### Referência
https://www.notion.so/catarse/Adicionar-campo-amount-e-total_shipping_fee-no-pagamento-f136d47488d14651b65839cfaf053916

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
