### PR TITLE
Importa recebíveis e armazena custo do meio de pagamento

### DIFF
--- a/services/catarse/app/actions/billing/gateway_payables/import.rb
+++ b/services/catarse/app/actions/billing/gateway_payables/import.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Billing
+  module GatewayPayables
+    class Import < Actor
+      input :payment, type: Billing::Payment
+      input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
+
+      def call
+        payables_data = pagar_me_client.list_transaction_payables(payment.gateway_id)
+
+        if payables_data.size != payment.installments_count
+          fail!(error: 'Payables count doesn`t match payment installments count')
+        end
+
+        import_gateway_payables(payables_data)
+      end
+
+      def import_gateway_payables(payables_data)
+        gateway_payables = payables_data.map { |data| build_gateway_payable(data) }
+
+        ActiveRecord::Base.transaction { gateway_payables.each(&:save!) }
+      end
+
+      def build_gateway_payable(payable_data)
+        gateway_payable = payment.gateway_payables.find_or_initialize_by(gateway_id: payable_data['id'])
+        gateway_payable.assign_attributes(
+          state: payable_data['status'],
+          amount_cents: payable_data['amount'],
+          fee_cents: payable_data['fee'],
+          installment_number: payable_data['installment'],
+          paid_at: payable_data['payment_date'].try(:to_datetime),
+          data: payable_data
+        )
+        gateway_payable
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/billing/processing_fees/import_gateway_fee.rb
+++ b/services/catarse/app/actions/billing/processing_fees/import_gateway_fee.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Billing
+  module ProcessingFees
+    class ImportGatewayFee < Actor
+      input :payment, type: Billing::Payment
+      input :pagar_me_client, type: PagarMe::Client, default: -> { PagarMe::Client.new }
+
+      def call
+        import_gateway_payables!
+
+        transaction_data = pagar_me_client.find_transaction(payment.gateway_id)
+        processing_fee_amount_cents = calculate_processing_fee_amount(transaction_data['cost'])
+
+        payment.processing_fees.create!(
+          vendor: Billing::ProcessingFeeVendors::PAGAR_ME,
+          amount_cents: processing_fee_amount_cents
+        )
+      end
+
+      private
+
+      def import_gateway_payables!
+        result = Billing::GatewayPayables::Import.result(payment: payment)
+
+        fail!(error: 'Gateway payables cannot be imported') if result.failure?
+      end
+
+      def calculate_processing_fee_amount(transaction_cost_cents)
+        payables_fee_cents = payment.gateway_payables.sum(:fee_cents)
+
+        if payment.credit_card?
+          transaction_cost_cents + payables_fee_cents
+        elsif payment.boleto? || payment.pix?
+          payables_fee_cents.zero? ? transaction_cost_cents : payables_fee_cents
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/clients/pagar_me/client.rb
+++ b/services/catarse/app/clients/pagar_me/client.rb
@@ -6,6 +6,11 @@ module PagarMe
 
     base_uri 'https://api.pagar.me/1/'
 
+    def find_transaction(transaction_id)
+      response = self.class.get("/transactions/#{transaction_id}", body: { api_key: api_key })
+      response.parsed_response
+    end
+
     def create_transaction(transaction_params)
       # TODO: handler errors (Timeout, internal server error)
       response = self.class.post('/transactions', body: transaction_params.merge(api_key: api_key))

--- a/services/catarse/app/clients/pagar_me/client.rb
+++ b/services/catarse/app/clients/pagar_me/client.rb
@@ -34,6 +34,11 @@ module PagarMe
       response
     end
 
+    def list_transaction_payables(transaction_id)
+      response = self.class.get("/transactions/#{transaction_id}/payables", body: { api_key: api_key })
+      response.parsed_response
+    end
+
     private
 
     def api_key

--- a/services/catarse/app/models/billing/gateway_payable.rb
+++ b/services/catarse/app/models/billing/gateway_payable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Billing
+  class GatewayPayable < ApplicationRecord
+    belongs_to :payment, class_name: 'Billing::Payment'
+
+    monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
+    monetize :fee_cents, numericality: { greater_than_or_equal_to: 0 }
+
+    validates :payment_id, presence: true
+    validates :gateway_id, presence: true
+    validates :state, presence: true
+    validates :installment_number, presence: true
+
+    validates :gateway_id, uniqueness: { scope: :payment_id }
+  end
+end

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -15,6 +15,7 @@ module Billing
 
     has_many :items, class_name: 'Billing::PaymentItem', dependent: :destroy
     has_many :processing_fees, class_name: 'Billing::ProcessingFee', dependent: :destroy
