### PR TITLE
✨ Valida integridade do valor no campo total_amount_cents

### DIFF
--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -32,12 +32,22 @@ module Billing
     validates :installments_count, numericality: { greater_than: 0 }, if: :credit_card?
     validates :installments_count, numericality: { equal_to: 1 }, unless: :credit_card?
 
+    validate :total_amount_represents_the_sum_of_amount_and_fees
+
     def lump_sum?
       installments_count == 1
     end
 
     def installment?
       installments_count > 1
+    end
+
+    private
+
+    def total_amount_represents_the_sum_of_amount_and_fees
+      return if total_amount_cents == (amount_cents + shipping_fee_cents + payment_method_fee_cents)
+
+      errors.add(:total_amount_cents, I18n.t('models.billing.payment.errors.invalid_total_amount'))
     end
   end
 end

--- a/services/catarse/config/locales/billing.en.yml
+++ b/services/catarse/config/locales/billing.en.yml
@@ -1,0 +1,6 @@
+en:
+  models:
+    billing:
+      payment:
+        errors:
+          invalid_total_amount: "doesn't match other values"

--- a/services/catarse/config/locales/billing.pt.yml
+++ b/services/catarse/config/locales/billing.pt.yml
@@ -1,0 +1,6 @@
+pt:
+  models:
+    billing:
+      payment:
+        errors:
+          invalid_total_amount: "incompatível com os outros valores"

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -55,5 +55,30 @@ RSpec.describe Billing::Payment, type: :model do
 
       it { is_expected.to validate_numericality_of(:installments_count).is_equal_to(1) }
     end
+
+    context 'when total amount cents represents sum of amount and fees' do
+      subject(:payment) do
+        described_class.new(total_amount: 50, amount: 20, shipping_fee: 20, payment_method_fee: 10)
+      end
+
+      it 'doesn`t add invalid_total_amount error' do
+        payment.valid?
+
+        expect(payment.errors[:total_amount_cents]).to be_empty
+      end
+    end
+
+    context 'when total amount cents doesn`t represent sum of amount and fees' do
+      subject(:payment) do
+        described_class.new(total_amount: 50, amount: 10, shipping_fee: 10, payment_method_fee: 10)
+      end
+
+      it 'adds invalid total amount error message' do
+        payment.valid?
+
+        error_message = I18n.t('models.billing.payment.errors.invalid_total_amount')
+        expect(payment.errors[:total_amount_cents]).to include error_message
+      end
+    end
   end
 end


### PR DESCRIPTION
### Descrição
É preciso adicionar uma validação ao pagamento garantindo que o total_amount é igual ao amount + shipping_fee + payment_method_fee. E se o valor estiver inválido, enviar uma mensagem de erro personalizada.

### Referência
https://www.notion.so/catarse/Validar-integridade-dos-valores-do-pagamento-69898e388f884b14acf38259f9c6d015

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
