### PR TITLE
🐞Corrige classe do botao de facebook

### DIFF
--- a/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
+++ b/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
@@ -6969,11 +6969,10 @@ textarea:required {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-.btn-fb {
+.btn-fb-flex {
   border: 1px solid #4b6fb8;
   background-color: #4b6fb8;
   color: #fff;
-
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6987,7 +6986,7 @@ textarea:required {
   box-shadow: 1px 1px 3px 0 #b9b9b9;
   font-weight: 600;
 }
-.btn.btn-medium.btn-fb {
+.btn.btn-medium.btn-fb-flex {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/services/catarse/app/views/catarse_bootstrap/devise/registrations/new.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/devise/registrations/new.html.slim
@@ -17,7 +17,7 @@
                 div = t('.form.inputs.google')
           .w-col.w-col-6
             .login-oauth
-              = link_to user_facebook_omniauth_authorize_path(locale: nil), class: 'btn btn-medium btn-fb'
+              = link_to user_facebook_omniauth_authorize_path(locale: nil), class: 'btn btn-medium btn-fb btn-fb-flex'
                 span.fa.fa-facebook-f&nbsp;
                 text = t('.form.inputs.facebook')
         .separator


### PR DESCRIPTION
### Descrição
Ao ajustar as classes do botão de facebook no #831 e  #836 , acabamos quebrando o botão do facebook nos outros lugares do site. Esse PR corrige isso.

### Referência
https://www.notion.so/catarse/Ajustar-classes-do-bot-o-de-facebook-e96a3e91dafe4127a9b6c97651684d21

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
