### PR TITLE
✨ Recebe identificador do cartão no checkout

### DIFF
--- a/services/catarse/app/api/catarse/v2/billing/payments_api.rb
+++ b/services/catarse/app/api/catarse/v2/billing/payments_api.rb
@@ -16,11 +16,17 @@ module Catarse
               requires :id, type: Integer
               requires :type, type: String, values: %w[Contribution Subscription]
             end
+
+            optional :credit_card_id, type: String
+            optional :credit_card_hash, type: String
+
+            given payment_method: ->(val) { val == ::Billing::PaymentMethods::CREDIT_CARD } do
+              exactly_one_of :credit_card_id, :credit_card_hash
+            end
           end
         end
 
         post '/payments' do
-          # TODO: Receive credit cards identifiers (id or hash)
           # TODO: Payment in installments
           payment_params = declared(params, include_missing: false)[:payment]
 

--- a/services/catarse/app/clients/pagar_me/transaction_params_builder.rb
+++ b/services/catarse/app/clients/pagar_me/transaction_params_builder.rb
@@ -2,21 +2,22 @@
 
 module PagarMe
   class TransactionParamsBuilder
-    attr_reader :payment, :user
+    attr_reader :payment, :user, :credit_card
 
     def initialize(payment:)
       @payment = payment
       @user = payment.user
+      @credit_card = payment.credit_card
     end
 
     def build
       case payment.payment_method
       when Billing::PaymentMethods::CREDIT_CARD
-        build_credit_card_params
+        build_credit_card_transaction_params
       when Billing::PaymentMethods::BOLETO
-        build_boleto_params
+        build_boleto_transaction_params
       when Billing::PaymentMethods::PIX
-        build_pix_params
+        build_pix_transaction_params
       end
     end
 
@@ -32,14 +33,11 @@ module PagarMe
       }
     end
 
-    def build_credit_card_params
-      base_params.merge(
-        capture: false,
-        card_id: 'card_123456789'
-      )
+    def build_credit_card_transaction_params
+      base_params.merge(build_credit_card_params).merge(capture: false)
     end
 
-    def build_boleto_params
+    def build_boleto_transaction_params
       # TODO: boleto expiration date calc
       # TODO: limit params characters length
       base_params.merge(
@@ -48,7 +46,7 @@ module PagarMe
       )
     end
 
-    def build_pix_params
+    def build_pix_transaction_params
       # TODO: pix expiration date calc
       base_params.merge(
         pix_expiration_date: 4.days.from_now.to_date.iso8601,
@@ -77,6 +75,14 @@ module PagarMe
           }
         ]
       }
+    end
+
+    def build_credit_card_params
+      if credit_card.present?
+        { card_id: credit_card.gateway_id }
+      else
+        { card_hash: payment.credit_card_hash }
+      end
     end
   end
 end

--- a/services/catarse/app/models/billing/credit_card.rb
+++ b/services/catarse/app/models/billing/credit_card.rb
@@ -3,10 +3,10 @@
 module Billing
   class CreditCard < ApplicationRecord
     belongs_to :user
-    belongs_to :payment, class_name: 'Billing::Payment'
+
+    has_many :payments, class_name: 'Billing::Payment', dependent: :nullify
 
     validates :user_id, presence: true
-    validates :payment_id, presence: true
     validates :gateway, presence: true
     validates :gateway_id, presence: true
     validates :holder_name, presence: true

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -8,8 +8,8 @@ module Billing
 
     belongs_to :billing_address, class_name: 'Shared::Address'
     belongs_to :shipping_address, class_name: 'Shared::Address', optional: true
+    belongs_to :credit_card, class_name: 'Billing::CreditCard', optional: true
 
-    has_one :credit_card, class_name: 'Billing::CreditCard', dependent: :destroy
     has_one :boleto, class_name: 'Billing::Boleto', dependent: :destroy
     has_one :pix, class_name: 'Billing::Pix', dependent: :destroy
 

--- a/services/catarse/app/queries/billing/credit_cards/safelist_query.rb
+++ b/services/catarse/app/queries/billing/credit_cards/safelist_query.rb
@@ -14,7 +14,7 @@ module Billing
       end
 
       def call
-        relation.joins(:payment).where(billing_payments: { state: 'paid' })
+        relation.joins(:payments).where(billing_payments: { state: 'paid' })
       end
     end
   end

--- a/services/catarse/db/migrate/20210511111140_add_credit_card_id_and_credit_card_hash_to_billing_payments.rb
+++ b/services/catarse/db/migrate/20210511111140_add_credit_card_id_and_credit_card_hash_to_billing_payments.rb
@@ -1,0 +1,9 @@
+class AddCreditCardIdAndCreditCardHashToBillingPayments < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :billing_payments,
+      :credit_card,
+      foreign_key: { to_table: :billing_credit_cards },
+      type: :uuid
+    add_column :billing_payments, :credit_card_hash, :string
+  end
+end

--- a/services/catarse/db/migrate/20210511113006_remove_payment_id_from_billing_credit_cards.rb
+++ b/services/catarse/db/migrate/20210511113006_remove_payment_id_from_billing_credit_cards.rb
@@ -1,0 +1,9 @@
+class RemovePaymentIdFromBillingCreditCards < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :billing_credit_cards,
+      :payment,
+      null: false,
+      foreign_key: { to_table: :billing_payments },
+      type: :uuid
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/billing/payments_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/billing/payments_api_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Catarse::V2::Billing::PaymentsAPI, type: :api do
         'payables' => [
           { 'id' => 123, 'type' => 'Contribution' },
           { 'id' => 456, 'type' => 'Subscription' }
-        ]
+        ],
+        credit_card_hash: Faker::Lorem.word
       }
     end
 

