### PR TITLE
💚 Renomeia state overdue para expired

### DIFF
--- a/services/catarse/app/actions/billing/payments/expire.rb
+++ b/services/catarse/app/actions/billing/payments/expire.rb
@@ -7,10 +7,10 @@ module Billing
       input :metadata, type: Hash, default: {}
 
       def call
-        fail!(error: 'Payment cannot transition to overdue') unless payment.can_transition_to?(:overdue)
+        fail!(error: 'Payment cannot transition to expired') unless payment.can_transition_to?(:expired)
 
         ActiveRecord::Base.transaction do
-          payment.transition_to!(:overdue, metadata)
+          payment.transition_to!(:expired, metadata)
           payment.items.each { |i| i.transition_to!(:canceled) }
         end
       end

--- a/services/catarse/app/actions/billing/payments/expire_overdue_payments.rb
+++ b/services/catarse/app/actions/billing/payments/expire_overdue_payments.rb
@@ -4,7 +4,7 @@ module Billing
   module Payments
     class ExpireOverduePayments < Actor
       def call
-        Billing::Payment.can_be_expired.find_each do |payment|
+        Billing::Payment.overdue.find_each do |payment|
           payment.expire!
         rescue StandardError => e
           Sentry.capture_exception(e, level: :fatal, extra: { payment_id: payment.id })

--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -40,7 +40,7 @@ module Billing
     delegate :wait_payment!, :authorize!, :settle!, :refuse!, :approve_on_antifraud!, :decline_on_antifraud!,
       :wait_review!, :refund!, :chargeback!, :expire!, to: :state_machine
 
-    scope :can_be_expired, Billing::Payments::CanBeExpiredQuery
+    scope :overdue, Billing::Payments::OverdueQuery
 
     def lump_sum?
       installments_count == 1

--- a/services/catarse/app/queries/billing/payments/overdue_query.rb
+++ b/services/catarse/app/queries/billing/payments/overdue_query.rb
@@ -2,7 +2,7 @@
 
 module Billing
   module Payments
-    class CanBeExpiredQuery
+    class OverdueQuery
       attr_reader :relation
 
       class << self

--- a/services/catarse/app/state_machines/billing/payment_state_machine.rb
+++ b/services/catarse/app/state_machines/billing/payment_state_machine.rb
@@ -12,7 +12,7 @@ module Billing
       declined_on_antifraud: :pending,
       waiting_review: :pending,
       paid: :paid,
-      overdue: :canceled,
+      expired: :canceled,
       refused: :canceled,
       refunded: :refunded,
       charged_back: :charged_back
@@ -25,13 +25,13 @@ module Billing
     state :declined_on_antifraud
     state :waiting_review
     state :paid
-    state :overdue
+    state :expired
     state :refused
     state :refunded
     state :charged_back
 
     transition from: :created, to: %i[waiting_payment authorized refused]
-    transition from: :waiting_payment, to: %i[paid overdue]
+    transition from: :waiting_payment, to: %i[paid expired]
     transition from: :authorized, to: %i[approved_on_antifraud declined_on_antifraud waiting_review paid]
     transition from: :waiting_review, to: %i[paid refused]
     transition from: :paid, to: %i[charged_back refunded]

--- a/services/catarse/spec/actions/billing/payments/expire_overdue_payments_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/expire_overdue_payments_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Billing::Payments::ExpireOverduePayments, type: :action do
     let(:payment_b) { Billing::Payment.new }
 
     before do
-      allow(Billing::Payment).to receive(:can_be_expired).and_return(scope)
+      allow(Billing::Payment).to receive(:overdue).and_return(scope)
       allow(scope).to receive(:find_each).and_yield(payment_b).and_yield(payment_a)
     end
 

--- a/services/catarse/spec/actions/billing/payments/expire_spec.rb
+++ b/services/catarse/spec/actions/billing/payments/expire_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Billing::Payments::Expire, type: :action do
 
     let(:payment) { create(:billing_payment, :waiting_payment) }
 
-    context 'when payment state cannot transition to overdue' do
-      before { allow(payment).to receive(:can_transition_to?).with(:overdue).and_return(false) }
+    context 'when payment state cannot transition to expired' do
+      before { allow(payment).to receive(:can_transition_to?).with(:expired).and_return(false) }
 
       it { is_expected.to be_failure }
 
       it 'returns error message' do
-        expect(result.error).to eq 'Payment cannot transition to overdue'
+        expect(result.error).to eq 'Payment cannot transition to expired'
       end
 
       it 'doesn`t transition payment state' do
@@ -40,13 +40,13 @@ RSpec.describe Billing::Payments::Expire, type: :action do
       end
     end
 
-    context 'when payment state can transition to overdue' do
+    context 'when payment state can transition to expired' do
       it { is_expected.to be_success }
 
-      it 'transitions payment state to overdue' do
+      it 'transitions payment state to expired' do
         result
 
-        expect(payment.reload).to be_in_state(:overdue)
+        expect(payment.reload).to be_in_state(:expired)
       end
 
       it 'transitions payment items state to canceled' do

--- a/services/catarse/spec/queries/billing/payments/overdue_query_spec.rb
+++ b/services/catarse/spec/queries/billing/payments/overdue_query_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Billing::Payments::CanBeExpiredQuery, type: :query do
+RSpec.describe Billing::Payments::OverdueQuery, type: :query do
   subject(:query) { described_class.new }
 
   describe '#call' do
@@ -21,7 +21,7 @@ RSpec.describe Billing::Payments::CanBeExpiredQuery, type: :query do
     end
 
     it 'returns payments that can be expired' do
-      expect(query.call).to eq [payment_with_pix, payment_with_boleto]
+      expect(query.call).to contain_exactly(payment_with_pix, payment_with_boleto)
     end
   end
 end

--- a/services/catarse/spec/state_machines/billing/payment_state_machine_spec.rb
+++ b/services/catarse/spec/state_machines/billing/payment_state_machine_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Billing::PaymentStateMachine, type: :state_machine do
       it { is_expected.to eq :paid }
     end
 
-    context 'when key is `overdue`' do
-      subject { described_class::MAP_TO_PAYMENT_ITEM_STATE['overdue'] }
+    context 'when key is `expired`' do
+      subject { described_class::MAP_TO_PAYMENT_ITEM_STATE['expired'] }
 
       it { is_expected.to eq :canceled }
     end
@@ -87,7 +87,7 @@ RSpec.describe Billing::PaymentStateMachine, type: :state_machine do
         declined_on_antifraud
         waiting_review
         paid
-        overdue
+        expired
         refused
         refunded
         charged_back
@@ -122,8 +122,8 @@ RSpec.describe Billing::PaymentStateMachine, type: :state_machine do
       expect { payment.transition_to!(:paid) }.not_to raise_error
     end
 
-    it 'allows transition to overdue' do
-      expect { payment.transition_to!(:overdue) }.not_to raise_error
+    it 'allows transition to expired' do
+      expect { payment.transition_to!(:expired) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
### Descrição
Substituir o estado overdue por expired pra ter um único termo para se referir a pagamentos expirados.

### Referência
https://www.notion.so/catarse/Renomear-overdue-para-expired-9e240dbc8a9c4f4690b57304be854aeb

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
