### PR TITLE
✨ Valida usuário do pagamento deve ser o mesmo do payable

### DIFF
--- a/services/catarse/app/models/billing/payment_item.rb
+++ b/services/catarse/app/models/billing/payment_item.rb
@@ -15,5 +15,12 @@ module Billing
     validates :payable_type, presence: true
 
     validates :payable_id, uniqueness: { scope: %i[payable_type payment_id] }
+    validate :payment_user_matches_payable_user
+
+    def payment_user_matches_payable_user
+      return if payment.blank? || payable.blank? || payment.user_id == payable.user_id
+
+      errors.add(:payable, I18n.t('models.billing.payment_item.errors.invalid_user'))
+    end
   end
 end

--- a/services/catarse/config/locales/billing.en.yml
+++ b/services/catarse/config/locales/billing.en.yml
@@ -5,3 +5,6 @@ en:
         errors:
           invalid_total_amount: "doesn't match other values"
           invalid_credit_card: "credit card owner doesn't match user"
+      payment_item:
+        errors:
+          invalid_user: "payment user doesn't match payable user"

--- a/services/catarse/config/locales/billing.pt.yml
+++ b/services/catarse/config/locales/billing.pt.yml
@@ -5,3 +5,6 @@ pt:
         errors:
           invalid_total_amount: "incompatível com os outros valores"
           invalid_credit_card: "usuário do cartão de credito não corresponde ao do pagamento"
+      payment_item:
+        errors:
+          invalid_user: "usuário de pagamento não corresponde ao usuário do pagavel"

--- a/services/catarse/spec/factories/billing/payment_items_factories.rb
+++ b/services/catarse/spec/factories/billing/payment_items_factories.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :billing_payment_item, class: 'Billing::PaymentItem' do
     association :payment, factory: :billing_payment
-    association :payable, factory: :contribution, strategy: :create
+    payable { create(:contribution, user: payment.user) }
 
     amount_cents { Faker::Number.number(digits: 4) }
     shipping_fee_cents { Faker::Number.number(digits: 4) }

--- a/services/catarse/spec/factories/billing/payments_factories.rb
+++ b/services/catarse/spec/factories/billing/payments_factories.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
 
     transient do
       payment_items do
-        build_list(:billing_payment_item, 2, payment: nil)
+        build_list(:billing_payment_item, 2, payment: instance)
       end
     end
 

--- a/services/catarse/spec/models/billing/payment_item_spec.rb
+++ b/services/catarse/spec/models/billing/payment_item_spec.rb
@@ -22,5 +22,32 @@ RSpec.describe Billing::PaymentItem, type: :model do
     it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
     it { is_expected.to validate_numericality_of(:shipping_fee).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_numericality_of(:total_amount).is_greater_than_or_equal_to(1) }
+
+    context 'when the payment and payable user are the same' do
+      subject(:payment_item) { described_class.new(payment: payment, payable: payable) }
+
+      let(:payment) { Billing::Payment.new(user: User.new(id: 1)) }
+      let(:payable) { Contribution.new(id: 1, user: User.new(id: 1)) }
+
+      it 'doesn`t add invalid user error' do
+        payment_item.valid?
+
+        expect(payment_item.errors[:payable]).to be_empty
+      end
+    end
+
+    context 'when the payment and payable user are different' do
+      subject(:payment_item) { described_class.new(payment: payment, payable: payable) }
+
+      let(:payment) { Billing::Payment.new(user: User.new(id: 1)) }
+      let(:payable) { Contribution.new(id: 1, user: User.new(id: 2)) }
+
+      it 'adds invalid invalid user error message' do
+        payment_item.valid?
+
+        error_message = I18n.t('models.billing.payment_item.errors.invalid_user')
+        expect(payment_item.errors[:payable]).to include error_message
+      end
+    end
   end
 end


### PR DESCRIPTION
### Descrição
Criar validação nos items dos pagamentos se os usuários do payable (Contribution e subscription) são os mesmo do payment.
 
### Referência
https://www.notion.so/catarse/Validar-que-usu-rio-s-pode-pagar-subscription-e-contribution-que-dele-c2e89df46c3746e3a2ef782394a1611c

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
