### PR TITLE
✨ Evita repasses duplicados

### DIFF
--- a/services/catarse/config/initializers/pagarme.rb
+++ b/services/catarse/config/initializers/pagarme.rb
@@ -25,3 +25,11 @@ CatarsePagarme.configure do |config|
   config.cielo_installment_amex_tax = CatarseSettings.get_without_cache(:cielo_installment_amex_tax)
   config.cielo_installment_not_amex_tax = CatarseSettings.get_without_cache(:cielo_installment_not_amex_tax)
 end
+
+class PagarMe::Transfer
+  def create(idempotency_key = nil)
+    headers = idempotency_key ? { 'Idempotency-Key' => idempotency_key } : Hash.new
+    update PagarMe::Request.post(self.class.url, params: to_hash, headers: headers).run
+    self
+  end
+end

--- a/services/catarse/engines/catarse_pagarme/app/models/catarse_pagarme/balance_transfer_delegator.rb
+++ b/services/catarse/engines/catarse_pagarme/app/models/catarse_pagarme/balance_transfer_delegator.rb
@@ -25,7 +25,7 @@ module CatarsePagarme
             seed: SecureRandom.hex(4)
           }
         })
-        transfer.create
+        transfer.create("#{balance_transfer.class.name}-#{balance_transfer.id}")
         raise "unable to create a transfer" unless transfer.id.present?
 
         balance_transfer.update(transfer_id: transfer.id)

--- a/services/catarse/lib/tasks/balance_transfer.rake
+++ b/services/catarse/lib/tasks/balance_transfer.rake
@@ -12,14 +12,28 @@ namespace :balance_transfer do
         bt.reload
 
         Rails.logger.info "[BalanceTransfer] processed to -> #{bt.transfer_id}"
+        Rails.logger.info "Sleeping 1 second"
+        sleep 1
       rescue Exception => e
         Sentry.capture_exception(e, user: { balance_transfer_id: bt.id })
         Rails.logger.info "[BalanceTransfer] processing gateway error on -> #{bt.id} "
+        Rails.logger.info "[BalanceTransfer] processing gateway error message -> #{e.message} "
 
-        bt.transition_to!(
-          :gateway_error,
-          { error_msg: e.message, error: e.to_json }
-        )
+        bt.transition_to!(:gateway_error, { error_msg: e.message, error: e.to_json })
+
+        if e.message == 'Idempotency-Key must be unique'
+          Rails.logger.info '[BalanceTransfer] Trying to find transfer on last 30 transfers on PagarMe'
+
+          PagarMe::Transfer.all(count: 30).each do |transfer|
+            if bt.id.to_s == transfer.metadata&.balance_transfer_id.to_s
+              Rails.logger.info "[BalanceTransfer] Transfer found: #{transfer.id}"
+              Rails.logger.info transfer.to_hash
+            end
+          end
+        end
+
+        Rails.logger.info "Sleeping 1 second"
+        sleep 1
       end
     end
   end


### PR DESCRIPTION
### Descrição
Por vezes o PagarMe nos retorna um erro de Timeout ao tentar realizar um repasse e com isso nunca sabemos se o repasse foi realizado de fato ou não, o que pode levar a um cenário do repasse ser feito duas vezes caso o comando seja executado de novo. Com essa modificação isso não será mais possível. Agora enviamos uma chave que identifica a transação e caso o PagarMe receba essa chave novamente, ele bloqueia o repasse.

### Referência
https://www.notion.so/catarse/Colocar-idempotencia-no-repasse-realizado-atrav-s-do-pagarme-34b3de29f127491094579666bad059b9

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
