### PR TITLE
🐞 Altera tipo e nome da coluna expires_at no pix.

### DIFF
--- a/services/catarse/app/actions/billing/payments/generate_pix.rb
+++ b/services/catarse/app/actions/billing/payments/generate_pix.rb
@@ -37,7 +37,7 @@ module Billing
       def create_pix(response)
         payment.create_pix!(
           key: response['pix_qr_code'],
-          expires_at: response['pix_expiration_date'].to_datetime
+          expires_on: response['pix_expiration_date'].to_date
         )
       end
     end

--- a/services/catarse/app/models/billing/pix.rb
+++ b/services/catarse/app/models/billing/pix.rb
@@ -6,6 +6,6 @@ module Billing
 
     validates :payment_id, presence: true
     validates :key, presence: true
-    validates :expires_at, presence: true
+    validates :expires_on, presence: true
   end
 end

--- a/services/catarse/db/migrate/20210519164335_change_expires_at_billing_pixes.rb
+++ b/services/catarse/db/migrate/20210519164335_change_expires_at_billing_pixes.rb
@@ -1,0 +1,6 @@
+class ChangeExpiresAtBillingPixes < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :billing_pixes, :expires_at, :expires_on
+    change_column :billing_pixes, :expires_on, :date
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/generate_pix_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Billing::Payments::GeneratePix, type: :action do
 
         expect(payment.reload.pix.attributes).to include(
           'key' => gateway_response['pix_qr_code'],
-          'expires_at' => gateway_response['pix_expiration_date'].to_datetime
+          'expires_on' => gateway_response['pix_expiration_date'].to_date
         )
       end
     end

--- a/services/catarse/spec/factories/billing/pix_factories.rb
+++ b/services/catarse/spec/factories/billing/pix_factories.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :billing_pix, class: 'Billing::Pix' do
     association :payment, factory: :billing_payment
     key { Faker::Lorem.paragraph }
-    expires_at { Faker::Date.between(from: Time.zone.tomorrow, to: 10.days.from_now) }
+    expires_on { Faker::Date.between(from: Time.zone.tomorrow, to: 10.days.from_now).to_date }
   end
 end

--- a/services/catarse/spec/models/billing/pix_spec.rb
+++ b/services/catarse/spec/models/billing/pix_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Billing::Pix, type: :model do
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:payment_id) }
     it { is_expected.to validate_presence_of(:key) }
-    it { is_expected.to validate_presence_of(:expires_at) }
+    it { is_expected.to validate_presence_of(:expires_on) }
   end
 end


### PR DESCRIPTION
### Descrição
Atualmente o campo expires_at do pix é datetime e deveria ser date e com isso podemos trocar o nome de expires_at para expires_on.

### Referência
https://www.notion.so/catarse/Alterar-tipo-do-expires_at-do-Pix-9c64fdf8347f4cc6974eab12bda91d83

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
