### PR TITLE
🐞 Exibe vocativo genérico nas notificações caso o usuário não tenha n…

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_error.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_error.html.slim
@@ -2,12 +2,15 @@
 
 - company_name = CatarseSettings[:company_name]
 
-| Oi #{user.display_name},
+- if user.display_name
+  |Oi, #{user.display_name}!
+- else
+  |Oi!
 br/
 p
   | Ocorreu um <strong>erro na na transferência</strong> para sua conta bancária.
 p
-  | Para que possamos transferir novamente, precisamos que você <strong>corrija os seus dados bancários</strong> e <strong>solicite o saque</strong> através da plataforma. 
+  | Para que possamos transferir novamente, precisamos que você <strong>corrija os seus dados bancários</strong> e <strong>solicite o saque</strong> através da plataforma.
 p
   | Você pode fazer isso agora mesmo, basta seguir esses passos:
 p

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_request.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_request.html.slim
@@ -3,7 +3,10 @@
 - bank_account = user.bank_account
 - company_name = CatarseSettings[:company_name]
 
-| Olá #{user.display_name},
+- if user.display_name
+  |Olá, #{user.display_name}!
+- else
+  |Olá!
 br/
 br/
 | O pedido de saque do dinheiro foi registrado no nosso sistema e o processo de transferência já está <strong>em andamento.</strong> :-)
@@ -32,11 +35,11 @@ p
   | <strong>Saiba mais sobre o processo de transferência nos artigos listados abaixo:</strong>
 p
   strong
-    | Para realizadores: 
+    | Para realizadores:
   = link_to 'A transferência do dinheiro', 'http://suporte.catarse.me/hc/pt-br/articles/217916143-A-transfer%C3%AAncia-do-dinheiro', target: '__blank'
 p
   strong
-    | Para apoiadores: 
+    | Para apoiadores:
   = link_to 'Regras e funcionamento dos reembolsos / estornos / cancelamentos', 'http://suporte.catarse.me/hc/pt-br/articles/202365507', target: '__blank'
 br/
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transferred.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transferred.html.slim
@@ -1,8 +1,10 @@
 - user = @notification.user
 - balance_transfer = @notification.balance_transfer
 - bank_account = balance_transfer.bank_data
-
-| Olá #{user.display_name},
+- if user.display_name
+  |Olá, #{user.display_name}!
+- else
+  |Olá!
 br/
 br/
 | O depósito do dinheiro <strong>já foi realizado!</strong> O valor será creditado na conta bancária cadastrada em até <strong>2 dias úteis</strong>.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/categorized_projects_of_the_week.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/categorized_projects_of_the_week.html.slim
@@ -1,7 +1,10 @@
 - user = @notification.user
 - category = @notification.category
 
-| Olá #{user.display_name},
+- if user.display_name
+    |Olá, #{user.display_name}!
+- else
+    |Olá!
 br/
 br/
 | Novidades dessa semana na categoria #{category.name_pt} do Catarse

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_delivery.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_delivery.html.slim
@@ -1,7 +1,11 @@
 - contribution ||= @notification.contribution
 - owner = contribution.project.user
 
-p Olá, <strong>#{contribution.user.display_name}</strong>!
+p
+- if contribution.user.display_name
+  | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  | Olá!
 
 p Há duas semanas, #{contribution.project.user.display_name} mandou um comunicado dizendo que já havia enviado sua recompensa do projeto #{contribution.project.name}.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled.html.slim
@@ -2,7 +2,10 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-|Olá, <strong>#{contribution.user.display_name}</strong>!
+- if contribution.user.display_name
+    | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+    | Olá!
 br
 | Lamentamos informar que não foi possível processar seu pagamento e seu apoio ao projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink, ref: 'notificacao_cancelado',utm_source:'notification',utm_medium:'email',utm_campaign:'contribution_canceled_link',utm_content:contribution.project.name)} foi cancelado.
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_slip.html.slim
@@ -2,7 +2,12 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-p Olá, <strong>#{contribution.user.display_name}</strong>!
+p
+- if contribution.user.display_name
+  | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  | Olá!
+
 p
   | Notamos que você não realizou o pagamento do boleto para o projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink, ref: 'notificacao_cancelado',utm_source:'notification',utm_medium:'email',utm_campaign:'contribution_canceled_slip_link',utm_content:contribution.project.name)}.
 p Como o prazo de pagamento já venceu, enviamos abaixo a 2ª via do boleto para que você possa finalizar o seu apoio. :-)

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_donated.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_donated.html.slim
@@ -3,7 +3,10 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-p Olá, <strong>#{user.display_name}</strong>!
+- if user.display_name
+  | Olá, <strong>#{user.display_name}</strong>!
+- else
+  | Olá!
 
 p Muito obrigado! A sua doação é essencial para mantermos independente e livre esse vibrante ecossistema de viabilizacão de projetos que é o Catarse. Dessa forma você ajuda a gente a investir em inovação, a seguir firme na missão de democratizar o financiamento coletivo no Brasil e a tornar a prática um hábito no país.
 p Seguem todos os dados da doação:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card.html.slim
@@ -1,13 +1,16 @@
 - contribution = @notification.contribution
 - details = contribution.details.first
 
-|Olá, #{contribution.user.display_name}!
+- if contribution.user.display_name
+    | Olá, #{contribution.user.display_name}!
+- else
+    | Olá!
 br
 br
 | Infelizmente o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} que você apoiou não atingiu a meta estabelecida no #{CatarseSettings[:company_name]}.
 br
 br
