### PR TITLE
🐞 Adiciona i18n para evento de revert_balance_expired no saldo

### DIFF
--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.en.yml
@@ -41,6 +41,7 @@ en:
         balance_expired: Refund not required within 90 days. See <a target='__blank'
           href='https://suporte.catarse.me/hc/pt-br/articles/202365507-Regras-e-funcionamento-dos-reembolsos-estornos-cancelamentos#reembolso90dias'>our
           policy</a>
+        revert_balance_expired: Refund expirated balance
         contribution_refunded_after_successful_pledged: Project repayment %{project_name}
         subscription_payment_refunded: Project repayment %{project_name}
         balance_received_from: Transfer received from %{from_user_name}

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/show.pt.yml
@@ -39,6 +39,7 @@ pt:
         contribution_chargedback: 'Contestação de apoio para o projeto %{project_name}'
         subscription_payment_chargedback: 'Contestação de apoio para o projeto %{project_name}'
         balance_expired: "Reembolso não requisitado dentro do prazo de 90 dias. Consulte <a target='__blank' href='https://suporte.catarse.me/hc/pt-br/articles/202365507-Regras-e-funcionamento-dos-reembolsos-estornos-cancelamentos#reembolso90dias'>nossa política</a>"
+        revert_balance_expired: "Devolução de saldo expirado"
         contribution_refunded_after_successful_pledged: 'Reembolso do projeto %{project_name}'
         subscription_payment_refunded: 'Reembolso do projeto %{project_name}'
         balance_received_from: 'Transferência recebida de %{from_user_name}'


### PR DESCRIPTION
### Descrição
Adiciona i18n para evento de revert_balance_expired no saldo

### Referência
https://www.notion.so/catarse/Adicionar-i18n-para-evento-de-revert_balance_expired-no-saldo-8a731a235e59425fb21d0a063cbc5699

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
