### PR TITLE
✨ Cria rotina para expirar pagamentos do pix e boleto.

### DIFF
--- a/services/catarse/app/actions/billing/payments/expire.rb
+++ b/services/catarse/app/actions/billing/payments/expire.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class Expire < Actor
+      input :payment, type: Billing::Payment
+      input :metadata, type: Hash, default: {}
+
+      def call
+        fail!(error: 'Payment cannot transition to overdue') unless payment.can_transition_to?(:overdue)
+
+        ActiveRecord::Base.transaction do
+          payment.transition_to!(:overdue, metadata)
+          payment.items.each { |i| i.transition_to!(:canceled) }
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/billing/payments/expire_overdue_payments.rb
+++ b/services/catarse/app/actions/billing/payments/expire_overdue_payments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class ExpireOverduePayments < Actor
+      def call
+        Billing::Payment.can_be_expired.find_each do |payment|
+          payment.expire!
+        rescue StandardError => e
+          Sentry.capture_exception(e, level: :fatal, extra: { payment_id: payment.id })
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -38,7 +38,9 @@ module Billing
     validate :credit_card_owner_matches_user, if: :credit_card?
 
     delegate :wait_payment!, :authorize!, :settle!, :refuse!, :approve_on_antifraud!, :decline_on_antifraud!,
-      :wait_review!, :refund!, :chargeback!, to: :state_machine
+      :wait_review!, :refund!, :chargeback!, :expire!, to: :state_machine
+
+    scope :can_be_expired, Billing::Payments::CanBeExpiredQuery
 
     def lump_sum?
       installments_count == 1

--- a/services/catarse/app/queries/billing/payments/can_be_expired_query.rb
+++ b/services/catarse/app/queries/billing/payments/can_be_expired_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Billing
+  module Payments
+    class CanBeExpiredQuery
+      attr_reader :relation
+
+      class << self
+        delegate :call, to: :new
+      end
+
+      def initialize(relation = Billing::Payment)
+        @relation = relation
+      end
+
+      def call
+        relation
+          .in_state(:waiting_payment)
+          .left_joins(:pix)
+          .left_joins(:boleto)
+          .where(payment_method: Billing::PaymentMethods.values_for(%w[BOLETO PIX]))
+          .where('COALESCE(billing_pixes.expires_on, billing_boletos.expires_on) < ?', Time.zone.today)
+      end
+    end
+  end
+end

--- a/services/catarse/app/state_machines/billing/payment_state_machine.rb
+++ b/services/catarse/app/state_machines/billing/payment_state_machine.rb
@@ -31,6 +31,7 @@ module Billing
     state :charged_back
 
     transition from: :created, to: %i[waiting_payment authorized refused]
+    transition from: :waiting_payment, to: %i[paid overdue]
     transition from: :authorized, to: %i[approved_on_antifraud declined_on_antifraud waiting_review paid]
     transition from: :waiting_review, to: %i[paid refused]
     transition from: :paid, to: %i[charged_back refunded]
@@ -73,6 +74,10 @@ module Billing
 
     def chargeback!(metadata = {})
       Billing::Payments::Chargeback.call(payment: object, metadata: metadata)
+    end
+
+    def expire!(metadata = {})
+      Billing::Payments::Expire.call(payment: object, metadata: metadata)
     end
   end
 end

--- a/services/catarse/spec/actions/billing/payments/expire_overdue_payments_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/expire_overdue_payments_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Payments::ExpireOverduePayments, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result }
+
+    let(:scope) { instance_double(ActiveRecord::Relation) }
+    let(:payment_a) { Billing::Payment.new }
+    let(:payment_b) { Billing::Payment.new }
+
+    before do
+      allow(Billing::Payment).to receive(:can_be_expired).and_return(scope)
+      allow(scope).to receive(:find_each).and_yield(payment_b).and_yield(payment_a)
+    end
+
+    it { is_expected.to be_success }
+
+    it 'expires overdue payments' do
+      expect([payment_a, payment_b]).to all(receive(:expire!))
+
+      result
+    end
+
+    context 'when payment expiration raise error' do
+      let(:error) { StandardError.new('some error') }
+
+      before do
+        allow(payment_a).to receive(:expire!).and_raise(error)
+        allow(payment_b).to receive(:expire!)
+      end
+
+      it 'handles error with Sentry' do
+        expect(Sentry).to receive(:capture_exception).with(
+          error,
+          level: :fatal,
+          extra: { payment_id: payment_a.id }
+        )
+
+        result
+      end
+
+      it 'doesn`t stop execution' do
+        expect(payment_b).to receive(:expire!)
+
+        result
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/billing/payments/expire_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/expire_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Payments::Expire, type: :action do
+  describe 'Inputs' do
+    subject(:inputs) { described_class.inputs }
+
+    it { is_expected.to include(payment: { type: Billing::Payment }) }
+
+    it 'includes metadata with a empty hash as default value' do
+      expect(inputs.dig(:metadata, :default)).to eq({})
+    end
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(payment: payment, metadata: { data: 'example' }) }
+
+    let(:payment) { create(:billing_payment, :waiting_payment) }
+
+    context 'when payment state cannot transition to overdue' do
+      before { allow(payment).to receive(:can_transition_to?).with(:overdue).and_return(false) }
+
+      it { is_expected.to be_failure }
+
+      it 'returns error message' do
+        expect(result.error).to eq 'Payment cannot transition to overdue'
+      end
+
+      it 'doesn`t transition payment state' do
+        result
+
+        expect(payment.reload).to be_in_state(:waiting_payment)
+      end
+    end
+
+    context 'when payment state can transition to overdue' do
+      it { is_expected.to be_success }
+
+      it 'transitions payment state to overdue' do
+        result
+
+        expect(payment.reload).to be_in_state(:overdue)
+      end
+
+      it 'transitions payment items state to canceled' do
+        result
+
+        expect(payment.reload.items).to all(be_in_state(:canceled))
+      end
+    end
+
+    context 'when state transition cannot be done' do
+      before { payment.items << create(:billing_payment_item, :refunded) }
+
+      it 'rollbacks transaction' do
+        begin
+          result
+        rescue Statesman::TransitionFailedError
+          # does nothing
+        end
+
+        expect(payment.reload).to be_in_state(:waiting_payment)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/factories/billing/payments_factories.rb
+++ b/services/catarse/spec/factories/billing/payments_factories.rb
@@ -34,6 +34,16 @@ FactoryBot.define do
       credit_card { association :billing_credit_card, user: user }
     end
 
