### PR TITLE
✨ Cria API para listagem e criação de níveis de apoio

### DIFF
--- a/services/catarse/Gemfile
+++ b/services/catarse/Gemfile
@@ -25,6 +25,7 @@ gem 'excelinator', github: 'stephannv/excelinator', branch: 'master'
 gem 'feedjira', '3.1.2'
 # change back to grape after fix this issue https://github.com/ruby-grape/grape/issues/2173
 gem 'grape', github: 'neocoin/grape', branch: 'master'
+gem 'grape-entity', '0.9.0'
 gem 'gridhook', github: 'catarse/gridhook', branch: 'master'
 gem 'has_scope', '0.8.0'
 gem 'high_voltage', '3.1.2'

--- a/services/catarse/Gemfile.lock
+++ b/services/catarse/Gemfile.lock
@@ -308,6 +308,9 @@ GEM
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
+    grape-entity (0.9.0)
+      activesupport (>= 3.0.0)
+      multi_json (>= 1.3.2)
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -727,6 +730,7 @@ DEPENDENCIES
   feedjira (= 3.1.2)
   fog-aws (= 3.10.0)
   grape!
+  grape-entity (= 0.9.0)
   gridhook!
   has_scope (= 0.8.0)
   high_voltage (= 3.1.2)

--- a/services/catarse/app/actions/membership/tiers/create.rb
+++ b/services/catarse/app/actions/membership/tiers/create.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Membership
+  module Tiers
+    class Create < Actor
+      input :attributes, type: Hash
+
+      output :tier, type: Membership::Tier
+
+      def call
+        self.tier = Membership::Tier.create!(attributes)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/membership/tiers/list.rb
+++ b/services/catarse/app/actions/membership/tiers/list.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Membership
+  module Tiers
+    class List < Actor
+      input :project_id, type: String
+
+      output :tiers, type: Enumerable
+
+      def call
+        project = Project.find(project_id)
+
+        self.tiers = project.tiers
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/base_api.rb
+++ b/services/catarse/app/api/catarse/v2/base_api.rb
@@ -39,6 +39,7 @@ module Catarse
 
       mount Catarse::V2::Billing::BaseAPI
       mount Catarse::V2::Integrations::BaseAPI
+      mount Catarse::V2::Membership::BaseAPI
       mount Catarse::V2::Portal::BaseAPI
       mount Catarse::V2::Shared::BaseAPI
     end

--- a/services/catarse/app/api/catarse/v2/membership/base_api.rb
+++ b/services/catarse/app/api/catarse/v2/membership/base_api.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Catarse
+  module V2
+    module Membership
+      class BaseAPI < Grape::API
+        namespace 'membership' do
+          mount Catarse::V2::Membership::TiersAPI
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/membership/tiers_api.rb
+++ b/services/catarse/app/api/catarse/v2/membership/tiers_api.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Catarse
+  module V2
+    module Membership
+      class TiersAPI < Grape::API
+        helpers do
+          def tier_params
+            declared(params, include_missing: false)[:tier]
+          end
+        end
+
+        params do
+          requires :project_id, type: String
+        end
+
+        get '/tiers' do
+          result = ::Membership::Tiers::List.result(project_id: params[:project_id])
+
+          present :tiers, result.tiers, with: ::Membership::TierEntity
+        end
+
+        params do
+          requires :tier, type: Hash do
+            requires :project_id, type: String
+            requires :name, type: String
+            requires :description, type: String
+            optional :subscribers_limit, type: Integer
+            optional :request_shipping_address, type: Boolean
+          end
+        end
+
+        post '/tiers' do
+          result = ::Membership::Tiers::Create.result(attributes: tier_params)
+
+          present :tier, result.tier, with: ::Membership::TierEntity
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/entities/base_entity.rb
+++ b/services/catarse/app/entities/base_entity.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class BaseEntity < Grape::Entity
+  format_with(:iso_timestamp) { |datetime| datetime.try(:iso8601) }
+end

--- a/services/catarse/app/entities/membership/tier_entity.rb
+++ b/services/catarse/app/entities/membership/tier_entity.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Membership
+  class TierEntity < BaseEntity
+    expose :id
+    expose :name
+    expose :description
+    expose :subscribers_limit
+    expose :request_shipping_address
+    expose :order
+  end
+end