-| Em até 5 dias úteis faremos o reembolso do valor do seu apoio, que <strong>virá como crédito na próxima ou 
+| Em até 5 dias úteis faremos o reembolso do valor do seu apoio, que <strong>virá como crédito na próxima ou
 | subsequente fatura do seu cartão</strong>. Assim que o reembolso for feito, você receberá um e-mail de confirmação da operação.
 br
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_slip_no_account.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_slip_no_account.html.slim
@@ -4,7 +4,10 @@
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
 p
+- if contribution.user.display_name
   |Olá, #{contribution.user.display_name}!
+- else
+  |Olá!
 p
   |O projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} não atingiu a meta de arrecadação estabelecida e, segundo as regras do Catarse, o seu apoio no valor de #{number_to_currency detail.value} ao projeto #{contribution.project.name} será devolvido a você.
 p

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_refunded.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_refunded.html.slim
@@ -4,14 +4,17 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-|Olá, <strong>#{contribution.user.display_name}</strong>!
+- if contribution.user.display_name
+  |Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  |Olá!
 br/
 br/
 
 - if detail.payment_method == 'BoletoBancario'
-  | O projeto #{project.name} foi #{project.decorator.display_mailer_status} e o valor do seu apoio já está disponível para saque em seu <strong>#{link_to 'perfil', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse. 
+  | O projeto #{project.name} foi #{project.decorator.display_mailer_status} e o valor do seu apoio já está disponível para saque em seu <strong>#{link_to 'perfil', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse.
 - else
-  | O projeto #{project.name} foi #{project.decorator.display_mailer_status} e, por isso, tentamos fazer o estorno do seu apoio para o cartão de crédito. Por algum motivo não foi possível estornar a transação diretamente para o seu cartão. Dessa forma, o valor do apoio está disponível para saque em seu <strong>#{link_to 'perfil', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse. 
+  | O projeto #{project.name} foi #{project.decorator.display_mailer_status} e, por isso, tentamos fazer o estorno do seu apoio para o cartão de crédito. Por algum motivo não foi possível estornar a transação diretamente para o seu cartão. Dessa forma, o valor do apoio está disponível para saque em seu <strong>#{link_to 'perfil', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse.
 br/
 br/
 
@@ -26,15 +29,15 @@ br/
 br/
 | Para <strong>solicitar o saque</strong> desse valor diretamente para a sua conta bancária, basta seguir este passo-a-passo:
 p
-    | 1) Faça o login no Catarse 
+    | 1) Faça o login no Catarse
     br/
     | 2) Entre na aba <strong>#{link_to 'saldo', edit_user_url(contribution.user_id, anchor: 'balance',ref: 'notificacao_project_success')}</strong>, no seu perfil.
     br/
     | 3) Clique em <strong>"Realizar saque"</strong>
     br/
     | 4) Preencha seus dados bancários e confira se eles estão corretos
-    br/ 
-    | 5) Clique em <strong>Solicitar o saque</strong> e confirme. 
+    br/
+    | 5) Clique em <strong>Solicitar o saque</strong> e confirme.
     br/
     | A transferência será realizada <strong>10 dias úteis</strong> após a solicitação de saque.
 br/

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contributions_project_unsuccessful_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contributions_project_unsuccessful_slip.html.slim
@@ -3,7 +3,10 @@
 - user = @notification.contribution.user
 - bank_account = user.bank_account
 
-|Olá, #{contribution.user.display_name}!
+- if contribution.user.display_name
+    |Olá, #{contribution.user.display_name}!
+- else
+    |Olá!
 br
 br
 | Infelizmente o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} que você apoiou não atingiu a meta estabelecida no #{CatarseSettings[:company_name]}.
@@ -26,7 +29,7 @@ br
 | Assim que o reembolso for feito, você receberá um e-mail de confirmação da operação.
 br
 br
-| Se ficou com alguma dúvida, entre em contato conosco respondendo a esta mensagem ou através do e-mail #{mail_to CatarseSettings[:email_contact]} 
+| Se ficou com alguma dúvida, entre em contato conosco respondendo a esta mensagem ou através do e-mail #{mail_to CatarseSettings[:email_contact]}
 | e nos informe a chave de identificação do seu apoio, que é: #{payment.gateway_id}
 br
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_approaching.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_approaching.html.slim
@@ -2,7 +2,11 @@
 - company_name = CatarseSettings[:company_name]
 - email_contact = CatarseSettings[:email_contact]
 
-p Olá #{project.user.display_name}!
+p
+- if project.user.display_name
+  | Olá, #{project.user.display_name}!
+- else
+  | Olá!
 
 p Estamos enviando essa mensagem para te lembrar que, pela estimativa que você publicou na sua  #{link_to 'página da sua campanha', project_by_slug_url(permalink: project.permalink)}, nesse próximo mês já começam os envios das recompensas para as pessoas que contribuíram com o seu projeto!
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_confirmed.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_confirmed.html.slim
@@ -1,7 +1,11 @@
 - contribution ||= @notification.contribution
 - owner = contribution.project.user
 - detail = contribution.details.ordered.first
-p Olá, <strong>#{contribution.user.display_name}</strong>!
+p
+- if contribution.user.display_name
+  | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  | Olá!
 
 - if !@notification.metadata.try(:[], 'message').present?
   p #{contribution.project.user.display_name} acabou de marcar que a sua recompensa do projeto #{contribution.project.name} foi <strong>enviada</strong>.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_error.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_error.html.slim
@@ -1,7 +1,11 @@
 - contribution ||= @notification.contribution
 - owner = contribution.project.user
 - detail = contribution.details.ordered.first
