### PR TITLE
🐞 Altera para nome público as chamadas nos emails automáticos que fal…

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/expiring_rewards.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/expiring_rewards.html.slim
@@ -3,10 +3,10 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-| Oi #{project.user.name},
+| Oi #{project.user.display_name},
 br/
 br/
-p Você criou recompensas com estimativa de entrega daqui a <strong>1 mês</strong>, porém ainda não definiu uma data de encerramento do seu projeto. 
+p Você criou recompensas com estimativa de entrega daqui a <strong>1 mês</strong>, porém ainda não definiu uma data de encerramento do seu projeto.
 p Vale lembrar que assim que o prazo chegar ao fim, alguns processos acontecem antes de o dinheiro chegar na sua conta:
 p
   | 1) Contabilização de pagamentos pendentes (caso aplicável)

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_report_exports.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_report_exports.html.slim
@@ -1,6 +1,6 @@
 - report = @notification.try(:report) || @notification.report
 center
-  |Olá, #{report.project.user.name}!
+  |Olá, #{report.project.user.display_name}!
 center
   p A exportação do relatório #{report.report_name_locale} está pronta.
 br


### PR DESCRIPTION
…tavam

### Descrição
Esta alteração coloca o nome público nas chamadas dos e-mails automáticos que faltavam (continuação do PR https://github.com/common-group/services-core/pull/903 ).

### Referência
https://www.notion.so/catarse/Alterar-nome-de-usu-rio-para-nome-p-blico-no-emails-autom-ticos-Pt-2-fc99c23c82b347e5af6bb4982086c11c

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