--- a/services/catarse/spec/actions/membership/tiers/create_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/create_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::Tiers::Create, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(attributes: { type: Hash }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(tier: { type: Membership::Tier }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(attributes: attributes) }
+
+    context 'when attributes are valid' do
+      let(:project) { create(:project) }
+      let(:attributes) { attributes_for(:membership_tier).merge(project_id: project.id) }
+
+      it { is_expected.to be_success }
+
+      it 'creates tier for given project' do
+        expect { result }.to change(project.tiers, :count).by(1)
+      end
+
+      it 'creates tier with given attribute' do
+        expect(result.tier.attributes).to include(attributes.stringify_keys)
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let(:attributes) { { name: nil } }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordInvalid) }
+    end
+  end
+end

--- a/services/catarse/spec/actions/membership/tiers/list_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/list_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::Tiers::List, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(project_id: { type: String }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(tiers: { type: Enumerable }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(project_id: project_id) }
+
+    context 'when project exists' do
+      let(:project) { create(:project) }
+      let!(:tiers) { create_list(:membership_tier, 3, project: project) }
+      let(:project_id) { project.id.to_s }
+
+      it { is_expected.to be_success }
+
+      it 'returns project`s tiers list' do
+        expect(result.tiers.to_a).to match_array tiers
+      end
+    end
+
+    context 'when project doesn`t exist' do
+      let(:project_id) { 'not-found' }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/membership/tiers_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/membership/tiers_api_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Catarse::V2::Membership::TiersAPI, type: :api do
+  mock_request_authentication
+
+  include_examples 'authenticate routes'
+
+  describe 'GET /v2/membership/tiers' do
+    let(:tiers) { build_list(:membership_tier, 5) }
+    let(:project_id) { Faker::Internet.uuid }
+
+    before do
+      allow(Membership::Tiers::List).to receive(:result)
+        .with(project_id: project_id)
+        .and_return(ServiceActor::Result.new(tiers: tiers))
+    end
+
+    it 'returns created tier' do
+      get '/api/v2/membership/tiers', params: { project_id: project_id }
+      expected_response = { tiers: Membership::TierEntity.represent(tiers) }.to_json
+
+      expect(response.body).to eq expected_response
+    end
+
+    it 'return status 200 - ok' do
+      get '/api/v2/membership/tiers', params: { project_id: project_id }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /v2/membership/tiers' do
+    let(:tier) { build(:membership_tier) }
+    let(:tier_params) do
+      attributes_for(:membership_tier, project_id: '123').slice(:project_id, :name, :description).stringify_keys
+    end
+
+    before do
+      allow(Membership::Tiers::Create).to receive(:result)
+        .with(attributes: tier_params)
+        .and_return(ServiceActor::Result.new(tier: tier))
+    end
+
+    it 'returns created tier' do
+      post '/api/v2/membership/tiers', params: { tier: tier_params }
+      expected_response = { tier: Membership::TierEntity.represent(tier) }.to_json
+
+      expect(response.body).to eq expected_response
+    end
+
+    it 'return status 201 - created' do
+      post '/api/v2/membership/tiers', params: { tier: tier_params }
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/services/catarse/spec/entities/membership/tier_entity_spec.rb
+++ b/services/catarse/spec/entities/membership/tier_entity_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::TierEntity, type: :entity do
+  let(:resource) { build(:membership_tier, :with_fake_id) }
+  let(:serializable_hash) { described_class.new(resource).serializable_hash }
+
+  it 'exposes id' do
+    expect(serializable_hash[:id]).to eq resource.id
+  end
+
+  it 'exposes name' do
+    expect(serializable_hash[:name]).to eq resource.name
+  end
+
+  it 'exposes description' do
+    expect(serializable_hash[:description]).to eq resource.description
+  end
+
+  it 'exposes subscribers_limit' do
+    expect(serializable_hash[:subscribers_limit]).to eq resource.subscribers_limit
+  end
+
+  it 'exposes request_shipping_address' do
+    expect(serializable_hash[:request_shipping_address]).to eq resource.request_shipping_address
+  end
+
+  it 'exposes order' do
+    expect(serializable_hash[:order]).to eq resource.order
+  end
+end

--- a/services/catarse/spec/factories/shared/traits.rb
+++ b/services/catarse/spec/factories/shared/traits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  trait :with_fake_id do
+    id { Faker::Internet.uuid }
+  end
+end


### PR DESCRIPTION
### Descrição
Adiciona API para listagem e criação de níveis de apoio. Detalhe para o Grape::Entity, que será nosso serializador para montagem de dados para as respostas das API.

### Referência
https://www.notion.so/catarse/Criar-rota-para-cria-o-de-n-veis-de-apoio-1f0c2f74f4044428a8e4832fc625ca38

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
