### PR TITLE
🐞 Ajusta o reembolso de boleto na ação de banir projeto.

### DIFF
--- a/services/catarse/app/actions/banish_project_action.rb
+++ b/services/catarse/app/actions/banish_project_action.rb
@@ -56,6 +56,7 @@ class BanishProjectAction
     @project.subscription_payments.where("data ->> 'payment_method' = 'boleto' ").find_each do |payment|
       if payment.status == 'paid'
         begin
+          cw = CommonWrapper.new
           balance_transaction_for_project_user(payment)
           # Remover saldo do apoiador de assinaturas
           BalanceTransaction.create!(
@@ -65,7 +66,7 @@ class BanishProjectAction
             subscription_payment_uuid: payment.id,
             project_id: payment.project.id
           ) if !BalanceTransaction.where(event_name: 'subscription_payment_refunded', subscription_payment_uuid: payment.id, user_id: payment.user.id).present?
-          payment.refund
+          cw.refund_subscription_payment(payment)
         rescue Exception => e
           Raven.capture_exception(e)
         end

--- a/services/catarse/app/models/common_wrapper.rb
+++ b/services/catarse/app/models/common_wrapper.rb
@@ -794,7 +794,26 @@ class CommonWrapper
       action: :post,
       current_ip: resource.user.current_sign_in_ip
     ).run
+    if response.success?
+      json = ActiveSupport::JSON.decode(response.body)
+      return json.try(:[], 'id')
+    else
+      Rails.logger.info(response.body)
+    end
+  end
 
+  def refund_subscription_payment(resource)
+    @api_key = common_api_key
+    uri = services_endpoint[:payment_service]
+    uri.path = '/rpc/refund_subscription_payment'
+    response = request(
+      uri.to_s,
+      body: {
+        id: resource.id
+      }.to_json,
+      action: :post,
+      current_ip: resource.user.current_sign_in_ip
+    ).run
     if response.success?
       json = ActiveSupport::JSON.decode(response.body)
       return json.try(:[], 'id')

--- a/services/catarse/db/migrate/20210520181911_subscription_index_adjustment.rb
+++ b/services/catarse/db/migrate/20210520181911_subscription_index_adjustment.rb
@@ -1,0 +1,14 @@
+class SubscriptionIndexAdjustment < ActiveRecord::Migration[6.1]
+  def up
+    execute %Q{
+      drop index idx_subscription_payment_refunded_evt_uniq;
+      create unique index idx_subscription_payment_refunded_evt_uniq on balance_transactions(event_name, subscription_payment_uuid, user_id) where event_name = 'subscription_payment_refunded';
+    }
+  end
+
+  def down
+    execute %Q{
+      drop index idx_subscription_payment_refunded_evt_uniq;
+    }
+  end
+end

--- a/services/common/src/SUMMARY.md
+++ b/services/common/src/SUMMARY.md
@@ -55,6 +55,7 @@
         - [Edit / Upgrade subscription](./http_payments_rpc_upgrade_subscription.md)
         - [Recharge subscription (Oneclick charge)](./http_payments_rpc_recharge_subscription.md)
         - [Canceling a subscription](./http_payments_rpc_cancel_subscription.md)
+        - [Refunding a subscription](./http_payments_rpc_refund_subscription_payment.md)
         - [List payments](./http_payments_payments.md)
         - [List subscriptions](./http_payments_subscriptions.md)
         - [List subscriptions status transitions](./http_payments_subscription_status_transitions.md)

--- a/services/service-core-db/migrations/2021-03-03-124757_add_refund_subscription_payment_to_payment_service_api/down.sql
+++ b/services/service-core-db/migrations/2021-03-03-124757_add_refund_subscription_payment_to_payment_service_api/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+drop function payment_service_api.refund_subscription_payment(uuid);

--- a/services/service-core-db/migrations/2021-03-03-124757_add_refund_subscription_payment_to_payment_service_api/up.sql
+++ b/services/service-core-db/migrations/2021-03-03-124757_add_refund_subscription_payment_to_payment_service_api/up.sql
@@ -1,0 +1,30 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION payment_service_api.refund_subscription_payment(id uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _catalog_payment payment_service.catalog_payments;
+            _result json;
+        begin
+            -- ensure that roles come from any permitted
+            perform core.force_any_of_roles('{platform_user}');
+
+            select * from payment_service.catalog_payments cp
+                where cp.id = $1 and cp.platform_id = core.current_platform_id()
+                into _catalog_payment;
+
+            if _catalog_payment.id is null then
+                raise 'catalog payment not found';
+            end if;
+
+            -- change subscription status to refunded
+            perform payment_service.transition_to(_catalog_payment, 'refunded', row_to_json(_catalog_payment.*));
+
+            select json_build_object(
+            'id', _catalog_payment.id,
+            'status', _catalog_payment.status
+            ) into _result;
+            return _result;
+        end;
+    $function$;


### PR DESCRIPTION
### Descrição
Corrigir Erro no QA:
A migration estava com o valor duplicado, fiz uma nova atualização.

Precisamos implementar a chamada de reembolso do comum no catarse. Atualmente essa chamada não existe e não altera o status do pagamento. 

### Referência
https://www.notion.so/catarse/Ajustar-a-o-de-banir-projetos-em-reembolso-de-boleto-61ddebd92da7425d80c2f7f8d8681833

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
