### PR TITLE
✨ Adiciona funcionalidade de reembolso de assinatura

### DIFF
--- a/services/catarse/app/controllers/admin/subscription_payments_controller.rb
+++ b/services/catarse/app/controllers/admin/subscription_payments_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# This controller is only a wrapper to trigger chargeback 
-# on common wrapper
 class Admin::SubscriptionPaymentsController < Admin::BaseController
   layout 'catarse_bootstrap'
 
@@ -15,9 +13,29 @@ class Admin::SubscriptionPaymentsController < Admin::BaseController
     render json: { subscription_payment_ids: collection_for_chargeback.pluck(:id) }
   end
 
+  def refund
+    authorize Admin, :refund_subscription_payment?
+
+    begin
+      subscription_payment = SubscriptionPayment.find(refund_payment_params['payment_common_id'])
+      subscription_payment.refund
+
+      render json: { success: I18n.t("admin.refund_subscriptions.refund_success") }, status: :created
+    rescue => exception
+      Raven.capture_exception(exception)
+      render json: { errors: [exception.message] }, status: :unprocessable_entity
+    end
+  end
+
   protected
 
   def collection_for_chargeback
     @collection_for_chargeback ||= SubscriptionPayment.where("(gateway_general_data->>'gateway_id')::text in (?) and (gateway_general_data->>'gateway_id')::text is not null", params[:gateway_payment_ids])
+  end
+
+  private
+
+  def refund_payment_params
+    params.require(:refund_payment).permit(:payment_common_id)
   end
 end

--- a/services/catarse/app/models/concerns/subscription_payments/refund_handler.rb
+++ b/services/catarse/app/models/concerns/subscription_payments/refund_handler.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SubscriptionPayments
+  module RefundHandler
+    extend ActiveSupport::Concern
+
+    def refund
+      # Reembolsa no pagarMe
+      transaction = PagarMe::Transaction.find(gateway_general_data['gateway_id'])
+      transaction.refund if transaction.payment_method == 'credit_card' && transaction.status == 'paid'
+
+      remove_payment_user_balance
+
+      add_amount_subscriber_balance if transaction.payment_method == 'boleto'
+
+      update_payment_status
+    end
+
+    private
+
+    def remove_payment_user_balance
+      amount_to_remove = ((amount - (amount * project.service_fee)) * -1)
+      add_balance_transaction(user_id: project.user_id, amount: amount_to_remove)
+    end
+
+    def add_amount_subscriber_balance
+      add_balance_transaction(user_id: user.id, amount: amount)
+    end
+
+    def add_balance_transaction(user_id:, amount:)
+      return if refunded?(user_id: user_id)
+
+      BalanceTransaction.create(
+        user_id: user_id,
+        event_name: 'subscription_payment_refunded',
+        amount: amount,
+        subscription_payment_uuid: id,
+        project_id: project.id
+      )
+    end
+
+    def refunded?(user_id:)
+      BalanceTransaction.where(event_name: 'subscription_payment_refunded',
+                               subscription_payment_uuid: id, user_id: user_id
+                              ).present?
+    end
+
+    def update_payment_status
+      cw = CommonWrapper.new
+      cw.refund_subscription_payment(self)
+    end
+  end
+end

--- a/services/catarse/app/models/subscription_payment.rb
+++ b/services/catarse/app/models/subscription_payment.rb
@@ -2,6 +2,7 @@
 
 class SubscriptionPayment < ApplicationRecord
   include Shared::CommonWrapper
+  include SubscriptionPayments::RefundHandler
 
   self.table_name = 'common_schema.catalog_payments'
   self.primary_key = :id

--- a/services/catarse/app/policies/admin_policy.rb
+++ b/services/catarse/app/policies/admin_policy.rb
@@ -4,8 +4,12 @@ class AdminPolicy < ApplicationPolicy
   def access?
     is_admin?
   end
-  
+
   def batch_chargeback?
     is_admin? && user.admin_roles.pluck(:role_label).include?('balance')
+  end
+
+  def refund_subscription_payment?
+    is_admin? && user.admin_roles.pluck(:role_label).include?('refund_subscription')
   end
 end

