### PR TITLE
🐞 Altera para nome público as chamadas dos emails automáticos

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/answer_survey.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/answer_survey.html.slim
@@ -5,8 +5,8 @@
 
 
 h2 style="text-align:center; line-height: 45px;"
-  - if contribution.user.name
-    |Olá, <strong>#{contribution.user.name}</strong>!
+  - if contribution.user.display_name
+    |Olá, <strong>#{contribution.user.display_name}</strong>!
   - else
     |Olá!
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/categorized_projects_of_the_week.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/categorized_projects_of_the_week.html.slim
@@ -1,7 +1,7 @@
 - user = @notification.user
 - category = @notification.category
 
-| Olá #{user.name},
+| Olá #{user.display_name},
 br/
 br/
 | Novidades dessa semana na categoria #{category.name_pt} do Catarse

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_contribution.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_contribution.html.slim
@@ -4,8 +4,8 @@
 - first_contribution = (total_contributors == 1)
 
 h2 style="text-align:center; line-height: 45px;"
-  - if contribution.user.name
-    | Olá, <strong>#{contribution.user.name}</strong>!
+  - if contribution.user.display_name
+    | Olá, <strong>#{contribution.user.display_name}</strong>!
   - else
     | Olá!
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_successful.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_successful.html.slim
@@ -1,8 +1,8 @@
 - contribution ||= @notification.contribution
 
 h2 style="text-align:center; line-height: 45px;"
-  - if contribution.user.name
-    |Olá, <strong>#{contribution.user.name}</strong>!
+  - if contribution.user.display_name
+    |Olá, <strong>#{contribution.user.display_name}</strong>!
   - else
     |Olá!
   br/

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_refund.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_refund.html.slim
@@ -2,7 +2,7 @@
 - bank_account = contribution.user.bank_account
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
-|Olá, #{contribution.user.name}!
+|Olá, #{contribution.user.display_name}!
 p O seu reembolso não foi efetuado devido a algum erro em seus dados bancários preenchidos:
 p
   |Banco: #{bank_account.try(:bank).to_s}

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/missing_contribution_address.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/missing_contribution_address.html.slim
@@ -3,7 +3,7 @@
 - contribution = @notification.contribution
 - project = contribution.project
 
-| Oi #{user.name},
+| Oi #{user.display_name},
 br/
 br/
 | Vimos que você fez uma contribuição aqui no #{company_name} para o projeto #{project.name} e que o seu apoio já foi confirmado no sistema. Apesar disso, notamos que <strong>você não informou todos seus dados</strong> no momento do apoio. O preenchimento do <strong>nome</strong>, <strong>CPF</strong> e do <strong>endereço completo (!)</strong> é fundamental para garantir a <strong>segurança do apoio, o controle do realizador</strong> e a <strong>entrega de recompensas.</strong>
@@ -11,7 +11,7 @@ br/
 br/
 | Para corrigir isso o quanto antes, pedimos que você entre no &nbsp;
 = link_to 'seu perfil', edit_user_url(user.id, anchor: 'settings'), target: '__blank'
-| &nbsp; e complete os dados que estiverem faltando. Depois de preencher os seus dados, não esqueça de clicar em <strong>Salvar!</strong> 
+| &nbsp; e complete os dados que estiverem faltando. Depois de preencher os seus dados, não esqueça de clicar em <strong>Salvar!</strong>
 br/
 br/
 = image_tag 'https://s3.amazonaws.com/catarse.files/user_settings.gif', width: 550

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_registration.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_registration.html.slim
@@ -2,8 +2,8 @@
 
 h2 style="text-align:center; line-height: 45px;"
   | Olá
-  - if user.name
-    | , #{user.name}!
+  - if user.display_name
+    | , #{user.display_name}!
   br/
   | Bem-vindo(a) ao Catarse!
 br/
@@ -14,7 +14,7 @@ br/
 | Nós, da equipe do Catarse, estamos diariamente trabalhando para criar e manter o ambiente mais seguro e confortável possível para toda a Comunidade.  E é por isso que, antes de apoiar ou publicar um projeto, é fundamental entender como funciona a plataforma, quais so os papéis de cada um e qual a dinâmica para que o financiamento coletivo seja uma boa experiência para todos!  #{link_to 'Clique aqui', 'https://crowdfunding.catarse.me/paratodos'} para conhecer mais sobre como funciona a plataforma e #{link_to 'aqui', 'http://suporte.catarse.me/hc/pt-br/articles/115002214043-Responsabilidades-e-Seguran%C3%A7a'} para saber mais sobre as Responsabilidades e Segurança dentro do Catarse.
 br/
 br/
-|Só para você não se esquecer, o seu email de acesso é: #{user.email} 
+|Só para você não se esquecer, o seu email de acesso é: #{user.email}
 br/
 br
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/pending_payment.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/pending_payment.html.slim
@@ -1,7 +1,7 @@
 - contribution = @notification.contribution
 
-- if contribution.user.name
-  |Olá, <strong>#{contribution.user.name}</strong>!
+- if contribution.user.display_name
+  |Olá, <strong>#{contribution.user.display_name}</strong>!
 - else
   |Olá!
 br


### PR DESCRIPTION
### Descrição
Pessoas trans têm recebido e-mails com seu nome de batismo (nome de usuário) e não com o seu nome social (nome público), o que gera constrangimento. Esta alteração coloca o nome público nas chamadas dos e-mails automáticos, para o bem-estar de tod@ e qualquer usuári@ do Catarse.

### Referência
https://www.notion.so/catarse/Alterar-nome-de-usu-rio-para-nome-p-blico-nos-e-mails-autom-ticos-6b69913f257a4e95b90a6511c692b50b

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
