### PR TITLE
🐞 Adiciona indice unico para o evento contribution_refunded_after_suc…

### DIFF
--- a/services/catarse/db/migrate/20210520110503_add_unique_index_for_contribution_refunded_after_successful_pledged.rb
+++ b/services/catarse/db/migrate/20210520110503_add_unique_index_for_contribution_refunded_after_successful_pledged.rb
@@ -1,0 +1,13 @@
+class AddUniqueIndexForContributionRefundedAfterSuccessfulPledged < ActiveRecord::Migration[6.1]
+  def up
+    execute %Q{
+      create unique index uidx_contrib_refunded_after_success_project on balance_transactions (event_name, contribution_id) where event_name = 'contribution_refunded_after_successful_pledged';
+    }
+  end
+
+  def down
+    execute %Q{
+      drop index if exists uidx_contrib_refunded_after_success_project;
+    }
+  end
+end


### PR DESCRIPTION
…cessful_pledged

### Descrição

Esse evento não tinha um indice unico na tabela de eventos do saldo, fazendo retentativas de reembolso adicionarem o evento mais de uma vez

### Referência
https://www.notion.so/catarse/Adicionar-indice-unico-no-evento-contribution_refunded_after_successful_pledged-do-saldo-8f0d30c4f74d4405a45d6b91b1b7207b

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
