### PR TITLE
✨ Corrige cálculo do valor mínimo possível para o parcelamento.

### DIFF
--- a/services/catarse/lib/billing/installment_simulator.rb
+++ b/services/catarse/lib/billing/installment_simulator.rb
@@ -7,7 +7,8 @@ module Billing
     def initialize
       @interest_rate = CatarseSettings.get_without_cache(:pagarme_interest_rate).to_f
       @max_installments = CatarseSettings.get_without_cache(:pagarme_max_installments).to_i
-      @minimum_value_for_installment = CatarseSettings.get_without_cache(:pagarme_minimum_value_for_installment).to_i
+      @minimum_value_for_installment =
+        CatarseSettings.get_without_cache(:pagarme_minimum_value_for_installment).to_i * 100
     end
 
     def calculate(amount)

--- a/services/catarse/spec/api/catarse/v2/billing/installment_simulations_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/billing/installment_simulations_api_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Catarse::V2::Billing::InstallmentSimulationsAPI, type: :api do
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_max_installments).and_return(6)
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_interest_rate).and_return(2.5)
       allow(CatarseSettings).to receive(:get_without_cache)
-        .with(:pagarme_minimum_value_for_installment).and_return(1500)
+        .with(:pagarme_minimum_value_for_installment).and_return(15)
     end
 
     context 'when the amount is greater than the minimum amount for installation' do

--- a/services/catarse/spec/lib/billing/installment_simulator_spec.rb
+++ b/services/catarse/spec/lib/billing/installment_simulator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Billing::InstallmentSimulator, type: :lib do
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_max_installments).and_return(max_installments)
       allow(CatarseSettings).to receive(:get_without_cache).with(:pagarme_interest_rate).and_return(interest_rate)
       allow(CatarseSettings).to receive(:get_without_cache)
-        .with(:pagarme_minimum_value_for_installment).and_return(1500)
+        .with(:pagarme_minimum_value_for_installment).and_return(15)
     end
 
     context 'when the amount is greater than the minimum amount for installation' do


### PR DESCRIPTION
### Descrição
Atualmente o valor minimo de parcelamento está em reais e devemos colocar em centavos para realizar os cálculos corretamente,

### Referência
https://www.notion.so/catarse/Corrigir-c-lculo-do-valor-m-nimo-poss-vel-para-parcelamento-a3467e34079449989cc1e5770d68aacb

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