+    has_many :gateway_payables, class_name: 'Billing::GatewayPayable', dependent: :destroy
 
     monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
     monetize :shipping_fee_cents, numericality: { greater_than_or_equal_to: 0 }

--- a/services/catarse/db/migrate/20210517143038_create_billing_gateway_payables.rb
+++ b/services/catarse/db/migrate/20210517143038_create_billing_gateway_payables.rb
@@ -1,0 +1,18 @@
+class CreateBillingGatewayPayables < ActiveRecord::Migration[6.1]
+  def change
+    create_table :billing_gateway_payables, id: :uuid do |t|
+      t.references :payment, null: false, foreign_key: { to_table: :billing_payments }, type: :uuid
+      t.string :gateway_id, null: false
+      t.string :state, null: false
+      t.monetize :amount
+      t.monetize :fee
+      t.integer :installment_number, null: false
+      t.datetime :paid_at
+      t.jsonb :data, default: {}
+
+      t.timestamps
+    end
+
+    add_index :billing_gateway_payables, %i[payment_id gateway_id], unique: true
+  end
+end

--- a/services/catarse/spec/actions/billing/gateway_payables/import_spec.rb
+++ b/services/catarse/spec/actions/billing/gateway_payables/import_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::GatewayPayables::Import, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to include(payment: { type: Billing::Payment }) }
+
+    it 'injects pagar_me_client dependency' do
+      proc = inputs.dig(:pagar_me_client, :default)
+
+      expect(proc.call).to be_an_instance_of(PagarMe::Client)
+    end
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
+
+    let(:payment) { create(:billing_payment, installments_count: 1) }
+    let(:pagar_me_client) { PagarMe::Client.new }
+
+    before do
+      allow(pagar_me_client).to receive(:list_transaction_payables)
+        .with(payment.gateway_id)
+        .and_return(gateway_response)
+    end
+
+    context 'when payables count is different from payment installments count' do
+      let(:payment) { create(:billing_payment, :credit_card, installments_count: 2) }
+      let(:gateway_response) { [{ foo: :bar }] }
+
+      it { is_expected.to be_failure }
+    end
+
+    context 'when payables count matches payment installments count' do
+      let(:gateway_response) { [payable_data] }
+      let(:payable_data) do
+        {
+          'id' => '123456',
+          'status' => 'waiting_funds',
+          'amount' => 5984,
+          'fee' => 155,
+          'installment' => 3,
+          'payment_date' => '2021-06-15T00:00:00.000Z'
+        }
+      end
+
+      it 'creates a new gateway payable' do
+        expect { result }.to change(payment.gateway_payables, :count).by(1)
+      end
+
+      it 'builds gateway payable from gateway response' do
+        result
+
+        gateway_payable = payment.gateway_payables.last
+
+        expect(gateway_payable.attributes).to include(
+          'gateway_id' => '123456',
+          'state' => 'waiting_funds',
+          'amount_cents' => 5984,
+          'fee_cents' => 155,
+          'installment_number' => 3,
+          'paid_at' => '2021-06-15'.to_datetime,
+          'data' => payable_data
+        )
+      end
+    end
+
+    context 'when payment has payable with same gateway id' do
+      let!(:gateway_payable) { create(:billing_gateway_payable, payment: payment, gateway_id: '0123') }
+      let(:gateway_response) { [payable_data] }
+      let(:payable_data) do
+        {
+          'id' => '0123',
+          'status' => 'waiting_funds',
+          'amount' => 200,
+          'fee' => 100,
+          'installment' => 9,
+          'payment_date' => '2021-01-01T00:00:00.000Z'
+        }
+      end
+
+      it 'doesn`t create a new gateway payable' do
+        expect { result }.not_to change(payment.gateway_payables, :count)
+      end
+
+      it 'updates gateway payable' do
+        result
+
+        expect(gateway_payable.reload.attributes).to include(
+          'gateway_id' => '0123',
+          'state' => 'waiting_funds',
+          'amount_cents' => 200,
+          'fee_cents' => 100,
+          'installment_number' => 9,
+          'paid_at' => '2021-01-01'.to_datetime,
+          'data' => payable_data
+        )
+      end
+    end
+
+    context 'when payable data is invalid' do
+      let(:gateway_response) { [payable_data] }
+      let(:payable_data) { { 'id' => '0123' } }
+
+      it 'raises error' do
+        expect { result }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/billing/processing_fees/import_gateway_fee_spec.rb
+++ b/services/catarse/spec/actions/billing/processing_fees/import_gateway_fee_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::ProcessingFees::ImportGatewayFee, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to include(payment: { type: Billing::Payment }) }
+
+    it 'injects pagar_me_client dependency' do
+      proc = inputs.dig(:pagar_me_client, :default)
+
+      expect(proc.call).to be_an_instance_of(PagarMe::Client)
+    end
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(payment: payment, pagar_me_client: pagar_me_client) }
+
+    let(:payment) { create(:billing_payment) }
+    let(:pagar_me_client) { PagarMe::Client.new }
+    let(:transaction_data) { { 'cost' => Faker::Number.number(digits: 3) } }
+
+    before do
+      allow(pagar_me_client).to receive(:find_transaction).with(payment.gateway_id).and_return(transaction_data)
+      allow(Billing::GatewayPayables::Import).to receive(:result)
+        .with(payment: payment)
+        .and_return(ServiceActor::Result.new(failure?: false))
+    end
+
+    context 'when payables import fails' do
+      before do
+        allow(Billing::GatewayPayables::Import).to receive(:result)
+          .with(payment: payment)
+          .and_return(ServiceActor::Result.new(failure?: true))
+      end
+
+      it { is_expected.to be_failure }
+    end
+
+    it 'creates a processing fee' do
+      gateway_fees = payment.processing_fees.where(vendor: Billing::ProcessingFeeVendors::PAGAR_ME)
+      expect { result }.to change(gateway_fees, :count).by(1)
+    end
+
+    context 'when payment is a credit card payment' do
+      let!(:gateway_payable_a) { create(:billing_gateway_payable, payment: payment) }
+      let!(:gateway_payable_b) { create(:billing_gateway_payable, payment: payment) }
+
+      before { payment.payment_method = Billing::PaymentMethods::CREDIT_CARD }
+
+      it 'assigns transaction cost + payables fee to processing fee' do
+        result
+
+        expected_amount = gateway_payable_a.fee_cents + gateway_payable_b.fee_cents + transaction_data['cost']
+        expect(payment.processing_fees.last.amount_cents).to eq expected_amount
+      end
+    end
+
+    context 'when payment is a pix payment with payables fee' do
+      let!(:gateway_payable_a) { create(:billing_gateway_payable, payment: payment) }
+      let!(:gateway_payable_b) { create(:billing_gateway_payable, payment: payment) }
+
+      before { payment.payment_method = Billing::PaymentMethods::PIX }
+
+      it 'assigns payables fee to processing fee' do
+        result
+
+        expected_amount = gateway_payable_a.fee_cents + gateway_payable_b.fee_cents
+        expect(payment.processing_fees.last.amount_cents).to eq expected_amount
+      end
+    end
+
+    context 'when payment is a pix payment without payables fee' do
+      before { payment.payment_method = Billing::PaymentMethods::PIX }
+
+      it 'assigns transaction cost to processing fee' do
+        result
+
+        expect(payment.processing_fees.last.amount_cents).to eq transaction_data['cost']
+      end
+    end
+
+    context 'when payment is a boleto payment with payables fee' do
+      let!(:gateway_payable_a) { create(:billing_gateway_payable, payment: payment) }
+      let!(:gateway_payable_b) { create(:billing_gateway_payable, payment: payment) }
+
+      before { payment.payment_method = Billing::PaymentMethods::BOLETO }
+
+      it 'assigns payables fee to processing fee' do
+        result
+
+        expected_amount = gateway_payable_a.fee_cents + gateway_payable_b.fee_cents
+        expect(payment.processing_fees.last.amount_cents).to eq expected_amount
+      end
+    end
+
+    context 'when payment is a boleto payment without payables fee' do
+      before { payment.payment_method = Billing::PaymentMethods::BOLETO }
+
+      it 'assigns transaction cost to processing fee' do
+        result
+
+        expect(payment.processing_fees.last.amount_cents).to eq transaction_data['cost']
+      end
+    end
+  end
+end

