### PR TITLE
🔧 Ajusta salvamento de dados do usuário nos passos de publicação de campanha solidária

### DIFF
--- a/services/catarse/app/controllers/users_controller.rb
+++ b/services/catarse/app/controllers/users_controller.rb
@@ -151,6 +151,7 @@ class UsersController < ApplicationController
 
   def update_user
     params[:user][:confirmed_email_at] = DateTime.now if params[:user].try(:[], :confirmed_email_at).present?
+    params[:user][:links_attributes] = params[:user].try(:links_attributes) || []
     @user.publishing_project = params[:user][:publishing_project].presence
     @user.publishing_user_about = params[:user][:publishing_user_about].presence
     @user.publishing_user_settings = params[:user][:publishing_user_settings].presence

--- a/services/catarse/catarse.js/legacy/src/vms/user-info-edit-vm.ts
+++ b/services/catarse/catarse.js/legacy/src/vms/user-info-edit-vm.ts
@@ -75,7 +75,7 @@ export class UserInfoEditViewModel {
 
             const userSaveAttributes = {
                 public_name: this._user.public_name,
-                links_attributes: this._user.links,
+                links_attributes: this._user.links || [],
                 cpf: this._user.owner_document,
                 name: this._user.name,
                 address_attributes: this._user.address,


### PR DESCRIPTION
### Descrição
Coloca um valor default [] para os links de presença online nos atributos quando há uma atualização do usuário caso os seja enviado vazio.

### Referência
https://www.notion.so/catarse/N-o-poss-vel-prosseguir-na-cria-o-de-projetos-solidaria-sem-preencher-algum-link-na-parte-dos-dad-878ffaf182914c9abe6033da33a8ab0e

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
