### PR TITLE
✨ Impedir geração do pix ou boleto com métodos diferentes do seu tipo.

### DIFF
--- a/services/catarse/app/actions/billing/payments/generate_boleto.rb
+++ b/services/catarse/app/actions/billing/payments/generate_boleto.rb
@@ -9,7 +9,8 @@ module Billing
       input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
 
       def call
-        # TODO: check if payment method is boleto
+        validate_payment_method!
+
         response = pagar_me_client.create_transaction(transaction_params)
 
         if response['status'] == 'waiting_payment'
@@ -24,6 +25,10 @@ module Billing
       end
 
       private
+
+      def validate_payment_method!
+        fail!(error: 'Invalid payment method') unless payment.boleto?
+      end
 
       def transaction_params
         PagarMe::TransactionParamsBuilder.new(payment: payment).build

--- a/services/catarse/app/actions/billing/payments/generate_pix.rb
+++ b/services/catarse/app/actions/billing/payments/generate_pix.rb
@@ -9,7 +9,8 @@ module Billing
       input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
 
       def call
-        # TODO: check if payment method is pix
+        validate_payment_method!
+
         response = pagar_me_client.create_transaction(transaction_params)
 
         if response['status'] == 'waiting_payment'
@@ -24,6 +25,10 @@ module Billing
       end
 
       private
+
+      def validate_payment_method!
+        fail!(error: 'Invalid payment method') unless payment.pix?
+      end
 
       def transaction_params
         PagarMe::TransactionParamsBuilder.new(payment: payment).build

--- a/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
       result
     end
 
+    context 'when payment method isn`t boleto' do
+      before { allow(payment).to receive(:boleto?).and_return(false) }
+
+      it 'doesn`t create transaction on gateway' do
+        expect(pagar_me_client).not_to receive(:create_transaction)
+
+        result
+      end
+
+      it 'doesn`t  change payment state' do
+        result
+
+        expect(payment.reload).to be_in_state('created')
+      end
+    end
+
     context 'when gateway response status is waiting_payment' do
       it { is_expected.to be_success }
 

--- a/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
       result
     end
 
+    context 'when payment method isn`t pix' do
+      before { allow(payment).to receive(:pix?).and_return(false) }
+
+      it 'doesn`t create transaction on gateway' do
+        expect(pagar_me_client).not_to receive(:create_transaction)
+
+        result
+      end
+
+      it 'doesn`t  change payment state' do
+        result
+
+        expect(payment.reload).to be_in_state('created')
+      end
+    end
+
     context 'when user response status is waiting_payment' do
       it { is_expected.to be_success }
 


### PR DESCRIPTION
### Descrição
Atualmente, por meio da Action GenerateBoleto e GeneratePix é possível gerar uma transação de um pagamento com o método diferente do seu tipo. A solução é criar uma condição para verificar se o método é valido.

### Referência
https://www.notion.so/catarse/Impedir-que-o-pix-ou-boleto-sejam-gerados-para-pagamentos-que-n-o-sejam-do-tipo-pix-ou-boleto-3ed635c540c94e4781

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