-p Olá, <strong>#{contribution.user.display_name}</strong>!
+p
+- if contribution.user.display_name
+  | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  | Olá!
 
 - if !@notification.metadata.try(:[], 'message').present?
   p #{contribution.project.user.display_name} acabou de sinalizar na plataforma que aconteceu um <strong>ERRO NO ENVIO</strong> de sua recompensa do projeto #{contribution.project.name}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/expiring_rewards.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/expiring_rewards.html.slim
@@ -3,7 +3,10 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-| Oi #{project.user.display_name},
+- if project.user.display_name
+  |Oi, #{project.user.display_name}!
+- else
+  |Oi!
 br/
 br/
 p Você criou recompensas com estimativa de entrega daqui a <strong>1 mês</strong>, porém ainda não definiu uma data de encerramento do seu projeto.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_finish.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_finish.html.slim
@@ -2,7 +2,11 @@
 - user = project.user
 - edit_url = edit_project_url(project.id, anchor: 'user_settings')
 
-| Oi #{user.decorator.display_name},
+- if user.decorator.display_name
+  | Oi, #{user.decorator.display_name}!
+- else
+  | Oi!
+
 br/
 br/
 | Detectamos que existem erro(s) ou ausência de preenchimento em algum(s) dos campos obrigatórios do seu projeto. Para que não isso não atrase <a href="http://suporte.catarse.me/hc/pt-br/articles/217916143-tudo-sobre-REPASSE#etapas" target="blank">os processos de finalização da campanha</a>, <strong>precisamos que você corrija esse(s) campo(s) o mais rápido possível.</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_refund.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_refund.html.slim
@@ -2,7 +2,11 @@
 - bank_account = contribution.user.bank_account
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
-|Olá, #{contribution.user.display_name}!
+
+- if contribution.user.display_name
+  |Olá, #{contribution.user.display_name}!
+- else
+  |Olá!
 p O seu reembolso não foi efetuado devido a algum erro em seus dados bancários preenchidos:
 p
   |Banco: #{bank_account.try(:bank).to_s}

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/late_delivery.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/late_delivery.html.slim
@@ -2,7 +2,11 @@
 - first_deliver = project.rewards.order(:deliver_at).first.deliver_at.try(:strftime, '%m/%Y')
 - email_contact = CatarseSettings[:email_contact]
 
-p Olá #{project.user.display_name}!
+p
+- if project.user.display_name
+  | Olá, #{project.user.display_name}!
+- else
+  | Olá!
 
 p Em seu projeto #{project.name} você ofereceu recompensas com estimativa de entrega para #{first_deliver}, porém ainda não marcou suas recompensas como enviadas para os seus apoiadores.
 
@@ -16,5 +20,5 @@ p Acesse o #{link_to 'relatórios de apoios', contributions_report_project_url(p
 p Se por algum acaso houver qualquer tipo atraso, é importante que você se comunique com os seus apoiadores através das #{link_to 'novidades', posts_project_url(project)}. É muito importante manter a transparência e deixar os apoiadores por dentro de tudo que envolve as recompensas, desde a produção até o acesso a elas.
 
 
-p 
+p
 = render partial: 'user_notifier/mailer/contact_info'

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/missing_contribution_address.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/missing_contribution_address.html.slim
@@ -3,7 +3,10 @@
 - contribution = @notification.contribution
 - project = contribution.project
 
-| Oi #{user.display_name},
+- if user.display_name
+  |Oi, #{user.display_name}!
+- else
+  |Oi!
 br/
 br/
 | Vimos que você fez uma contribuição aqui no #{company_name} para o projeto #{project.name} e que o seu apoio já foi confirmado no sistema. Apesar disso, notamos que <strong>você não informou todos seus dados</strong> no momento do apoio. O preenchimento do <strong>nome</strong>, <strong>CPF</strong> e do <strong>endereço completo (!)</strong> é fundamental para garantir a <strong>segurança do apoio, o controle do realizador</strong> e a <strong>entrega de recompensas.</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_terms_2016.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_terms_2016.html.slim
@@ -1,5 +1,10 @@
-p Olá #{@notification.user.display_name}!
-p Enviamos esse email para lembrá-los sobre as novidades do #{link_to ' Catarse ', 'https://catarse.me', target: '_blank'} e sobre a atualização dos nossos Termos de Uso, que passou a valer a partir do dia 20 de Junho de 2016. 
+p
+- if @notification.user.display_name
+  | Olá, #{@notification.user.display_name}!
+- else
+  | Olá!
+
+p Enviamos esse email para lembrá-los sobre as novidades do #{link_to ' Catarse ', 'https://catarse.me', target: '_blank'} e sobre a atualização dos nossos Termos de Uso, que passou a valer a partir do dia 20 de Junho de 2016.
 p Abaixo, um resumo das principais mudanças:
 strong Lançamento de uma nova modalidade: Catarse Flex
 p Com a mesma taxa do Tudo ou Nada (13% sob o valor arrecadado), projetos inscritos na modalidade Catarse Flex não precisam atingir a meta para receberem os recursos. #{link_to 'Saiba mais aqui.', 'http://blog.catarse.me/por-que-flex/', target: '_blank'}
@@ -27,11 +32,11 @@ br
 br
 
 strong Por que eu recebi essa mensagem?
-p Você recebeu essa mensagem por ter apoiado ou realizado um projeto no Catarse nos últimos 12 meses. Além de querermos compartilhar os avanços da plataforma, é nosso dever informar nossos usuários sobre alterações em nossos termos de uso. 
+p Você recebeu essa mensagem por ter apoiado ou realizado um projeto no Catarse nos últimos 12 meses. Além de querermos compartilhar os avanços da plataforma, é nosso dever informar nossos usuários sobre alterações em nossos termos de uso.
 strong Qual a diferença entre o Catarse Tudo ou Nada e o Catarse Flex?