+    trait :with_boleto do
+      payment_method { Billing::PaymentMethods::BOLETO }
+      boleto { association :billing_boleto }
+    end
+
+    trait :with_pix do
+      payment_method { Billing::PaymentMethods::PIX }
+      pix { association :billing_pix }
+    end
+
     transient do
       payment_items do
         build_list(:billing_payment_item, 2, payment: nil)

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Billing::Payment, type: :model do
   describe 'Delegations' do
     %i[
       wait_payment! authorize! settle! refuse! approve_on_antifraud! decline_on_antifraud! wait_review! refund!
-      chargeback!
+      chargeback! expire!
     ].each do |method|
       it { is_expected.to delegate_method(method).to(:state_machine) }
     end

--- a/services/catarse/spec/queries/billing/payments/can_be_expired_query_spec.rb
+++ b/services/catarse/spec/queries/billing/payments/can_be_expired_query_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Billing::Payments::CanBeExpiredQuery, type: :query do
+  subject(:query) { described_class.new }
+
+  describe '#call' do
+    let!(:payment_with_pix) { create(:billing_payment, :with_pix, :waiting_payment) }
+    let!(:payment_with_boleto) { create(:billing_payment, :with_boleto, :waiting_payment) }
+
+    before do
+      payment_with_boleto.boleto.update!(expires_on: '2021-01-01')
+      payment_with_pix.pix.update!(expires_on: '2021-01-01')
+
+      Billing::PaymentStateMachine.states.each do |state|
+        create(:billing_payment, :with_boleto, state: state)
+        create(:billing_payment, :with_pix, state: state)
+        create(:billing_payment, :with_credit_card, state: state)
+      end
+    end
+
+    it 'returns payments that can be expired' do
+      expect(query.call).to eq [payment_with_pix, payment_with_boleto]
+    end
+  end
+end

--- a/services/catarse/spec/state_machines/billing/payment_state_machine_spec.rb
+++ b/services/catarse/spec/state_machines/billing/payment_state_machine_spec.rb
@@ -115,6 +115,18 @@ RSpec.describe Billing::PaymentStateMachine, type: :state_machine do
     end
   end
 
+  context 'when state is waiting_payment' do
+    let(:payment) { create(:billing_payment, :waiting_payment) }
+
+    it 'allows transition to paid' do
+      expect { payment.transition_to!(:paid) }.not_to raise_error
+    end
+
+    it 'allows transition to overdue' do
+      expect { payment.transition_to!(:overdue) }.not_to raise_error
+    end
+  end
+
   context 'when state is authorized' do
     let(:payment) { create(:billing_payment, :authorized) }
 
@@ -255,6 +267,16 @@ RSpec.describe Billing::PaymentStateMachine, type: :state_machine do
       expect(Billing::Payments::Chargeback).to receive(:call).with(payment: state_machine.object, metadata: {})
 
       state_machine.chargeback!
+    end
+  end
+
+  describe '#expire!' do
+    subject(:state_machine) { create(:billing_payment, :waiting_payment).state_machine }
+
+    it 'calls Billing::Payments::Expire action' do
+      expect(Billing::Payments::Expire).to receive(:call).with(payment: state_machine.object, metadata: {})
+
+      state_machine.expire!
     end
   end
 end


### PR DESCRIPTION
### Descrição
É necessário criar uma rotina para verificar capturar pagamentos em boleto ou pix que estão com a data de expiração vencida e alterar o estado do pagamento. 

### Referência
https://www.notion.so/catarse/Criar-rotina-para-expirar-pagamentos-de-boleto-e-pix-3ad9a87b2f6c483abfd9da5cf3805c35

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
