### PR TITLE
✨ Adiciona máquina de estado às assinaturas

### DIFF
--- a/services/catarse/app/models/membership/subscription.rb
+++ b/services/catarse/app/models/membership/subscription.rb
@@ -2,6 +2,8 @@
 
 module Membership
   class Subscription < ApplicationRecord
+    include Utils::HasStateMachine
+
     belongs_to :project
     belongs_to :user
     belongs_to :tier, class_name: 'Membership::Tier'

--- a/services/catarse/app/models/membership/subscription_state_transition.rb
+++ b/services/catarse/app/models/membership/subscription_state_transition.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Membership
+  class SubscriptionStateTransition < ApplicationRecord
+    belongs_to :subscription, class_name: 'Membership::Subscription', inverse_of: :state_transitions
+
+    after_destroy :update_most_recent, if: :most_recent?
+
+    private
+
+    def update_most_recent
+      last_transition = subscription.state_transitions.order(:sort_key).last
+      return if last_transition.blank?
+
+      last_transition.update(most_recent: true)
+    end
+  end
+end

--- a/services/catarse/app/state_machines/membership/subscription_state_machine.rb
+++ b/services/catarse/app/state_machines/membership/subscription_state_machine.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Membership
+  class SubscriptionStateMachine
+    include Statesman::Machine
+
+    state :started, initial: true
+    state :active
+    state :canceling
+    state :canceled
+    state :inactive
+    state :deleted
+
+    transition from: :started, to: %i[active deleted]
+    transition from: :active, to: %i[canceling inactive]
+    transition from: :canceling, to: %i[canceled]
+    transition from: :inactive, to: %i[active]
+
+    after_transition(after_commit: true) do |subscription, transition|
+      subscription.update!(state: transition.to_state)
+    end
+  end
+end

--- a/services/catarse/db/migrate/20210707002644_create_membership_subscription_state_transitions.rb
+++ b/services/catarse/db/migrate/20210707002644_create_membership_subscription_state_transitions.rb
@@ -1,0 +1,27 @@
+class CreateMembershipSubscriptionStateTransitions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :membership_subscription_state_transitions, id: :uuid do |t|
+      t.string :to_state, null: false
+      t.jsonb :metadata, default: {}
+      t.integer :sort_key, null: false
+      t.references :subscription,
+        null: false,
+        foreign_key: { to_table: :membership_subscriptions },
+        type: :uuid,
+        index: { name: 'idx_membership_sub_state_transitions_sub_id'}
+      t.boolean :most_recent, null: false
+
+      t.timestamps
+    end
+
+    add_index(:membership_subscription_state_transitions,
+              %i[subscription_id sort_key],
+              unique: true,
+              name: "idx_membership_sub_state_transitions_parent_sort")
+    add_index(:membership_subscription_state_transitions,
+              %i[subscription_id most_recent],
+              unique: true,
+              where: "most_recent",
+              name: "idx_membership_sub_state_transitions_parent_most_recent")
+  end
+end

--- a/services/catarse/spec/factories/membership/subscriptions_factories.rb
+++ b/services/catarse/spec/factories/membership/subscriptions_factories.rb
@@ -2,11 +2,13 @@
 
 FactoryBot.define do
   factory :membership_subscription, class: 'Membership::Subscription' do
+    traits_for_enum :state, Membership::SubscriptionStateMachine.states
+
     association :project
     association :user
     tier { association :membership_tier, project: project }
     billing_option { association :membership_billing_option, tier: tier }
-    state { '#TODO' }
+    state { Membership::SubscriptionStateMachine.states.sample }
     cadence_in_months { 1 }
     amount { Faker::Number.number(digits: 4) }
   end

--- a/services/catarse/spec/models/membership/subscription_spec.rb
+++ b/services/catarse/spec/models/membership/subscription_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Membership::Subscription, type: :model do
+  it_behaves_like 'has state machine'
+
   describe 'Relations' do
     it { is_expected.to belong_to(:project) }
     it { is_expected.to belong_to(:user) }

--- a/services/catarse/spec/state_machines/membership/subscription_state_machine_spec.rb
+++ b/services/catarse/spec/state_machines/membership/subscription_state_machine_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::SubscriptionStateMachine, type: :state_machine do
+  describe '.states' do
+    it 'returns payment item states list' do
+      expect(described_class.states).to eq %w[started active canceling canceled inactive deleted]
+    end
+  end
+
+  describe 'Transitions' do
+    context 'when state is started' do
+      it 'allows transition to active' do
+        subscription = create(:membership_subscription, :started)
+
+        expect { subscription.transition_to!(:active) }.not_to raise_error
+      end
+
+      it 'allows transition to deleted' do
+        subscription = create(:membership_subscription, :started)
+
+        expect { subscription.transition_to!(:deleted) }.not_to raise_error
+      end
+    end
+
+    context 'when state is active' do
+      it 'allows transition to canceling' do
+        subscription = create(:membership_subscription, :active)
+
+        expect { subscription.transition_to!(:canceling) }.not_to raise_error
+      end
+
+      it 'allows transition to inactive' do
+        subscription = create(:membership_subscription, :active)
+
+        expect { subscription.transition_to!(:inactive) }.not_to raise_error
+      end
+    end
+
+    context 'when state is canceling' do
+      it 'allows transition to canceled' do
+        subscription = create(:membership_subscription, :canceling)
+
+        expect { subscription.transition_to!(:canceled) }.not_to raise_error
+      end
+    end
+
+    context 'when state is inactive' do
+      it 'allows transition to active' do
+        subscription = create(:membership_subscription, :inactive)
+
+        expect { subscription.transition_to!(:active) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '.after_transition' do
+    it 'updates subscription to new state' do
+      subscription = create(:membership_subscription, :started)
+      subscription.state_machine.transition_to!(:active)
+
+      expect(subscription.reload).to be_in_state(:active)
+    end
+  end
+end


### PR DESCRIPTION
### Descrição
Foi adicionada uma máquina de estado ao modelo de assinatura.

### Referência
https://www.notion.so/catarse/Adicionar-estados-assinatura-34001135add346aaa438336a4ef4a347

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
