### PR TITLE
✨ Evita duplicação de cartão de crédito.

### DIFF
--- a/services/catarse/db/migrate/20210511113019_add_unique_index_for_billing_credit_cards.rb
+++ b/services/catarse/db/migrate/20210511113019_add_unique_index_for_billing_credit_cards.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexForBillingCreditCards < ActiveRecord::Migration[6.1]
+  def change
+    add_index :billing_credit_cards,
+      %i[user_id gateway gateway_id],
+      unique: true,
+      name: 'index_credit_card_user_gateway_gateway_id'
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/authorize_transaction_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/authorize_transaction_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
   describe '#call' do
     subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
 
-    let(:payment) { create(:billing_payment, :created) }
+    let(:payment) { create(:billing_payment, :created, :credit_card) }
     let(:pagar_me_client) { PagarMe::Client.new }
     let(:transaction_params) { PagarMe::TransactionParamsBuilder.new(payment: payment).build }
     let(:gateway_response) do
@@ -70,22 +70,84 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
 
           expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
         end
+      end
+    end
 
-        it 'creates credit card' do
-          result
-
-          expect(payment.credit_card.attributes).to include(
-            'user_id' => payment.user_id,
-            'gateway' => payment.gateway,
-            'gateway_id' => gateway_response.dig('card', 'id'),
-            'holder_name' => gateway_response.dig('card', 'holder_name'),
-            'bin' => gateway_response.dig('card', 'first_digits'),
-            'last_digits' => gateway_response.dig('card', 'last_digits'),
-            'country' => gateway_response.dig('card', 'country'),
-            'brand' => gateway_response.dig('card', 'brand'),
-            'expires_on' => Date.parse('2028-02-01')
+    context 'when credit card hasn`t been used by user before' do
+      before do
+        Billing::CreditCard.create(
+          attributes_for(:billing_credit_card).merge(
+            gateway: 'pagar_me',
+            user_id: create(:user).id,
+            gateway_id: gateway_response['card']['id']
           )
-        end
+        )
+      end
+
+      it 'creates credit card' do
+        expect { result }.to change(Billing::CreditCard, :count).by(1)
+      end
+
+      it 'assigns created credit card to payment' do
+        result
+
+        expect(payment.credit_card.attributes).to include(
+          'user_id' => payment.user_id,
+          'gateway' => payment.gateway,
+          'gateway_id' => gateway_response.dig('card', 'id'),
+          'holder_name' => gateway_response.dig('card', 'holder_name'),
+          'bin' => gateway_response.dig('card', 'first_digits'),
+          'last_digits' => gateway_response.dig('card', 'last_digits'),
+          'country' => gateway_response.dig('card', 'country'),
+          'brand' => gateway_response.dig('card', 'brand'),
+          'expires_on' => Date.parse('2028-02-01')
+        )
+      end
+    end
+
+    context 'when payment already has a credit card' do
+      let(:payment) { create(:billing_payment, :created, :with_credit_card) }
+
+      it 'doesn`t create credit card' do
+        expect { result }.not_to change(Billing::CreditCard, :count)
+      end
+
+      it 'doesn`t change payment credit card' do
+        expect { result }.not_to change(payment, :credit_card_id)
+      end
+    end
+
+    context 'when credit card has been used by user before' do
+      let!(:credit_card) do
+        Billing::CreditCard.create(
+          attributes_for(:billing_credit_card).merge(
+            user_id: payment.user_id,
+            gateway_id: gateway_response['card']['id'],
+            gateway: 'pagar_me'
+          )
+        )
+      end
+
+      before do
+        payment.update!(credit_card_id: nil)
+        Billing::CreditCard.create(
+          attributes_for(:billing_credit_card).merge(
+            gateway: 'pagar_me',
+            user_id: create(:user).id,
+            gateway_id: gateway_response['card']['id']
+          )
+        )
+        gateway_response['card']['id'] = credit_card.gateway_id
+      end
+
+      it 'doesn`t create credit card' do
+        expect { result }.not_to change(Billing::CreditCard, :count)
+      end
+
+      it 'assigns found credit card to payment' do
+        result
+
+        expect(payment.credit_card_id).to eq(credit_card.id)
       end
     end
 


### PR DESCRIPTION
### Descrição
Atualmente quando o card id da transação seja um que já exista na nossa base de dados nós salvamos ele novamente, a alteração evita a duplicação de cartão de créditos já salvos.

### Referência
https://www.notion.so/catarse/Evitar-duplica-o-de-cart-o-de-cr-ditos-113e6c18e7904115b062da23e9bd87de

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
