### PR TITLE
💚 Garante o mesmo usuário para o pagamento e para o cartão de crédito.

### DIFF
--- a/services/catarse/spec/clients/konduto/params_builders/payment_spec.rb
+++ b/services/catarse/spec/clients/konduto/params_builders/payment_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Konduto::ParamsBuilders::Payment, type: :params_builder do
   end
 
   describe '#build' do
-    let(:payment) { create(:billing_payment, credit_card: build(:billing_credit_card)) }
+    let(:payment) { create(:billing_payment, :with_credit_card) }
 
     it 'returns all attributes with corresponding methods results' do
       expect(params_builder.build).to eq(


### PR DESCRIPTION
### Descrição
Temos uma validação credit_card_owner_matches_user, mas em casos onde não temos o credit_card como método de pagamento, essa validação não ocorre. Alguns testes quebram e para isso, devemos passar o método de pagamento. 

### Referência
https://www.notion.so/catarse/Garante-o-mesmo-usu-rio-para-o-pagamento-e-para-o-cart-o-de-cr-dito-8485af9a850e467fb793c82d27fc2454

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