-p Os dois modelos tem algumas diferenças e a principal delas é o compromisso. Projetos inscritos na modalidade Tudo ou Nada só assumem o compromisso de execução do projeto e entrega de recompensas caso atinjam (ou superem) a meta. No modelo Flex, os realizadores assumem o compromisso independente do valor arrecadado. Saiba mais sobre as diferenças entre as duas modalidades. 
+p Os dois modelos tem algumas diferenças e a principal delas é o compromisso. Projetos inscritos na modalidade Tudo ou Nada só assumem o compromisso de execução do projeto e entrega de recompensas caso atinjam (ou superem) a meta. No modelo Flex, os realizadores assumem o compromisso independente do valor arrecadado. Saiba mais sobre as diferenças entre as duas modalidades.
 strong Estou com projeto no ar, o que mudou no meu repasse?
-p O seu prazo de repasse será o mesmo: 10 dias úteis após a finalização da campanha. A única coisa que mudou é que, caso seu projeto seja financiado depois do dia 20/06/2016, pediremos que você confirme seus dados bancários antes de realizarmos a transferência do valor. Fique tranquilo que a confirmação é super rápida e pode ser feita através do seu painel de controle assim que o seu projeto for finalizado. Te enviaremos um passo-a-passo quando for o momento de você confirmá-los, mas, caso queira, você pode checar mais informações nesse artigo. 
+p O seu prazo de repasse será o mesmo: 10 dias úteis após a finalização da campanha. A única coisa que mudou é que, caso seu projeto seja financiado depois do dia 20/06/2016, pediremos que você confirme seus dados bancários antes de realizarmos a transferência do valor. Fique tranquilo que a confirmação é super rápida e pode ser feita através do seu painel de controle assim que o seu projeto for finalizado. Te enviaremos um passo-a-passo quando for o momento de você confirmá-los, mas, caso queira, você pode checar mais informações nesse artigo.
 strong Como eu posso publicar um projeto?
 p Caso ainda não tenha criado o seu rascunho, você poderá criá-lo através do botão Comece seu projeto. A partir daí, basta escolher a modalidade e preencher - no mínimo - todos os campos obrigatórios. Você poderá publicá-lo quando quiser, através do botão PUBLICAR.
 strong Se não existe mais curadoria, como eu posso conseguir dicas para a minha campanha?

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_settings.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_settings.html.slim
@@ -2,7 +2,10 @@
 - settings_link = -> (text) { link_to text, edit_user_url(user, anchor: 'settings') }
 - ispf = user.account_type == 'pf'
 
-| Oi #{user.decorate.display_name},
+- if user.decorate.display_name
+  | Oi, #{user.decorate.display_name}!
+- else
+  | Oi!
 br/
 br/
 | A fim de melhorar a sua experiência no Catarse, estamos trabalhando para reorganizar suas informações dentro da plataforma e reforçar alguns processos de segurança. Dá só uma olhada no que mudou:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_card_pending_review.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_card_pending_review.html.slim
@@ -1,6 +1,10 @@
 - contribution = @notification.contribution
 
-p Olá, <strong>#{contribution.user.display_name}</strong> !
+p
+- if contribution.user.display_name
+  | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  | Olá!
 
 p O seu apoio está sendo <strong>processado</strong> por nossos meios de pagamento e poderá ficar em análise por até 48h.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_slip.html.slim
@@ -2,9 +2,13 @@
 - expire_date = contribution.payments.last.gateway_data.try(:[], "boleto_expiration_date").try(:to_datetime).try(:strftime, '%d/%m')
 - details = contribution.details.ordered.first
 
-p Olá, <strong>#{contribution.user.display_name}</strong> !
+p
+- if contribution.user.display_name
+  | Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  | Olá!
 
-p O seu boleto para apoiar o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} foi gerado com sucesso! 
+p O seu boleto para apoiar o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} foi gerado com sucesso!
 
 p Caso ainda não tenha realizado o pagamento, você poderá acessar o boleto clicando no botão abaixo. Lembrando que o vencimento dele é dia: <strong>#{expire_date}</strong>
 
@@ -14,7 +18,7 @@ p
       = image_tag "#{CatarseSettings[:base_url]}/assets/catarse_bootstrap/display_slip.png"
 
 p
-  | Caso você não seja redirecionado ao clicar na imagem acima, acesse seu boleto através deste #{link_to 'link', details.decorate.display_slip_url, target: '__blank'} 
+  | Caso você não seja redirecionado ao clicar na imagem acima, acesse seu boleto através deste #{link_to 'link', details.decorate.display_slip_url, target: '__blank'}
 
 p Caso já tenha feito o pagamento, o seu apoio será confirmado na plataforma em até 2 dias úteis. Você pode seguir acompanhando o status do seu apoio através do histórico de apoio #{link_to 'em seu perfil do Catarse', edit_user_url(contribution.user.id, anchor: 'contributions'), target: '__blank'}
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_confirmed_after_finished.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_confirmed_after_finished.html.slim
@@ -2,7 +2,11 @@
 - contribution = @notification.contribution
 - project = contribution.project
 
-| Olá, #{project.user.decorate.display_name}!
+p
+- if project.user.decorate.display_name
+  | Olá, #{project.user.decorate.display_name}!
+- else
+  | Olá!
 br/
 br/
 | Uma nova contribuição foi confirmada para o seu projeto após ter sido finalizado.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_refunded_after_successful_pledged.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_refunded_after_successful_pledged.html.slim
@@ -7,10 +7,13 @@
 - company_name = CatarseSettings[:company_name]
 
 p
