### PR TITLE
✨ Atribui gateway na criação do pagamento.

### DIFF
--- a/services/catarse/app/actions/billing/payments/authorize_transaction.rb
+++ b/services/catarse/app/actions/billing/payments/authorize_transaction.rb
@@ -15,7 +15,7 @@ module Billing
 
         payment.transition_to!(next_state, response)
         credit_card = payment.credit_card || find_or_create_credit_card(response['card'])
-        payment.update!(gateway: 'pagar_me', gateway_id: response['id'], credit_card: credit_card)
+        payment.update!(gateway_id: response['id'], credit_card: credit_card)
       end
 
       private
@@ -42,7 +42,7 @@ module Billing
       end
 
       def find_credit_card(gateway_id)
-        Billing::CreditCard.find_by(gateway: 'pagar_me', gateway_id: gateway_id, user_id: payment.user_id)
+        Billing::CreditCard.find_by(gateway: payment.gateway, gateway_id: gateway_id, user_id: payment.user_id)
       end
 
       def create_credit_card(credit_card_data)
@@ -50,7 +50,7 @@ module Billing
 
         payment.create_credit_card!(
           user: payment.user,
-          gateway: 'pagar_me',
+          gateway: payment.gateway,
           gateway_id: credit_card_data['id'],
           holder_name: credit_card_data['holder_name'],
           bin: credit_card_data['first_digits'],

--- a/services/catarse/app/actions/billing/payments/generate_boleto.rb
+++ b/services/catarse/app/actions/billing/payments/generate_boleto.rb
@@ -15,7 +15,7 @@ module Billing
 
         if response['status'] == 'waiting_payment'
           payment.transition_to!(:waiting_payment, response)
-          payment.update!(gateway: 'pagar_me', gateway_id: response['id'])
+          payment.update!(gateway_id: response['id'])
           create_boleto(response)
         else
           handle_fatal_error('Invalid gateway request',

--- a/services/catarse/app/actions/billing/payments/generate_pix.rb
+++ b/services/catarse/app/actions/billing/payments/generate_pix.rb
@@ -15,7 +15,7 @@ module Billing
 
         if response['status'] == 'waiting_payment'
           payment.transition_to!(:waiting_payment, response)
-          payment.update!(gateway: 'pagar_me', gateway_id: response['id'])
+          payment.update!(gateway_id: response['id'])
           create_pix(response)
         else
           handle_fatal_error('Invalid gateway request',

--- a/services/catarse/app/api/catarse/v2/billing/payments_api.rb
+++ b/services/catarse/app/api/catarse/v2/billing/payments_api.rb
@@ -7,7 +7,6 @@ module Catarse
         params do
           requires :payment, type: Hash do
             requires :payment_method, type: String
-            requires :gateway, type: String
             requires :installments_count, type: Integer
 
             requires :billing_address_id, type: String

--- a/services/catarse/app/enumerations/billing/gateways.rb
+++ b/services/catarse/app/enumerations/billing/gateways.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Billing
+  class Gateways < EnumerateIt::Base
+    associate_values(:pagar_me)
+  end
+end

--- a/services/catarse/app/lib/billing/payment_builder.rb
+++ b/services/catarse/app/lib/billing/payment_builder.rb
@@ -21,7 +21,7 @@ module Billing
     def base_attributes
       replicate_addresses
       initial_state = Billing::PaymentStateMachine.initial_state
-      attributes.except(:payables).merge(state: initial_state)
+      attributes.except(:payables).merge(state: initial_state, gateway: Billing::Gateways::PAGAR_ME)
     end
 
     def replicate_addresses

--- a/services/catarse/app/models/billing/credit_card.rb
+++ b/services/catarse/app/models/billing/credit_card.rb
@@ -6,6 +6,8 @@ module Billing
 
     has_many :payments, class_name: 'Billing::Payment', dependent: :nullify
 
+    has_enumeration_for :gateway, with: Billing::Gateways, required: true, create_helpers: true
+
     validates :user_id, presence: true
     validates :gateway, presence: true
     validates :gateway_id, presence: true

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -22,6 +22,7 @@ module Billing
     monetize :total_amount_cents, numericality: { greater_than_or_equal_to: 1 }
 
     has_enumeration_for :payment_method, with: Billing::PaymentMethods, required: true, create_helpers: true
+    has_enumeration_for :gateway, with: Billing::Gateways, required: true, create_helpers: true
 
     validates :user_id, presence: true
     validates :billing_address_id, presence: true

--- a/services/catarse/config/locales/gateways.yml
+++ b/services/catarse/config/locales/gateways.yml
@@ -1,0 +1,4 @@
+en:
+  enumerations:
+    gateways:
+      pagar_me: 'Pagar.me'

--- a/services/catarse/spec/actions/billing/payments/authorize_transaction_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/authorize_transaction_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
           expect(payment.reload).to be_in_state(gateway_status)
         end
 
-        it 'updates payment gateway and gateway id' do
+        it 'updates payment gateway_id' do
           result
 
-          expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
+          expect(payment.reload.attributes).to include('gateway_id' => gateway_response['id'])
         end
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
       before do
         Billing::CreditCard.create(
           attributes_for(:billing_credit_card).merge(
-            gateway: 'pagar_me',
+            gateway: payment.gateway,
             user_id: create(:user).id,
             gateway_id: gateway_response['card']['id']
           )
@@ -123,7 +123,7 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
           attributes_for(:billing_credit_card).merge(
             user_id: payment.user_id,
             gateway_id: gateway_response['card']['id'],
-            gateway: 'pagar_me'
+            gateway: payment.gateway
           )
         )
       end
@@ -132,7 +132,7 @@ RSpec.describe Billing::Payments::AuthorizeTransaction, type: :action do
         payment.update!(credit_card_id: nil)
         Billing::CreditCard.create(
           attributes_for(:billing_credit_card).merge(
-            gateway: 'pagar_me',
+            gateway: payment.gateway,
             user_id: create(:user).id,
             gateway_id: gateway_response['card']['id']
           )

--- a/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
@@ -71,10 +71,10 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
         expect(payment.reload).to be_in_state('waiting_payment')
       end
 
-      it 'updates payment gateway and gateway_id' do
+      it 'updates payment gateway_id' do
         result
 
-        expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
+        expect(payment.reload.attributes).to include('gateway_id' => gateway_response['id'])
       end
 
       it 'creates a new boleto' do

--- a/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
         expect(payment.reload).to be_in_state('waiting_payment')
       end
 
-      it 'updates gateway and gateway_id' do
+      it 'updates payment gateway_id' do
         result
 
-        expect(payment.reload.attributes).to include('gateway' => 'pagar_me', 'gateway_id' => gateway_response['id'])
+        expect(payment.reload.attributes).to include('gateway_id' => gateway_response['id'])
       end
 
       it 'creates a new pix' do

--- a/services/catarse/spec/api/catarse/v2/billing/payments_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/billing/payments_api_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Catarse::V2::Billing::PaymentsAPI, type: :api do
     let(:payment_params) do
       {
         'payment_method' => payment.payment_method,
-        'gateway' => payment.gateway,
         'billing_address_id' => Faker::Internet.uuid,
         'installments_count' => Faker::Number.number(digits: 1),
         'payables' => [

--- a/services/catarse/spec/enumerations/billing/gateways_spec.rb
+++ b/services/catarse/spec/enumerations/billing/gateways_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Gateways, type: :enumeration do
+  describe '.list' do
+    subject { described_class.list }
+
+    it { is_expected.to include('pagar_me') }
+  end
+end

--- a/services/catarse/spec/factories/billing/credit_cards_factories.rb
+++ b/services/catarse/spec/factories/billing/credit_cards_factories.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :billing_credit_card, class: 'Billing::CreditCard' do
     association :user, factory: :user
-    gateway { Faker::Lorem.word }
+    gateway { Billing::Gateways.list.sample }
+
     gateway_id { Faker::Internet.uuid }
     holder_name { Faker::Name.name }
     bin { Faker::Business.credit_card_number.tr('-', '')[0..5] }

--- a/services/catarse/spec/factories/billing/payments_factories.rb
+++ b/services/catarse/spec/factories/billing/payments_factories.rb
@@ -8,10 +8,11 @@ FactoryBot.define do
     traits_for_enum :payment_method, Billing::PaymentMethods.list
     payment_method { Billing::PaymentMethods.list.sample }
 
+    gateway { Billing::Gateways.list.sample }
+
     traits_for_enum :state, Billing::PaymentStateMachine.states
     state { Billing::PaymentStateMachine.states.sample }
 
-    gateway { Faker::Lorem.word }
     gateway_id { Faker::Internet.uuid }
 
     credit_card_hash { Faker::Crypto.sha1 if credit_card? }

--- a/services/catarse/spec/lib/billing/payment_builder_spec.rb
+++ b/services/catarse/spec/lib/billing/payment_builder_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Billing::PaymentBuilder, type: :lib do
       expect(payment.state).to eq Billing::PaymentStateMachine.initial_state
     end
 
+    it 'assigns gateway' do
+      expect(payment.gateway).to eq Billing::Gateways::PAGAR_ME
+    end
+
     it 'assigns billing address replica' do
       replica = instance_double(Shared::Address, id: Faker::Internet.uuid)
       allow(Shared::AddressReplicator).to receive(:by_id).with(attributes[:billing_address_id]).and_return(replica)

--- a/services/catarse/spec/models/billing/credit_card_spec.rb
+++ b/services/catarse/spec/models/billing/credit_card_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Billing::CreditCard, type: :model do
     it { is_expected.to have_many(:payments).class_name('Billing::Payment').dependent(:nullify) }
   end
 
+  describe 'Configurations' do
+    it 'setups gateway with Billing::Gateways enum' do
+      expect(described_class.enumerations).to include(gateway: Billing::Gateways)
+    end
+  end
+
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:gateway) }

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Billing::Payment, type: :model do
     it 'setups payment_method with Billing::PaymentMethods enum' do
       expect(described_class.enumerations).to include(payment_method: Billing::PaymentMethods)
     end
+
+    it 'setups gateway with Billing::Gateways enum' do
+      expect(described_class.enumerations).to include(gateway: Billing::Gateways)
+    end
   end
 
   describe 'Validations' do


### PR DESCRIPTION
### Descrição
Adicionar o valor do gateway no momento da criação do pagamento. Atualmente esse valor do gateway não é fixo e é atualizado em diversos locais do código.

### Referência
https://www.notion.so/catarse/Atribuir-gateway-no-momento-da-cria-o-do-pagamento-e432104b27104de8a86c795b2ebe71ae

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