--- a/services/catarse/catarse.js/legacy/src/c/admin-refund-subscription.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/admin-refund-subscription.tsx
@@ -1,0 +1,114 @@
+import m from 'mithril';
+import _ from 'underscore';
+import h from '../h';
+import { I18nText } from '../shared/components/i18n-text';
+import { ThisWindow } from '../entities';
+
+declare var window : ThisWindow
+
+const I18nScope = _.partial(h.i18nScope, 'admin.refund_subscriptions.view');
+
+const adminRefundSubscription = {
+    oninit: function(vnode) {
+        let payment = vnode.attrs.payment,
+            data = {};
+
+        let builder = { requestOptions: {
+                        url: (`admin/subscription_payments/refund`),
+                        method: 'POST'}
+                    };
+
+        const load = () => m.request(_.extend({}, { data }, builder.requestOptions)),
+              resp = h.RedrawStream('');
+
+        builder.requestOptions.config = (xhr) => {
+            if (h.authenticityToken()) {
+                xhr.setRequestHeader('X-CSRF-Token', h.authenticityToken());
+            }
+        };
+
+        const requestSuccess = (res) => {
+            resp(res.success);
+        };
+
+        const requestError = (err) => {
+            resp(err.errors[0]);
+        };
+
+        const submit = (e) => {
+            e.target.disabled = true;
+            e.target.innerHTML = window.I18n.t('wait', I18nScope());
+            data['refund_payment'] = { ['payment_common_id'] : payment.id };
+            load().then(requestSuccess, requestError);
+            return false;
+        };
+
+        const unload = () => {
+            resp('');
+        };
+
+        vnode.state = {
+            toggler: h.toggleProp(false, true),
+            submit,
+            resp,
+            unload,
+        };
+
+    },
+    view: function({state, attrs}) {
+        return (
+            <span>
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                <span class="alt-link" style="cursor: pointer" onclick={state.toggler.toggle}>
+                    <i class="fa fa-undo"></i>&nbsp;
+                    <I18nText scope="admin.refund_subscriptions.view.refund"/>
+                </span>
+                {state.toggler() &&
+                    <div class='dropdown-list card u-radius dropdown-list-medium zindex-10' onremove={state.unload}>
+                        { state.resp() ?
+                            <div name="response-refund-box">
+                                <div class="w-row">
+                                    <div class="w-col w-col-12">
+                                        { state.resp() }
+                                    </div>
+                                </div>
+                                <div class="w-row">
+                                    <div class="w-col w-col-12">
+                                        <button class="btn btn-small btn-terciary" onclick={state.toggler.toggle}>
+                                            <I18nText scope="admin.refund_subscriptions.view.close"/>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+
+                        :
+                            <div name="confirmation-refund-box">
+                                <div class="w-row">
+                                    <div class="w-col w-col-12">
+                                        <I18nText scope="admin.refund_subscriptions.view.confirm"/>
+                                    </div>
+                                </div>
+                                <div class="w-row">
+                                    <div class="w-col w-col-5">
+                                        <form class='w-form' onsubmit={(event : Event) => event.preventDefault()}>
+                                            <button onclick={state.submit} class="btn btn-small">
+                                                <I18nText scope="admin.refund_subscriptions.view.positive"/>
+                                            </button>
+                                        </form>
+                                    </div>
+                                    <div class="w-col w-col-offset-1 w-col-6">
+                                        <button class="btn btn-small btn-terciary" onclick={state.toggler.toggle}>
+                                            <I18nText scope="admin.refund_subscriptions.view.negative"/>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </span>
+        )
+    }
+};
+
+export default adminRefundSubscription;

--- a/services/catarse/catarse.js/legacy/src/c/admin-subscription-detail.js
+++ b/services/catarse/catarse.js/legacy/src/c/admin-subscription-detail.js
@@ -8,6 +8,7 @@ import {
 } from '../api';
 import h from '../h';
 import models from '../models';
+import adminRefundSubscription from './admin-refund-subscription';
 
 const adminSubscriptionDetail = {
     oninit: function(vnode) {
@@ -189,8 +190,9 @@ const adminSubscriptionDetail = {
                                 h.momentify(payment.created_at, 'DD/MM/YYYY HH:mm')
                                 )
                             ),
-                        m('.w-col.w-col-6',
+                        m('.w-col.w-col-6', [
                                 m(`span.${payment.selected() ? 'link-hidden-dark' : 'alt-link'}`, {
+                                    style: 'cursor:pointer;',
                                     onclick: () => {
                                         state.clearSelected(payments);
                                         payment.selected(true);
@@ -198,7 +200,11 @@ const adminSubscriptionDetail = {
                                     }
                                 },
                                     payment.status
+                                ),
+                                (payment.status === 'paid' && (
+                                    m(adminRefundSubscription, { payment })
                                 ))
+                        ])
                     ])),
                     m('.fontweight-semibold.fontsize-smaller.lineheight-tighter.u-marginbottom-20.u-margintop-20',
                       'Notificações'

--- a/services/catarse/config/locales/admin.pt.yml
+++ b/services/catarse/config/locales/admin.pt.yml
@@ -227,6 +227,15 @@ pt:
         current_balance: "Saldo atual"
         receiver_id: "Id do destinatário:"
         next_step: "Próximo passo"
+    refund_subscriptions:
+      refund_success: "Reembolso realizado com sucesso."
+      view:
+        refund: "Reembolsar"
+        confirm: "Deseja realmente reembolsar este pagamento?"
+        positive: "Sim"
+        negative: "Não"
+        close: "Fechar"
+        wait: "Aguarde..."
   channels:
     admin:
       <<: *admin

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -237,6 +237,7 @@ Catarse::Application.routes.draw do
         resources :subscription_payments do
           collection do
             post :batch_chargeback
+            post :refund
           end
         end
 

--- a/services/catarse/spec/controllers/admin/subscription_payments_controller_spec.rb
+++ b/services/catarse/spec/controllers/admin/subscription_payments_controller_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::SubscriptionPaymentsController, type: :controller do
+  let(:admin) { create(:user, admin: true) }
+  let(:current_user) { admin }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  describe 'POST refund_payment' do
+    context 'when user has admin roles and succeed' do
+      let(:payment_common_id) { SecureRandom.uuid }
+      let(:subscription_payment) { SubscriptionPayment.new(id: payment_common_id) }
+
+      before do
+        current_user.admin_roles.create(role_label: 'refund_subscription')
+
+        allow(SubscriptionPayment).to receive(:find).with(payment_common_id).and_return(subscription_payment)
+        allow(subscription_payment).to receive(:refund).and_return(true)
+
+        post :refund, params: { refund_payment: { payment_common_id: payment_common_id } }
+      end
+
+      it 'refunds subscription payment' do
+        expect(subscription_payment).to receive(:refund)
+
+        post :refund, params: { refund_payment: { payment_common_id: payment_common_id } }
+      end
+
+      it 'returns `created` http response' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns an success message' do
+        expect(response.body).to include(I18n.t('admin.refund_subscriptions.refund_success'))
+      end
+    end
+
+    context 'when user has admin roles and an error occurs' do
+      before do
+        current_user.admin_roles.create(role_label: 'refund_subscription')
+        post :refund, params: { refund_payment: { payment_common_id: SecureRandom.uuid } }
+      end
+
+      it 'returns `unprocessable_entity` http response' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns an error message' do
+        expect(response.body).to include('error')
+      end
+    end
+
+    context 'when user has not admin roles' do
+      before { post :refund, params: { refund_payment: { payment_common_id: SecureRandom.uuid } } }
+
+      it 'redirects' do
+        expect(response.code.to_i).to eq(302)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/models/subscription_payment_spec.rb
+++ b/services/catarse/spec/models/subscription_payment_spec.rb
@@ -3,5 +3,195 @@
 require 'rails_helper'
 
 RSpec.describe SubscriptionPayment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#refund' do
+    let(:gateway_id) { '123' }
+    let(:subscription_payment) { described_class.new(gateway_general_data: { gateway_id: gateway_id }) }
+    let(:transaction) { double(status: 'paid', refund: true, payment_method: 'credit_card') } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      allow(PagarMe::Transaction).to receive(:find).with(gateway_id).and_return(transaction)
+      allow(subscription_payment).to receive(:remove_payment_user_balance)
+      allow(subscription_payment).to receive(:add_amount_subscriber_balance)
+      allow(subscription_payment).to receive(:update_payment_status)
+    end
+
+    context 'when transaction is paid with credit_card as the payment_method' do
+      it 'refunds on pagarme' do
+        expect(transaction).to receive(:refund)
+
+        subscription_payment.refund
+      end
+    end
+
+    context 'when transaction isn`t paid with credit_card as the payment_method' do
+      before do
+        allow(transaction).to receive(:status).and_return('refunded')
+      end
+
+      it 'doesn`t refund on pagarme' do
+        expect(transaction).not_to receive(:refund)
+
+        subscription_payment.refund
+      end
+    end
+
+    context 'when transaction is paid with boleto as the payment_method' do
+      before { allow(transaction).to receive(:payment_method).and_return('boleto') }
+
+      it 'doesn`t refund on pagarme' do
+        expect(transaction).not_to receive(:refund)
+
+        subscription_payment.refund
+      end
+    end
+
+    it 'removes payment amount from user balance' do
+      expect(subscription_payment).to receive(:remove_payment_user_balance)
+
+      subscription_payment.refund
+    end
+
+    context 'when payment method is boleto' do
+      before { allow(transaction).to receive(:payment_method).and_return('boleto') }
+
+      it 'adds amount to subscriber balance' do
+        expect(subscription_payment).to receive(:add_amount_subscriber_balance)
+
+        subscription_payment.refund
+      end
+    end
+
+    context 'when payment method isn`t boleto' do
+      let(:transaction) { double(status: 'paid', refund: true, payment_method: 'pix') } # rubocop:disable RSpec/VerifiedDoubles
+
+      it 'doesn`t add amount to subscriber balance' do
+        expect(subscription_payment).not_to receive(:add_amount_subscriber_balance)
+
+        subscription_payment.refund
+      end
+    end
+
+    it 'updates payment status' do
+      expect(subscription_payment).to receive(:update_payment_status)
+
+      subscription_payment.refund
+    end
+  end
+
+  # Private functions
+
+  describe '#remove_payment_user_balance' do
+    let(:amount) { 100 }
+    let(:fee) { 0.13 }
+    let(:amount_to_remove) { ((amount - (amount * fee)) * -1) }
+    let(:project_user_id) { 456 }
+    let(:subscription_payment) do
+      described_class.new(project: Project.new(service_fee: fee, user_id: project_user_id))
+    end
+
+    before do
+      allow(subscription_payment).to receive(:amount).and_return(amount)
+      allow(subscription_payment).to receive(:add_balance_transaction)
+    end
+
+    it 'adds a transaction removing the amount from user`s balance' do
+      expect(subscription_payment).to receive(:add_balance_transaction)
+        .with(user_id: project_user_id, amount: amount_to_remove)
+
+      subscription_payment.send(:remove_payment_user_balance)
+    end
+  end
+
+  describe '#add_amount_subscriber_balance' do
+    let(:amount) { 100 }
+    let(:user_id) { 123 }
+    let(:subscription_payment) { described_class.new(user: User.new(id: user_id)) }
+
+    before do
+      allow(subscription_payment).to receive(:amount).and_return(amount)
+      allow(subscription_payment).to receive(:add_balance_transaction)
+    end
+
+    it 'adds a transaction adding the amount to subscriber balance' do
+      expect(subscription_payment).to receive(:add_balance_transaction).with(user_id: user_id, amount: amount)
+
+      subscription_payment.send(:add_amount_subscriber_balance)
+    end
+  end
+
+  describe '#add_balance_transaction' do
+    let(:amount) { 100 }
+    let(:user_id) { 123 }
+    let(:id) { SecureRandom.uuid }
+    let(:project) { Project.new }
+    let(:subscription_payment) { described_class.new(id: id, project: project) }
+
+    before do
+      allow(subscription_payment).to receive(:amount).and_return(amount)
+      allow(BalanceTransaction).to receive(:create)
+    end
+
+    context 'when it wasn`t refunded already' do
+      it 'adds a transaction adding the amount to subscriber balance' do
+        expect(BalanceTransaction).to receive(:create)
+          .with(user_id: user_id, event_name: 'subscription_payment_refunded',
+                amount: amount, subscription_payment_uuid: id, project_id: project.id
+               )
+
+        subscription_payment.send(:add_balance_transaction, user_id: user_id, amount: amount)
+      end
+    end
+
+    context 'when it was already refunded' do
+      before do
+        allow(BalanceTransaction).to receive(:where)
+          .with(event_name: 'subscription_payment_refunded', subscription_payment_uuid: id, user_id: user_id)
+          .and_return(true)
+      end
+
+      it 'doesn`t add a transaction adding the amount to subscriber balance' do
+        expect(BalanceTransaction).not_to receive(:create)
+
+        subscription_payment.send(:add_balance_transaction, user_id: user_id, amount: amount)
+      end
+    end
+  end
+
+  describe '#refunded?' do
+    let(:user) { create(:user) }
+    let(:id) { SecureRandom.uuid }
+    let(:subscription_payment) { described_class.new(id: id) }
+
+    context 'when it doesn`t have a refund transation' do
+      it 'returns false' do
+        expect(subscription_payment.send(:refunded?, user_id: user.id)).to be false
+      end
+    end
+
+    context 'when it has a refund transation' do
+      before do
+        create(:balance_transaction,
+          event_name: 'subscription_payment_refunded',
+          subscription_payment_uuid: id, user: user
+        )
+      end
+
+      it 'returns true' do
+        expect(subscription_payment.send(:refunded?, user_id: user.id)).to be true
+      end
+    end
+  end
+
+  describe '#update_payment_status' do
+    let(:subscription_payment) { described_class.new }
+    let(:common_wrapper) { double(refund_subscription_payment: true) } # rubocop:disable RSpec/VerifiedDoubles
+
+    before { allow(CommonWrapper).to receive(:new).and_return(common_wrapper) }
+
+    it 'updates the payment status' do
+      expect(common_wrapper).to receive(:refund_subscription_payment).with(subscription_payment)
+
+      subscription_payment.send(:update_payment_status)
+    end
+  end
 end


### PR DESCRIPTION
### Descrição
Funcionalidade implementada para diminuir a incidência de tickets e dar mais autonomia ao atendimento.
Adiciona um botão `Reembolsar` ao lado de pagamentos com status `paid` no admin de assinaturas.

### Referência
https://www.notion.so/catarse/Implementar-bot-o-no-admin-assinaturas-para-reembolsar-apoio-mensal-f0f03c43b30e4df98ab9699f13e39820

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