-  | Olá #{project.user.decorate.display_name},
+- if project.user.decorate.display_name
+  | Olá, #{project.user.decorate.display_name}!
+- else
+  | Olá!
 
 p
-  | O apoio realizado pelo #{contribution.user.decorate.display_name} foi cancelado e reembolsado. 
+  | O apoio realizado pelo #{contribution.user.decorate.display_name} foi cancelado e reembolsado.
 
 p
   | Isso pode ter acontecido por algum dos dois motivos seguintes:
@@ -27,7 +30,7 @@ p
   | - Opção 1: Realizar o depósito de #{fmt_value_without_fee} para a conta do Catarse (Banco Itau, Ag 4465, CC 11152-6, CNPJ 14.512.425/0001-94) e enviar o comprovante para a nossa equipe, através deste #{link_to 'link', 'https://suporte.catarse.me/hc/pt-br/requests/new'}.
   br/
   br/
-  | - Opção 2: Entrar em contato com nosso #{link_to 'atendimento', 'https://suporte.catarse.me/hc/pt-br/requests/new'} e realizar o pagamento via  boleto bancário. 
+  | - Opção 2: Entrar em contato com nosso #{link_to 'atendimento', 'https://suporte.catarse.me/hc/pt-br/requests/new'} e realizar o pagamento via  boleto bancário.
 p
   | Você pode acessar o #{link_to 'relatório de apoios', contributions_report_project_url(project)} cancelados e reembolsados a qualquer momento.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_deadline.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_deadline.html.slim
@@ -4,7 +4,11 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-|Olá, #{user.display_name}!
+- if user.display_name
+  | Olá, #{user.display_name}!
+- else
+  | Olá!
+
 br/
 br/
 |Essa mensagem é para avisar que em 1 semana, o projeto #{project.name} irá completar 365 dias no ar.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_in_waiting_funds.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_in_waiting_funds.html.slim
@@ -3,7 +3,10 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-| Oi #{project.user.display_name},
+- if project.user.display_name
+  | Oi, #{project.user.display_name}!
+- else
+  | Oi!
 br/
 br/
 | O prazo do projeto #{link_to project.name, project_link} no #{company_name} chegou ao fim.
@@ -21,7 +24,7 @@ br/
   | Estamos a esperar o prazo para contabilizar esses apoios de última hora. Com esse processo finalizado iremos repassar o valor arrecadado para você.
 - else
   | <strong>1) Se o seu projeto já atingiu ou ultrapassou a meta:</strong>
-  '  vamos apenas esperar o prazo para contabilizar esses apoios de última hora. Com esse processo finalizado, basta 
+  '  vamos apenas esperar o prazo para contabilizar esses apoios de última hora. Com esse processo finalizado, basta
   = link_to 'repassar o valor arrecadado para você.', 'http://suporte.catarse.me/hc/pt-br/articles/202037493-Como-ser%C3%A1-feito-o-repasse-do-dinheiro-', target: '__blank'
   br/
   br/

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_chargeback.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_chargeback.html.slim
@@ -9,7 +9,11 @@
 - value_without_fee = (contribution.value - (contribution.value * project.service_fee))
 - fmt_value_without_fee = number_to_currency(value_without_fee, precision: 2)
 
-| Olá #{project.user.display_name},
+- if project.user.display_name
+  | Olá, #{project.user.display_name}!
+- else
+  | Olá!
+
 br/
 p
   | O apoiador #{contributor.display_name} contestou o apoio para o seu projeto junto à operadora de cartão de crédito.
@@ -19,7 +23,7 @@ p
     | Conforme descrito nos #{link_to 'termos de uso', terms_link}, o #{company_name} deduziu o valor do apoio contestado do total arrecadado no projeto.
 
   p
-    | Para reaver esse pagamento, 
+    | Para reaver esse pagamento,
 	strong
       |recomendamos que entre em contato diretamente com o apoiador através do email ou telefone
       |, pedindo para efetuar um novo pagamento para o seu projeto.
@@ -28,14 +32,14 @@ p
 	p
 		| Seguindo nossos #{link_to 'termos de uso', terms_link}, o #{company_name} deduziu o valor do apoio do seu #{link_to 'saldo no Catarse', edit_user_url(owner, anchor: 'balance')}.
 	p
-		| Para reaver esse pagamento, 
-		strong 
+		| Para reaver esse pagamento,
+		strong
           | recomendamos que entre em contato diretamente com o apoiador através do email ou telefone
 		|, e peça para ele realizar um depósito direto na sua conta bancária.
 - elsif !contribution.project_owner_has_balance_to_cover_chargeback?
 	p
-		| Segundo nossos #{link_to 'termos de uso', terms_link}, como a transferência dos apoios ao projeto já foi efetuada, 
-		strong 
+		| Segundo nossos #{link_to 'termos de uso', terms_link}, como a transferência dos apoios ao projeto já foi efetuada,
+		strong
           | você é o responsável por devolver o valor do apoio, descontadas as taxas de serviço cobradas pelo Catarse.
 	p
 		| Caso seu saldo no Catarse não seja suficiente para quitar essa contestação, o valor será lançado e o saldo permanecerá negativo até que esse débito seja quitado através das seguintes opções:
@@ -44,9 +48,9 @@ p
 		| - Opção 1: Realizar o depósito de #{fmt_value_without_fee} para a conta do Catarse (Banco Itau, Ag 4465, CC 11152-6, CNPJ 14.512.425/0001-94) e enviar o comprovante para a nossa equipe, através deste #{link_to 'link', 'https://suporte.catarse.me/hc/pt-br/requests/new'}.
 		br/
 		br/