--- a/services/catarse/spec/clients/pagar_me/client_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/client_spec.rb
@@ -15,6 +15,23 @@ RSpec.describe PagarMe::Client, type: :client do
     end
   end
 
+  describe '#find_transaction' do
+    let(:transaction_id) { Faker::Lorem.word }
+    let(:request_response) { Hash[*Faker::Lorem.words(number: 4)].to_json }
+
+    before do
+      stub_request(:get, "#{described_class.base_uri}/transactions/#{transaction_id}")
+        .with(body: { api_key: api_key })
+        .to_return(body: request_response, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns transaction' do
+      response = client.find_transaction(transaction_id)
+
+      expect(response).to eq JSON.parse(request_response)
+    end
+  end
+
   describe '#create_transaction' do
     let(:transaction_params) { { key: 'value' } }
     let(:request_response) { Hash[*Faker::Lorem.words(number: 4)].to_json }

--- a/services/catarse/spec/clients/pagar_me/client_spec.rb
+++ b/services/catarse/spec/clients/pagar_me/client_spec.rb
@@ -115,4 +115,21 @@ RSpec.describe PagarMe::Client, type: :client do
       end
     end
   end
+
+  describe '#list_transaction_payables' do
+    let(:transaction_id) { Faker::Lorem.word }
+    let(:request_response) { Hash[*Faker::Lorem.words(number: 4)].to_json }
+
+    before do
+      stub_request(:get, "#{described_class.base_uri}/transactions/#{transaction_id}/payables")
+        .with(body: { api_key: api_key })
+        .to_return(body: request_response, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns transaction payables' do
+      response = client.list_transaction_payables(transaction_id)
+
+      expect(response).to eq JSON.parse(request_response)
+    end
+  end
 end

--- a/services/catarse/spec/factories/billing/gateway_payables_factories.rb
+++ b/services/catarse/spec/factories/billing/gateway_payables_factories.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billing_gateway_payable, class: 'Billing::GatewayPayable' do
+    association :payment, factory: :billing_payment
+    gateway_id { Faker::Internet.uuid }
+    state { Faker::Lorem.word }
+    amount { Faker::Number.number(digits: 4) }
+    fee { Faker::Number.number(digits: 3) }
+    installment_number { Faker::Number.number(digits: 1) }
+    paid_at { Faker::Time.backward(days: 30) }
+    data { Hash[*Faker::Lorem.words(number: 8)] }
+  end
+end

--- a/services/catarse/spec/factories/billing/processing_fees_factories.rb
+++ b/services/catarse/spec/factories/billing/processing_fees_factories.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :billing_processing_fee, class: 'Billing::ProcessingFee' do
     association :payment, factory: :billing_payment
-    amount { Faker::Number.number(digits: 4) }
+    amount { Faker::Number.number(digits: 3) }
     vendor { Billing::ProcessingFeeVendors.list.sample }
   end
 end

--- a/services/catarse/spec/models/billing/gateway_payable_spec.rb
+++ b/services/catarse/spec/models/billing/gateway_payable_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::GatewayPayable, type: :model do
+  describe 'Relations' do
+    it { is_expected.to belong_to(:payment).class_name('Billing::Payment') }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:payment_id) }
+    it { is_expected.to validate_presence_of(:gateway_id) }
+    it { is_expected.to validate_presence_of(:state) }
+    it { is_expected.to validate_presence_of(:installment_number) }
+
+    it do
+      gateway_payable = create(:billing_gateway_payable)
+      expect(gateway_payable).to validate_uniqueness_of(:gateway_id).scoped_to(:payment_id)
+    end
+
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
+    it { is_expected.to validate_numericality_of(:fee).is_greater_than_or_equal_to(0) }
+  end
+end

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Billing::Payment, type: :model do
 
     it { is_expected.to have_many(:items).class_name('Billing::PaymentItem').dependent(:destroy) }
     it { is_expected.to have_many(:processing_fees).class_name('Billing::ProcessingFee').dependent(:destroy) }
+    it { is_expected.to have_many(:gateway_payables).class_name('Billing::GatewayPayable').dependent(:destroy) }
   end
 
   describe 'Configurations' do


### PR DESCRIPTION
### Descrição
A atividade é sobre armazenar os custos de processamento do meio de pagamento, mas pra isso eu precisava importar os recebíveis, então dividi esse PR em 2 commits pra facilitar a revisão.
No primeiro commit eu crio o modelo dos recebíveis e crio uma action para importá-los. No segundo commit eu criei uma action para usar os recebíveis e calcular a taxa do meio de pagamento.

### Referência
https://www.notion.so/catarse/Implementar-taxas-do-gateway-89d77a7062af40ae828b0787ac07eee2

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
