### PR TITLE
✨ Valida estimativa de entrega de recompensas ao publicar o projeto

### DIFF
--- a/services/catarse/app/models/concerns/project/base_validator.rb
+++ b/services/catarse/app/models/concerns/project/base_validator.rb
@@ -12,6 +12,11 @@ module Project::BaseValidator
     with_options if: :online? do |wo|
       wo.validates_presence_of :city
       wo.validates_length_of :name, maximum: Project::NAME_MAXLENGTH
+      wo.validate do |project|
+        if state_changed? && project.rewards.select{ |r| r.deliver_at < Time.zone.today }.present?
+          errors.add(:rewards, :deliver_at_in_the_past)
+        end
+      end
     end
 
     # Start validations when project state

--- a/services/catarse/app/models/reward.rb
+++ b/services/catarse/app/models/reward.rb
@@ -33,6 +33,8 @@ class Reward < ApplicationRecord
     if: -> { project && project.is_sub? }
 
   validates_numericality_of :maximum_contributions, only_integer: true, greater_than: 0, allow_nil: true
+  validate :deliver_date_cannot_be_in_the_past, if: :deliver_at?, on: :create
+
   scope :remaining, -> {
     where("
              rewards.maximum_contributions IS NULL
@@ -57,6 +59,12 @@ class Reward < ApplicationRecord
   before_save :log_changes
   after_save :expires_project_cache
   after_save :index_on_common
+
+  def deliver_date_cannot_be_in_the_past
+    if deliver_at < Time.zone.today
+      errors.add(:deliver_at, :deliver_at_in_the_past)
+    end
+  end
 
   def log_changes
     self.last_changes = changes.to_json

--- a/services/catarse/catarse.js/legacy/src/c/project-dashboard-menu.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-dashboard-menu.js
@@ -14,6 +14,7 @@ import _ from 'underscore';
 import h from '../h';
 import railsErrorsVM from '../vms/rails-errors-vm';
 import projectVM from '../vms/project-vm';
+import popNotification from '../c/pop-notification';
 
 const I18nScope = _.partial(h.i18nScope, 'projects.dashboard_nav');
 const linksScope = _.partial(h.i18nScope, 'projects.dashboard_nav_links');
@@ -23,6 +24,7 @@ const projectDashboardMenu = {
         const body = document.getElementsByTagName('body')[0],
             editLinksToggle = h.toggleProp(true, false),
             validating = prop(false),
+            deliverAtError = prop(false),
             showPublish = h.toggleProp(true, false),
             bodyToggleForNav = h.toggleProp('body-project open', 'body-project closed'),
             validatePublish = () => {
@@ -38,6 +40,10 @@ const projectDashboardMenu = {
                     m.redraw();
                 }).catch((err) => {
                     validating(false);
+                    deliverAtError(false);
+                    if (err.errors_json['rewards'] != undefined) {
+                      deliverAtError(true);
+                    }
                     railsErrorsVM.setRailsErrors(err.errors_json);
                     m.redraw();
                 });
@@ -62,6 +68,7 @@ const projectDashboardMenu = {
 
         vnode.state = {
             body,
+            deliverAtError,
             validating,
             validatePublish,
             editLinksToggle,
@@ -188,7 +195,9 @@ const projectDashboardMenu = {
                                         }, [
                                             window.I18n.t('publish', I18nScope()), m.trust('&nbsp;&nbsp;'), m('span.fa.fa-chevron-right')
                                         ]) : '')
-                                    ]))
+                                    ]), [
+                                        !state.deliverAtError() ? m(popNotification, { message: window.I18n.t('activerecord.errors.messages.deliver_at_in_the_past') }) : ''
+                                    ])
                             )
                         ] : [
                             ((project.mode === 'flex' && project.is_published) ? [

--- a/services/catarse/config/locales/catarse_bootstrap/activerecord.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/activerecord.en.yml
@@ -172,6 +172,8 @@ en:
         body: Content
         visible: Publish (check if you want to publish this nóvidade)
     errors:
+      messages:
+        deliver_at_in_the_past: Reward delivery date cannot be in the past
       models:
         payment:
           duplicate: Your payment is already being processed

--- a/services/catarse/config/locales/catarse_bootstrap/activerecord.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/activerecord.pt.yml
@@ -181,6 +181,8 @@ pt:
         body: 'Conteúdo'
         visible: 'Publicar (Marque caso queira publicar essa nóvidade)'
     errors:
+      messages:
+        deliver_at_in_the_past: 'Data de entrega da recompensa não pode ser anterior à hoje.'
       models:
         payment:
           duplicate: "O seu pagamento já está sendo processado"

--- a/services/catarse/spec/models/project_spec.rb
+++ b/services/catarse/spec/models/project_spec.rb
@@ -46,6 +46,49 @@ RSpec.describe Project, type: :model do
     it { is_expected.to allow_value('test-project').for(:permalink) }
     it { is_expected.not_to allow_value('users').for(:permalink) }
     it { is_expected.not_to allow_value('agua.sp.01').for(:permalink) }
+
+    context 'when an online project has rewards with delivery date in the future' do
+      let(:project) { create(:project, goal: 10_000, state: 'online') }
+
+      before do
+        project.rewards.first.update(deliver_at: Date.tomorrow)
+      end
+
+      it 'doesn`t add deliver_at_in_the_past error' do
+        project.valid?
+
+        expect(project.errors[:rewards]).to be_empty
+      end
+    end
+
+    context 'when an online project has rewards with delivery date in the past' do
+      let(:project) { create(:project, goal: 10_000, state: 'online') }
+
+      before do
+        project.rewards.first.update(deliver_at: Date.yesterday)
+      end
+
+      it 'doesn`t add deliver_at_in_the_past error' do
+        project.valid?
+
+        expect(project.errors[:rewards]).to be_empty
+      end
+    end
+
+    context 'when a project changes state to online and has rewards with delivery date in the past' do
+      let(:project) { create(:project, goal: 10_000, state: 'draft') }
+
+      before do
+        project.rewards.first.update(deliver_at: Date.yesterday)
+      end
+
+      it 'adds deliver_at_in_the_past error message' do
+        project.push_to_online
+
+        error_message = I18n.t('activerecord.errors.messages.deliver_at_in_the_past')
+        expect(project.errors[:rewards]).to include error_message
+      end
+    end
   end
 
   describe 'before validations' do

--- a/services/catarse/spec/models/reward_spec.rb
+++ b/services/catarse/spec/models/reward_spec.rb
@@ -28,6 +28,29 @@ RSpec.describe Reward, type: :model do
     end
   end
 
+  describe 'validations' do
+    context 'when deliver_at is in the future' do
+      let(:reward) { Reward.new(deliver_at: Date.tomorrow) }
+
+      it 'doesn`t add deliver_at_in_the_past error' do
+        reward.valid?
+
+        expect(reward.errors[:deliver_at]).to be_empty
+      end
+    end
+
+    context 'when deliver_at is in the past' do
+      let(:reward) { Reward.new(deliver_at: Date.yesterday) }
+
+      it 'adds deliver_at_in_the_past error message' do
+        reward.valid?
+
+        error_message = I18n.t('activerecord.errors.messages.deliver_at_in_the_past')
+        expect(reward.errors[:deliver_at]).to include error_message
+      end
+    end
+  end
+
   describe 'Associations' do
     it { is_expected.to belong_to :project }
     it { is_expected.to have_many :contributions }


### PR DESCRIPTION
### Descrição
Projeto criado a mais tempo conseguem criar recompensas com data de entrega no passado.

### Referência
https://www.notion.so/catarse/Validar-estimativa-de-entrega-de-recompensas-ao-publicar-o-projeto-4af8905f6dc449a2a446cb77dfaf8392

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