-		| - Opção 2: Entrar em contato com nosso #{link_to 'atendimento', 'https://suporte.catarse.me/hc/pt-br/requests/new'} e realizar o pagamento via  boleto bancário. 
+		| - Opção 2: Entrar em contato com nosso #{link_to 'atendimento', 'https://suporte.catarse.me/hc/pt-br/requests/new'} e realizar o pagamento via  boleto bancário.
 	p
-		| Além disso, recomendamos que você entre em contato com o apoiador por email ou por telefone para reaver este pagamento. Caso isso não aconteça, recomendamos que a recompensa não seja entregue. 
+		| Além disso, recomendamos que você entre em contato com o apoiador por email ou por telefone para reaver este pagamento. Caso isso não aconteça, recomendamos que a recompensa não seja entregue.
 
 hr/
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_contribution_confirmed.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_contribution_confirmed.html.slim
@@ -4,7 +4,11 @@
 - project_link = project_by_slug_url(permalink: project.permalink)
 - company_name = CatarseSettings[:company_name]
 
-| Olá, <strong>#{project.user.decorate.display_name}</strong>!
+
+- if project.user.decorate.display_name
+  |Olá, <strong>#{project.user.decorate.display_name}</strong>!
+- else
+  |Olá!
 br
 br
 | Nas últimas 24 horas de campanha, seu projeto recebeu #{link_to "#{confirmed_contributions_today.length} novos apoios", contributions_report_project_url(project)}, parabéns!
@@ -32,6 +36,6 @@ table width="500" border="1" cellpadding="10" cellspacing="0" style='font-size: 
         td= contribution.reward.try(:decorate).try(:display_description)
 br/
 br/
-|Lembrando que você pode baixar os #{link_to 'relatórios de apoios', contributions_report_project_url(project)} a qualquer momento. 
+|Lembrando que você pode baixar os #{link_to 'relatórios de apoios', contributions_report_project_url(project)} a qualquer momento.
 
 = render partial: 'user_notifier/mailer/contact_info'

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_report_exports.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_report_exports.html.slim
@@ -1,6 +1,9 @@
 - report = @notification.try(:report) || @notification.report
 center
+- if report.project.user.display_name
   |Olá, #{report.project.user.display_name}!
+- else
+  |Olá!
 center
   p A exportação do relatório #{report.report_name_locale} está pronta.
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_success.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_success.html.slim
@@ -3,7 +3,11 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-| Uhuu, #{project.user.display_name},
+
+- if project.user.display_name
+  | Uhuu, #{project.user.display_name}!
+- else
+  | Uhuu!
 br/
 p Parabéns pela campanha! O projeto #{link_to project.name, project_link} foi financiado \o/
 p
@@ -13,7 +17,7 @@ p
 p
   | Para fazer a solicitação de saque, basta seguir este passo-a-passo:
 p
-    | 1) Faça o login no Catarse 
+    | 1) Faça o login no Catarse
     br/
     | 2) Entre na aba <strong>#{link_to 'saldo', edit_user_url(project.user_id, anchor: 'balance',ref: 'notificacao_project_success')}</strong>, no seu perfil.
     br/
@@ -31,14 +35,14 @@ p
 br/
 br/
 
-p 
+p
   | <strong>Dúvidas frequentes:</strong>
-p 
+p
   = link_to 'Quais são as etapas e prazos do repasse?', 'http://suporte.catarse.me/hc/pt-br/articles/217916143#etapas', target: '__blank'
   br/
   = link_to 'Quando o dinheiro estará disponível na minha conta?', 'http://suporte.catarse.me/hc/pt-br/articles/217916143#quando', target: '__blank'
   br/
-  = link_to 'Como funciona a cobrança de taxa do Catarse', 'http://suporte.catarse.me/hc/pt-br/articles/217916143#taxa', target: '__blank' 
+  = link_to 'Como funciona a cobrança de taxa do Catarse', 'http://suporte.catarse.me/hc/pt-br/articles/217916143#taxa', target: '__blank'
   br/
 p
   |Confira mais detalhes sobre o processo no artigo <strong>#{link_to 'A transferência do dinheiro', 'http://suporte.catarse.me/hc/pt-br/articles/217916143', target: '__blank'}</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_unsuccessful.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_unsuccessful.html.slim
@@ -3,7 +3,10 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-|Oi, #{project.user.display_name},
+- if project.user.display_name
+  |Oi, #{project.user.display_name}!
+- else
+  |Oi!
 br/
 br/
 | Infelizmente o projeto #{link_to project.name, project_link } não alcançou a meta de financiamento no #{company_name}.
@@ -17,7 +20,7 @@ br/
 | Seu projeto pode não ter atingido a meta mas com certeza você aprendeu alguma coisa e pode tirar grande proveito dessa experiência se quiser! Compartilhe esse aprendizado conosco!
 br/
 br/
-strong 1. Quais os 2 piores problemas que você enfrentou durante a campanha? 
+strong 1. Quais os 2 piores problemas que você enfrentou durante a campanha?
 br/
 br/
 | Pode ser algo diretamente relacionado com o #{company_name}, uma reflexão sua, auto-crítica, ou mesmo motivos externos que dificultaram seu trajeto no financiamento coletivo.
@@ -26,13 +29,13 @@ br/
 strong 2. O que você mais sentiu falta na plataforma do #{company_name}?
 br/
 br/
-| Como podemos melhorar a plataforma? Como poderiamos ter te ajudado mais? 
+| Como podemos melhorar a plataforma? Como poderiamos ter te ajudado mais?
 br/
 br/
 | Estamos sempre em busca de melhorar a usabilidade do site e o nosso serviço. Para isso precisamos estar atentos ao que você tem a dizer sobre a gente.
 br/
 br/
