### PR TITLE
✨ Valida usuário do pagamento é dono do cartão de crédito.

### DIFF
--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -35,6 +35,7 @@ module Billing
     validates :installments_count, numericality: { equal_to: 1 }, unless: :credit_card?
 
     validate :total_amount_represents_the_sum_of_amount_and_fees
+    validate :credit_card_owner_matches_user, if: :credit_card?
 
     def lump_sum?
       installments_count == 1
@@ -50,6 +51,12 @@ module Billing
       return if total_amount_cents == (amount_cents + shipping_fee_cents + payment_method_fee_cents)
 
       errors.add(:total_amount_cents, I18n.t('models.billing.payment.errors.invalid_total_amount'))
+    end
+
+    def credit_card_owner_matches_user
+      return if credit_card.blank? || user_id == credit_card.user_id
+
+      errors.add(:credit_card_id, I18n.t('models.billing.payment.errors.invalid_credit_card'))
     end
   end
 end

--- a/services/catarse/config/locales/billing.en.yml
+++ b/services/catarse/config/locales/billing.en.yml
@@ -4,3 +4,4 @@ en:
       payment:
         errors:
           invalid_total_amount: "doesn't match other values"
+          invalid_credit_card: "credit card owner doesn't match user"

--- a/services/catarse/config/locales/billing.pt.yml
+++ b/services/catarse/config/locales/billing.pt.yml
@@ -4,3 +4,4 @@ pt:
       payment:
         errors:
           invalid_total_amount: "incompatível com os outros valores"
+          invalid_credit_card: "usuário do cartão de credito não corresponde ao do pagamento"

--- a/services/catarse/spec/clients/konduto/params_builders/order_spec.rb
+++ b/services/catarse/spec/clients/konduto/params_builders/order_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Konduto::ParamsBuilders::Order, type: :params_builder do
   end
 
   describe '#build' do
-    let(:payment) { create(:billing_payment, :credit_card, credit_card: build(:billing_credit_card)) }
+    let(:payment) { create(:billing_payment, :with_credit_card) }
 
     it 'returns all attributes with corresponding methods results' do
       expect(params_builder.build).to eq(

--- a/services/catarse/spec/factories/billing/payments_factories.rb
+++ b/services/catarse/spec/factories/billing/payments_factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     trait :with_credit_card do
       payment_method { Billing::PaymentMethods::CREDIT_CARD }
-      association :credit_card, factory: :billing_credit_card
+      credit_card { association :billing_credit_card, user: user }
     end
 
     transient do

--- a/services/catarse/spec/queries/billing/credit_cards/safelist_query_spec.rb
+++ b/services/catarse/spec/queries/billing/credit_cards/safelist_query_spec.rb
@@ -6,20 +6,17 @@ RSpec.describe Billing::CreditCards::SafelistQuery, type: :query do
   subject(:query) { described_class.new }
 
   describe '#call' do
-    let(:paid_credit_card) { create(:billing_credit_card) }
+    let!(:payment) { create(:billing_payment, :paid, :with_credit_card) }
 
     before do
-      create(:billing_payment, :paid, credit_card: paid_credit_card)
-
       not_paid_states = Billing::PaymentStateMachine.states - ['paid']
       not_paid_states.each do |state|
-        credit_card = create(:billing_credit_card)
-        create(:billing_payment, state: state, credit_card: credit_card)
+        create(:billing_payment, :with_credit_card, state: state)
       end
     end
 
     it 'returns credit cards used on paid payments' do
-      expect(query.call).to eq [paid_credit_card]
+      expect(query.call).to eq [payment.credit_card]
     end
   end
 end


### PR DESCRIPTION
### Descrição
Atualmente, é possível que o pagamento seja processado com um id cartão de crédito que pertence a outro usuário. Foi criada então uma validação para esse caso.
 
### Referência
https://www.notion.so/catarse/Validar-que-usu-rio-do-pagamento-o-dono-do-cart-o-de-cr-dito-a5353d6b0452496385965d43bb1aa7ec

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
