### PR TITLE
✨ Armazena custos de processamento do antifraude

### DIFF
--- a/services/catarse/app/enumerations/billing/payment_methods.rb
+++ b/services/catarse/app/enumerations/billing/payment_methods.rb
@@ -2,10 +2,6 @@
 
 module Billing
   class PaymentMethods < EnumerateIt::Base
-    associate_values(
-      :credit_card,
-      :pix,
-      :boleto
-    )
+    associate_values(:credit_card, :pix, :boleto)
   end
 end

--- a/services/catarse/app/enumerations/billing/processing_fee_vendors.rb
+++ b/services/catarse/app/enumerations/billing/processing_fee_vendors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Billing
+  class ProcessingFeeVendors < EnumerateIt::Base
+    associate_values(:pagar_me, :konduto)
+  end
+end

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -14,6 +14,7 @@ module Billing
     has_one :pix, class_name: 'Billing::Pix', dependent: :destroy
 
     has_many :items, class_name: 'Billing::PaymentItem', dependent: :destroy
+    has_many :processing_fees, class_name: 'Billing::ProcessingFee', dependent: :destroy
 
     monetize :total_amount_cents, numericality: { greater_than_or_equal_to: 1 }
 

--- a/services/catarse/app/models/billing/processing_fee.rb
+++ b/services/catarse/app/models/billing/processing_fee.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Billing
+  class ProcessingFee < ApplicationRecord
+    belongs_to :payment, class_name: 'Billing::Payment'
+
+    monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
+
+    has_enumeration_for :vendor, with: Billing::ProcessingFeeVendors, required: true, create_helpers: true
+
+    validates :payment_id, presence: true
+  end
+end

--- a/services/catarse/config/locales/processing_fee_vendor.yml
+++ b/services/catarse/config/locales/processing_fee_vendor.yml
@@ -1,0 +1,5 @@
+en:
+  enumerations:
+    processing_fee_vendor:
+      pagar_me: 'Pagar.me'
+      konduto: 'Konduto'

--- a/services/catarse/db/migrate/20210510161930_create_billing_processing_fees.rb
+++ b/services/catarse/db/migrate/20210510161930_create_billing_processing_fees.rb
@@ -1,0 +1,11 @@
+class CreateBillingProcessingFees < ActiveRecord::Migration[6.1]
+  def change
+    create_table :billing_processing_fees, id: :uuid do |t|
+      t.references :payment, null: false, foreign_key: { to_table: :billing_payments }, type: :uuid
+      t.monetize :amount
+      t.string :vendor, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/services/catarse/spec/enumerations/billing/processing_fee_vendors_spec.rb
+++ b/services/catarse/spec/enumerations/billing/processing_fee_vendors_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::ProcessingFeeVendors, type: :enumeration do
+  describe '.list' do
+    subject { described_class.list }
+
+    it { is_expected.to include('konduto') }
+    it { is_expected.to include('pagar_me') }
+  end
+end

--- a/services/catarse/spec/factories/billing/processing_fees_factories.rb
+++ b/services/catarse/spec/factories/billing/processing_fees_factories.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billing_processing_fee, class: 'Billing::ProcessingFee' do
+    association :payment, factory: :billing_payment
+    amount { Faker::Number.number(digits: 4) }
+    vendor { Billing::ProcessingFeeVendors.list.sample }
+  end
+end

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Billing::Payment, type: :model do
     it { is_expected.to belong_to(:shipping_address).class_name('Shared::Address').optional }
 
     it { is_expected.to have_many(:items).class_name('Billing::PaymentItem').dependent(:destroy) }
+    it { is_expected.to have_many(:processing_fees).class_name('Billing::ProcessingFee').dependent(:destroy) }
   end
 
   describe 'Configurations' do

--- a/services/catarse/spec/models/billing/processing_fee_spec.rb
+++ b/services/catarse/spec/models/billing/processing_fee_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::ProcessingFee, type: :model do
+  describe 'Relations' do
+    it { is_expected.to belong_to(:payment).class_name('Billing::Payment') }
+  end
+
+  describe 'Configurations' do
+    it 'setups vendor with Billing::ProcessingFeeVendors enum' do
+      expect(described_class.enumerations).to include(vendor: Billing::ProcessingFeeVendors)
+    end
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:payment_id) }
+    it { is_expected.to validate_presence_of(:vendor) }
+
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
+  end
+end


### PR DESCRIPTION
### Descrição
Registra os custos de processamento do antifraude no pagamento e já cria a estrutura para os custos de processamento de pagamento.

### Referência
https://www.notion.so/catarse/Armazenar-custos-da-an-lise-do-antifraude-ecba22d4fd924417895969ef692388cd

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
