### PR TITLE
🐞 Oculta cidade e estado dos usuários na aba de apoiadores e assinantes

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-contributor-card.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/project-contributor-card.tsx
@@ -46,7 +46,6 @@ const projectContributorCard = {
                     project: attrs.project()
                 })
             }, userVM.displayName(contribution.data)),
-            m('.fontcolor-secondary.fontsize-smallest.u-marginbottom-10', `${h.selfOrEmpty(contribution.data.city)}, ${h.selfOrEmpty(contribution.data.state)}`),
             m('.fontsize-smaller', [
                 m('span.fontweight-semibold', contribution.data.total_contributed_projects), ' apoiados  |  ',
                 m('span.fontweight-semibold', contribution.data.total_published_projects), ' criado'


### PR DESCRIPTION
### Descrição
Atualmente, na aba de apoiadores e de assinantes é exibido logo abaixo do nome, a cidade e o estado do apoiador/assinante. É uma informação sem utilidade explícita e pode estar infringindo a LGPD. Esta alteração remove essas informações.

### Referência
https://www.notion.so/catarse/Ocultar-cidade-e-estado-da-aba-de-apoiadores-e-assinantes-5ae52d1701064cc68dd53854e6273be3

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
