### PR TITLE
✨ Não permite letras na validação da agência.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/root/users/edit/#balance/user-balance-amount/user-balance-withdraw-request/user-bank-form.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/users/edit/#balance/user-balance-amount/user-balance-withdraw-request/user-bank-form.tsx
@@ -4,6 +4,10 @@ import { UserBankSearchList } from './user-bank-search-list'
 import { UserBankAccountInputTextField } from './user-bank-account-input-text-field'
 import { withHooks, useState, useMemo } from 'mithril-hooks'
 import { UserBankAccountSelectValue } from './user-bank-account-select-value'
+import h from '../../../../../../h'
+import _ from 'underscore'
+
+const I18nScope = _.partial(h.i18nScope, 'bank_accounts.errors');
 
 export type UserBankFormProps = {
     bankAccount: BankAccount
@@ -24,6 +28,9 @@ export const UserBankForm = withHooks<UserBankFormProps>(_UserBankForm)
 function _UserBankForm(props : UserBankFormProps) {
 
     const [ showOtherBanks, setShowOtherBanks ] = useState(false)
+    const [ showErrorAgency, setErrorAgency ] = useState(false)
+    const [ showErrorAgencyId, setErrorAgencyId ] = useState(false)
+
     const {
         getErrors,
         banks,
@@ -75,6 +82,11 @@ function _UserBankForm(props : UserBankFormProps) {
     const handleOnChangeValueFor = (field : string) => (value : string | number) => onChange({...bankAccount, [field]: value } as BankAccount)
 
     const shouldShowOtherBanksInput = `${bankAccount.bank_id}` === '0'
+
+    const errorAgencyDigit = (value : string, field : string, set : Function, show : boolean) => {
+        value == '' || value.match(/^[0-9]+$/) != null ? set(false) : set(!show)
+        handleOnChangeValueFor(`${field}`)(value.replace(/\D/gim, ''))
+    }
 
     return (
         <div>
@@ -149,6 +161,8 @@ function _UserBankForm(props : UserBankFormProps) {
                             className='w-col w-col-7 w-col-small-7 w-col-tiny-7 w-sub-col-middle'
                             labelText='Agência'
                             {...getHandleFor('agency')}
+                            onChange={(agency) => errorAgencyDigit(agency,'agency', setErrorAgency, showErrorAgency)}
+                            errors={showErrorAgency ? [window.I18n.t('only_numbers_for_agency_digit', I18nScope())] : []}
                             />
 
                         <UserBankAccountInputTextField
@@ -157,6 +171,8 @@ function _UserBankForm(props : UserBankFormProps) {
                             labelText='Dígito agência'
                             required={false}
                             {...getHandleFor('agency_digit')}
+                            onChange={(agency_digit) => errorAgencyDigit(agency_digit,'agency_digit', setErrorAgencyId, showErrorAgencyId)}
+                            errors={showErrorAgencyId ? [window.I18n.t('only_numbers_for_agency_digit', I18nScope())] : []}
                             />
                     </div>
                 </div>

--- a/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/error.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/error.en.yml
@@ -1,0 +1,4 @@
+pt:
+  bank_accounts:
+    errors:
+      only_numbers_for_agency_digit: 'Agency Digit cannot contain letters. Replace the letter with the number "0".'

--- a/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/error.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/bank_accounts/error.pt.yml
@@ -1,0 +1,4 @@
+pt:
+  bank_accounts:
+    errors:
+      only_numbers_for_agency_digit: 'Dígito da agência não pode conter letras. Substitua a letra pelo número "0".'


### PR DESCRIPTION
### Descrição
Não aceitar letras no campo de agência e avisar o usuário sobre a correção.

### Referência
https://www.notion.so/catarse/N-o-permitir-letras-na-valida-o-da-agencia-4f2012ba815a4194a2085d114c69f93f

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