--- a/services/catarse/spec/clients/konduto/params_builders/address_spec.rb
+++ b/services/catarse/spec/clients/konduto/params_builders/address_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Konduto::ParamsBuilders::Address, type: :params_builder do
   end
 
   describe '#build' do
-    let(:credit_card) { create(:billing_credit_card) }
-    let(:address) { credit_card.payment.billing_address }
+    let(:credit_card) { build(:billing_credit_card) }
+    let(:address) { build(:shared_address) }
 
     it 'returns all attributes with corresponding methods results' do
       expect(params_builder.build).to eq(

--- a/services/catarse/spec/clients/pagar_me/transaction_params_builder_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/transaction_params_builder_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe PagarMe::TransactionParamsBuilder, type: :params_builder do
   describe '#build' do
     subject(:result) { described_class.new(payment: payment).build }
 
-    context 'when payment_method is credit_card' do
-      let(:payment) { create(:billing_payment, :credit_card) }
+    context 'when payment_method is credit_card with credit card registered' do
+      let(:payment) { create(:billing_payment, :with_credit_card) }
 
-      it 'returns credit card transaction params' do
+      it 'returns credit card transaction params with card_id' do
         expect(result).to eq(
           reference_key: payment.id,
           payment_method: Billing::PaymentMethods::CREDIT_CARD,
@@ -17,7 +17,23 @@ RSpec.describe PagarMe::TransactionParamsBuilder, type: :params_builder do
           async: false,
           postback_url: 'https://example.com',
           capture: false,
-          card_id: 'card_123456789'
+          card_id: payment.credit_card.gateway_id
+        )
+      end
+    end
+
+    context 'when payment_method is credit_card without credit card registered' do
+      let(:payment) { create(:billing_payment, :credit_card) }
+
+      it 'returns credit card transaction params with card_hash' do
+        expect(result).to eq(
+          reference_key: payment.id,
+          payment_method: Billing::PaymentMethods::CREDIT_CARD,
+          amount: payment.total_amount_cents,
+          async: false,
+          postback_url: 'https://example.com',
+          capture: false,
+          card_hash: payment.credit_card_hash
         )
       end
     end

--- a/services/catarse/spec/factories/billing/credit_cards_factories.rb
+++ b/services/catarse/spec/factories/billing/credit_cards_factories.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :billing_credit_card, class: 'Billing::CreditCard' do
-    association :payment, factory: :billing_payment
-    user { payment.user }
+    association :user, factory: :user
     gateway { Faker::Lorem.word }
     gateway_id { Faker::Internet.uuid }
     holder_name { Faker::Name.name }

--- a/services/catarse/spec/factories/billing/payments_factories.rb
+++ b/services/catarse/spec/factories/billing/payments_factories.rb
@@ -14,6 +14,8 @@ FactoryBot.define do
     gateway { Faker::Lorem.word }
     gateway_id { Faker::Internet.uuid }
 
+    credit_card_hash { Faker::Crypto.sha1 if credit_card? }
+
     trait :with_shipping_address do
       association :shipping_address, factory: :shared_address
     end

--- a/services/catarse/spec/models/billing/credit_card_spec.rb
+++ b/services/catarse/spec/models/billing/credit_card_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe Billing::CreditCard, type: :model do
   describe 'Relations' do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:payment).class_name('Billing::Payment') }
+
+    it { is_expected.to have_many(:payments).class_name('Billing::Payment').dependent(:nullify) }
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:user_id) }
-    it { is_expected.to validate_presence_of(:payment_id) }
     it { is_expected.to validate_presence_of(:gateway) }
     it { is_expected.to validate_presence_of(:gateway_id) }
     it { is_expected.to validate_presence_of(:holder_name) }

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Billing::Payment, type: :model do
     it { is_expected.to belong_to :user }
     it { is_expected.to belong_to(:billing_address).class_name('Shared::Address') }
     it { is_expected.to belong_to(:shipping_address).class_name('Shared::Address').optional }
+    it { is_expected.to belong_to(:credit_card).class_name('Billing::CreditCard').optional }
+
+    it { is_expected.to have_one(:pix).class_name('Billing::Pix').dependent(:destroy) }
+    it { is_expected.to have_one(:boleto).class_name('Billing::Boleto').dependent(:destroy) }
 
     it { is_expected.to have_many(:items).class_name('Billing::PaymentItem').dependent(:destroy) }
   end

--- a/services/catarse/spec/queries/billing/credit_cards/safelist_query_spec.rb
+++ b/services/catarse/spec/queries/billing/credit_cards/safelist_query_spec.rb
@@ -6,12 +6,15 @@ RSpec.describe Billing::CreditCards::SafelistQuery, type: :query do
   subject(:query) { described_class.new }
 
   describe '#call' do
-    let!(:paid_credit_card) { create(:billing_credit_card, payment: create(:billing_payment, :paid)) }
+    let(:paid_credit_card) { create(:billing_credit_card) }
 
     before do
+      create(:billing_payment, :paid, credit_card: paid_credit_card)
+
       not_paid_states = Billing::PaymentStateMachine.states - ['paid']
-      not_paid_states.map do |state|
-        create(:billing_credit_card, payment: create(:billing_payment, state: state))
+      not_paid_states.each do |state|
+        credit_card = create(:billing_credit_card)
+        create(:billing_payment, state: state, credit_card: credit_card)
       end
     end
 


### PR DESCRIPTION
### Descrição
Recebe o ID ou hash do cartão de crédito no processamento de pagamento.

### Referência
https://www.notion.so/catarse/Processar-pagamentos-com-cart-o-de-cr-dito-utilizando-id-do-cart-o-ou-hash-do-cart-o-272ec06e12c94e1aa1b461fbf467ddb9

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