-| Esperamos que você considere essa experiência válida e saiba que estamos a postos caso precise da nossa ajuda! 
+| Esperamos que você considere essa experiência válida e saiba que estamos a postos caso precise da nossa ajuda!
 br/
 br/
 | Te esperamos numa próxima.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_visible.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_visible.html.slim
@@ -4,21 +4,24 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-|Olá, #{user.decorate.display_name}.
+- if user.decorate.display_name
+  |Olá, #{user.decorate.display_name}!
+- else
+  |Olá!
 br/
 br/
 | <strong>O projeto #{link_to project.name, project_link, target: '__blank'} está no ar e já pode receber apoios!</strong>
 br/
 br/
 | É muito importante se planejar para uma campanha. Mas se você não planejou suas ações anteriormente, não perca tempo.
-'  A hora é essa! Estamos aqui para te ajudar! Para conversar sobre estratégias de comunicação com nossa equipe e receber 
+'  A hora é essa! Estamos aqui para te ajudar! Para conversar sobre estratégias de comunicação com nossa equipe e receber
 '  sugestões sobre como agir na sua campanha, responda esse email ou envie uma mensagem para #{mail_to CatarseSettings[:email_projects]}.
 br/
 br/
 | Confira nosso #{link_to 'GUIA DE REALIZADORES', guides_url} para saber mais sobre como conduzir uma campanha!
 br/
 br/
-| Lembre-se que <strong>você é o responsável por promover a campanha e cuidar da divulgação do projeto.</strong> É da sua rede que virão grande parte dos apoios! 
+| Lembre-se que <strong>você é o responsável por promover a campanha e cuidar da divulgação do projeto.</strong> É da sua rede que virão grande parte dos apoios!
 br/
 br/
 strong Uma pequena lista sobre o que pode ou não ser alterado em um projeto no ar:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_credit_card.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_credit_card.html.slim
@@ -4,7 +4,10 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-|Olá, <strong>#{contribution.user.display_name}</strong>!
+- if contribution.user.display_name
+  |Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  |Olá!
 br
 br
 |O projeto #{contribution.project.name} foi #{project.decorator.display_mailer_status} aqui no #{company_name} e por isso reembolsamos o valor do seu apoio. O crédito efetivo deverá acontecer na fatura vigente, caso ela ainda esteja em aberto, ou na subsequente, caso a desse mês já esteja fechada.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_slip.html.slim
@@ -5,7 +5,10 @@
 - user = @notification.contribution.user
 - bank_account = user.bank_account
 
-|Olá, <strong>#{contribution.user.display_name}</strong>!
+- if contribution.user.display_name
+  |Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  |Olá!
 br
 br
 |A devolução do valor do seu apoio para o projeto #{contribution.project.name} no #{company_name} acabou de ser realizada para a conta bancária:
@@ -19,7 +22,7 @@ br
 br
 | Nome: #{bank_account.try(:owner_name)}
 br
-| CPF: #{bank_account.try(:owner_document)}  
+| CPF: #{bank_account.try(:owner_document)}
 br
 | Valor devolvido: #{number_to_currency detail.value, precision: 2}
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refunded_and_canceled.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refunded_and_canceled.html.slim
@@ -2,7 +2,11 @@
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
-|Olá, <strong>#{contribution.user.display_name}</strong>!
+
+- if contribution.user.display_name
+  |Olá, <strong>#{contribution.user.display_name}</strong>!
+- else
+  |Olá!
 br
 br
 | Seu reembolso foi realizado com sucesso e o pagamento para o projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink)}, cancelado.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/reminder.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/reminder.html.slim
@@ -2,7 +2,11 @@
 - user = @notification.user
 - company_name = CatarseSettings[:company_name]
 
-|Olá, <strong>#{user.display_name}</strong>!
+
+- if user.display_name
+  |Olá, <strong>#{user.display_name}</strong>!
+- else
+  |Olá!
 br
 br
 | Este é o lembrete de que o projeto #{link_to project.name, project_by_slug_url(permalink: project.permalink, ref: 'notificacao-reminder', utm_source:'notification',utm_medium:'email',utm_campaign:'reminder_link',utm_content:project.name)} está terminando em breve!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/subscription_report.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/subscription_report.html.slim
@@ -5,12 +5,17 @@
 - new_inactive = transitions.where(to_status: 'inactive')
 - new_canceled = transitions.where(to_status: 'canceled')
 
-h3 Olá #{owner.display_name},
+h3
+- if owner.display_name
+  |Olá, #{owner.display_name}!
+- else
+  |Olá!
+
 h3 Seu saldo atual no Catarse é R$#{owner.total_balance}.
 br
 p Nas últimas 24h da sua campanha:
 
-table style="border-collapse:collapse;border-spacing:0;width:100%;" 
+table style="border-collapse:collapse;border-spacing:0;width:100%;"
   tr
     th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:4px;border-color:#fff;overflow:hidden;word-break:normal;background-color:#ffffc7;text-align:center"  Assinaturas Iniciadas
     th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:4px;border-color:#fff;;overflow:hidden;word-break:normal;background-color:#d7f6d6;text-align:center"  Assinaturas Ativadas
@@ -33,8 +38,8 @@ br
   h3
     span style="color:#ffae42;"  ●
     | Assinaturas Iniciadas
