### PR TITLE
🐞 Altera tipo e nome da coluna expires_at no boleto.

### DIFF
--- a/services/catarse/app/actions/billing/payments/generate_boleto.rb
+++ b/services/catarse/app/actions/billing/payments/generate_boleto.rb
@@ -38,7 +38,7 @@ module Billing
         payment.create_boleto!(
           barcode: response['boleto_barcode'],
           url: response['boleto_url'],
-          expires_at: response['boleto_expiration_date'].to_datetime
+          expires_on: response['boleto_expiration_date'].to_date
         )
       end
     end

--- a/services/catarse/app/models/billing/boleto.rb
+++ b/services/catarse/app/models/billing/boleto.rb
@@ -7,7 +7,6 @@ module Billing
     validates :payment_id, presence: true
     validates :barcode, presence: true
     validates :url, presence: true
-    # TODO: Check attribute type. Investigate if expires at is date or datetime
-    validates :expires_at, presence: true
+    validates :expires_on, presence: true
   end
 end

--- a/services/catarse/db/migrate/20210519164330_change_expires_at_billing_boletos.rb
+++ b/services/catarse/db/migrate/20210519164330_change_expires_at_billing_boletos.rb
@@ -1,0 +1,6 @@
+class ChangeExpiresAtBillingBoletos < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :billing_boletos, :expires_at, :expires_on
+    change_column :billing_boletos, :expires_on, :date
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_boleto_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Billing::Payments::GenerateBoleto, type: :action do
         expect(payment.boleto.attributes).to include(
           'barcode' => gateway_response['boleto_barcode'],
           'url' => gateway_response['boleto_url'],
-          'expires_at' => gateway_response['boleto_expiration_date'].to_datetime
+          'expires_on' => gateway_response['boleto_expiration_date'].to_date
         )
       end
     end

--- a/services/catarse/spec/factories/billing/boletos_factories.rb
+++ b/services/catarse/spec/factories/billing/boletos_factories.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     association :payment, factory: :billing_payment
     barcode { Faker::Barcode.isbn }
     url { Faker::Internet.url }
-    expires_at { Faker::Date.between(from: Time.zone.tomorrow, to: 10.days.from_now) }
+    expires_on { Faker::Date.between(from: Time.zone.tomorrow, to: 10.days.from_now).to_date }
   end
 end

--- a/services/catarse/spec/models/billing/boleto_spec.rb
+++ b/services/catarse/spec/models/billing/boleto_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe Billing::Boleto, type: :model do
     it { is_expected.to validate_presence_of(:payment_id) }
     it { is_expected.to validate_presence_of(:barcode) }
     it { is_expected.to validate_presence_of(:url) }
-    it { is_expected.to validate_presence_of(:expires_at) }
+    it { is_expected.to validate_presence_of(:expires_on) }
   end
 end


### PR DESCRIPTION
### Descrição
Atualmente o campo expires_at do boleto é datetime e deveria ser date e com isso podemos trocar o nome de expires_at para expires_on.

### Referência
https://www.notion.so/catarse/Alterar-tipo-do-expires_at-expira-o-do-boleto-d133c0440b904101a85b355dbee9d195

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
