### PR TITLE
✨ Adiciona opções de cobrança

### DIFF
--- a/services/catarse/app/models/membership/billing_option.rb
+++ b/services/catarse/app/models/membership/billing_option.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Membership
+  class BillingOption < ApplicationRecord
+    belongs_to :tier, class_name: 'Membership::Tier'
+
+    monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
+
+    validates :cadence_in_months, numericality: { equal_to: 1, only_integer: true }
+  end
+end

--- a/services/catarse/app/models/membership/tier.rb
+++ b/services/catarse/app/models/membership/tier.rb
@@ -4,6 +4,8 @@ module Membership
   class Tier < ApplicationRecord
     belongs_to :project
 
+    has_many :billing_options, class_name: 'Membership::BillingOption', dependent: :destroy
+
     validates :name, presence: true
     validates :description, presence: true
 

--- a/services/catarse/db/migrate/20210628144857_create_membership_billing_options.rb
+++ b/services/catarse/db/migrate/20210628144857_create_membership_billing_options.rb
@@ -1,0 +1,12 @@
+class CreateMembershipBillingOptions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :membership_billing_options, id: :uuid do |t|
+      t.references :tier, null: false, foreign_key: { to_table: :membership_tiers }, type: :uuid
+      t.integer :cadence_in_months, null: false
+      t.monetize :amount
+      t.boolean :enabled, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/services/catarse/spec/factories/membership/billing_options_factories.rb
+++ b/services/catarse/spec/factories/membership/billing_options_factories.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :membership_billing_option, class: 'Membership::BillingOption' do
+    association :tier
+    cadence_in_months { 1 }
+    amount { Faker::Number.number(digits: 4) }
+    enabled { Faker::Boolean.boolean }
+  end
+end

--- a/services/catarse/spec/models/membership/billing_option_spec.rb
+++ b/services/catarse/spec/models/membership/billing_option_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::BillingOption, type: :model do
+  describe 'Relations' do
+    it { is_expected.to belong_to(:tier).class_name('Membership::Tier') }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_numericality_of(:cadence_in_months).is_equal_to(1).only_integer }
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
+  end
+end

--- a/services/catarse/spec/models/membership/tier_spec.rb
+++ b/services/catarse/spec/models/membership/tier_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Membership::Tier, type: :model do
   describe 'Relations' do
     it { is_expected.to belong_to(:project) }
+
+    it { is_expected.to have_many(:billing_options).class_name('Membership::BillingOption').dependent(:destroy) }
   end
 
   describe 'Validations' do


### PR DESCRIPTION
### Descrição
Adiciona o modelo de opção de cobrança. Ele representará as opções de cobrança de um nível de assinatura. Por exemplo: Projeto A tem 4 níveis de assinatura (Tier 1, Tier 2, Tier 3 e Tier 4). Com o modelo opção de cobrança, o realizador poderá dizer que pro Tier 1, poderá ser pago 20 reais por mês, 55 reais por trimestre, 100 reais por semestre ou 200 reais anuais.

### Referência
https://www.notion.so/catarse/Criar-modelo-Op-es-de-cobran-a-cd0035e60cdd4790a3c2a882b0388e57

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