-  
-  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;" 
+
+  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;"
     tr
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:50%;"  Nome
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:25%;"  Qtde. apoios
@@ -44,14 +49,14 @@ br
         td style="font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;border-top-width:1px;border-bottom-width:1px;width:50%;"  #{transition.subscription.user.display_name}
         td style="font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;border-top-width:1px;border-bottom-width:1px;width:25%;"  #{transition.subscription.subscription_payments.where(status: :paid).count}
         td style="font-size:14px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#fff;border-top-width:1px;border-bottom-width:1px;text-align:center;width:25%;"  R$#{transition.subscription.amount}
-        
+
 
 - if new_active.count >= 1
   h3
     span style="color:#7cc142;"  ●
     | Assinaturas Ativadas
-  
-  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;" 
+
+  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;"
     tr
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:50%;"  Nome
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:25%;"  Qtde. apoios
@@ -67,8 +72,8 @@ br
   h3
     span style="color:#e86666;"  ●
     | Assinaturas Inativadas
-  
-  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;" 
+
+  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;"
     tr
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:50%;"  Nome
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:25%;"  Qtde. apoios
@@ -85,7 +90,7 @@ br
     span style="color:#e86666;"  ●
     | Assinaturas Canceladas
 
-  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;" 
+  table style="border-collapse:collapse;border-spacing:0;border-color:#ccc;width:100%;margin-bottom:60px;"
     tr
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:50%;"  Nome
       th style="font-size:14px;font-weight:bold;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;border-color:#ccc;color:#333;background-color:#f0f0f0;border-top-width:1px;border-bottom-width:1px;text-align:left;width:25%;"  Qtde. apoios

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/terms_update.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/terms_update.html.slim
@@ -1,6 +1,9 @@
 - user = @notification.user
 
-| Oi #{user.display_name},
+- if user.display_name
+  |Oi, #{user.display_name}!
+- else
+  |Oi!
 br/
 br/
 | Enviamos este email para avisar sobre a atualização dos nossos #{link_to 'Termos de Uso', 'http://www.catarse.me/pt/terms-of-use', target: '__blank'} e #{link_to 'Política de Privacidade', 'http://www.catarse.me/pt/privacy-policy', target: '__blank' }, que passam a valer para todos os Usuários do Catarse, a partir de hoje, dia 22 de Março de 2018.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/user_deactivate.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/user_deactivate.html.slim
@@ -1,9 +1,13 @@
-p Olá #{@notification.user.display_name},
+p
+- if @notification.user.display_name
+  |Olá, #{@notification.user.display_name}!
+- else
+  |Olá!
 
-p 
+p
   | Sua conta no Catarse já está desativada. Caso sinta saudades, você pode reativar a sua conta a qualquer momento, basta #{link_to('clicar aqui', reactivate_user_url(@notification.user, token: @notification.user.reactivate_token))} e voltar a apoiar ou realizar projetos incríveis.
 
-p 
+p
   | Qualquer dúvida você pode entrar em contato conosco respondendo a esta mensagem ou através do e-mail #{mail_to CatarseSettings[:email_contact]}
 
 p Um abraço,

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/video_200k_project_owner.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/video_200k_project_owner.html.slim
@@ -1,27 +1,31 @@
 = link_to 'https://www.youtube.com/watch?v=CRqXvKk5A1Q', target: :blank do
   img src="https://s3.amazonaws.com/catarse.files/video.jpg"
 
-p Olá, #{@notification.user.display_name}
+p
+- if @notification.user.display_name
+  |Olá, #{@notification.user.display_name}!
+- else
+  |Olá!
 
-p 
-  'Estamos muito felizes em anunciar que ultrapassamos a marca de 200 mil apoiadores de projetos no Catarse. 
+p
+  'Estamos muito felizes em anunciar que ultrapassamos a marca de 200 mil apoiadores de projetos no Catarse.
    Sem você isso seria não seria possível. Muito obrigado!
 
 p
   'Para comemorar, lançamos hoje um #{link_to('vídeo', 'https://www.youtube.com/watch?v=CRqXvKk5A1Q', target: :blank)}
    que mostra um pouco do impacto que juntos já causamos até agora e que faz uma provocação: e se fôssemos um milhão?
 
-p 
-  'Fique à vontade para #{link_to('compartilhar', 'http://www.facebook.com/sharer/sharer.php?u=https://www.youtube.com/watch?v=CRqXvKk5A1Q', target: :blank)} 
-   o vídeo em suas redes e usá-lo como mais um material de divulgação da sua campanha que está no ar. 
-   O vídeo traz uma noção de comunidade e pode despertar nas pessoas o desejo de participar de um movimento maior, 
+p
+  'Fique à vontade para #{link_to('compartilhar', 'http://www.facebook.com/sharer/sharer.php?u=https://www.youtube.com/watch?v=CRqXvKk5A1Q', target: :blank)}
+   o vídeo em suas redes e usá-lo como mais um material de divulgação da sua campanha que está no ar.
+   O vídeo traz uma noção de comunidade e pode despertar nas pessoas o desejo de participar de um movimento maior,
    uma vontade de, por meio do seu projeto, estar entre as pessoas que se juntam pra tirar ideias do papel.
 
 p Sucesso na campanha. Obrigado!
 
-p #SomosMuitos #Catarse200mil 
+p #SomosMuitos #Catarse200mil
 
-p 
+p
   'Felipe Caruso
   br/
   'Missionário do coletivismo


### PR DESCRIPTION
### Descrição
 Quando um usuário não tem nome nenhum registrado, a notificação acaba exibindo um 'Sem nome'. Essa alteração insere uma verificação para exibir um vocativo genérico caso o usuário não possua nome público.

### Referência
https://www.notion.so/catarse/Exibir-vocativo-gen-rico-nas-notifica-es-quando-o-usu-rio-n-o-possuir-nome-cadastrado-d2dca9fd88744b38b7f9e9e897016223

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
