### PR TITLE
✨ Cria níveis de apoio de assinatura

### DIFF
--- a/services/catarse/app/models/concerns/projects/membership_relations.rb
+++ b/services/catarse/app/models/concerns/projects/membership_relations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Projects
+  module MembershipRelations
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :tiers, class_name: 'Membership::Tier', dependent: :destroy
+    end
+  end
+end

--- a/services/catarse/app/models/membership.rb
+++ b/services/catarse/app/models/membership.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Membership
+  def self.table_name_prefix
+    'membership_'
+  end
+end

--- a/services/catarse/app/models/membership/tier.rb
+++ b/services/catarse/app/models/membership/tier.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Membership
+  class Tier < ApplicationRecord
+    belongs_to :project
+
+    validates :name, presence: true
+    validates :description, presence: true
+
+    validates :name, length: { maximum: 512 }
+    validates :description, length: { maximum: 16_000 }
+
+    validates :subscribers_limit, numericality: { greater_than: 0, only_integer: true }, allow_nil: true
+    validates :order, numericality: { only_integer: true }
+  end
+end

--- a/services/catarse/app/models/project.rb
+++ b/services/catarse/app/models/project.rb
@@ -23,6 +23,8 @@ class Project < ApplicationRecord
   include Project::VideoHandler
   include Project::CustomValidators
 
+  include Projects::MembershipRelations
+
   has_notifications
 
   mount_uploader :uploaded_image, ProjectUploader

--- a/services/catarse/db/migrate/20210618133120_create_membership_tiers.rb
+++ b/services/catarse/db/migrate/20210618133120_create_membership_tiers.rb
@@ -1,0 +1,15 @@
+class CreateMembershipTiers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :membership_tiers, id: :uuid do |t|
+      t.references :project, null: false, foreign_key: true
+      t.string :name, null: false, limit: 512
+      t.text :description, null: false
+      t.text :thumbnail
+      t.integer :subscribers_limit
+      t.boolean :request_shipping_address, default: false, null: false
+      t.integer :order, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/services/catarse/spec/factories/membership/tiers_factories.rb
+++ b/services/catarse/spec/factories/membership/tiers_factories.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :membership_tier, class: 'Membership::Tier' do
+    association :project, factory: :project
+
+    name { Faker::Lorem.sentence }
+    description { Faker::Lorem.sentence(word_count: 20) }
+    request_shipping_address { Faker::Boolean.boolean }
+    subscribers_limit { nil }
+    order { Faker::Number.number(digits: 1) }
+
+    trait :with_thumbnail do
+      thumbnail { File.open('spec/fixtures/files/testimg.png') }
+    end
+  end
+end

--- a/services/catarse/spec/models/membership/tier_spec.rb
+++ b/services/catarse/spec/models/membership/tier_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::Tier, type: :model do
+  describe 'Relations' do
+    it { is_expected.to belong_to(:project) }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:description) }
+
+    it { is_expected.to validate_length_of(:name).is_at_most(512) }
+    it { is_expected.to validate_length_of(:description).is_at_most(16_000) }
+
+    it { is_expected.to validate_numericality_of(:subscribers_limit).is_greater_than(0).only_integer.allow_nil }
+    it { is_expected.to validate_numericality_of(:order).only_integer }
+  end
+end

--- a/services/catarse/spec/models/project_spec.rb
+++ b/services/catarse/spec/models/project_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many :notifications }
     it { is_expected.to have_many :project_transitions }
     it { is_expected.to have_many :balance_transactions }
+
+    it { is_expected.to have_many(:tiers).class_name('Membership::Tier').dependent(:destroy) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
### Descrição
Estou criando no nível de apoio para assinaturas. Na nova arquitetura as recompensas (projetos pontuais) e níveis de apoio (projetos de assinatura) serão entidades separadas por terem alguns comportamentos distintos um do outro. Pra não termos um modelo inchado cheio de condições verificando qual o tipo do projeto, teremos isso separado. No futuro poderemos até usar um padrão pra compor esses dois modelos (Reward e Tier) em um só, mas por enquanto não tem problema ficar assim.

### Referência
https://www.notion.so/catarse/Criar-modelo-N-vel-de-apoio-Assinaturas-ef51dba7876642ee865ac9ddcf090434

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
