### PR TITLE
✨ Adiciona api de edição/remoção de níveis de apoio

### DIFF
--- a/services/catarse/app/actions/membership/tiers/destroy.rb
+++ b/services/catarse/app/actions/membership/tiers/destroy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Membership
+  module Tiers
+    class Destroy < Actor
+      input :id, type: String
+
+      def call
+        tier = Membership::Tier.find(id)
+
+        tier.destroy!
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/membership/tiers/update.rb
+++ b/services/catarse/app/actions/membership/tiers/update.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Membership
+  module Tiers
+    class Update < Actor
+      input :id, type: String
+      input :attributes, type: Hash
+
+      output :tier, type: Membership::Tier
+
+      def call
+        self.tier = Membership::Tier.find(id)
+
+        tier.update!(attributes)
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/membership/tiers_api.rb
+++ b/services/catarse/app/api/catarse/v2/membership/tiers_api.rb
@@ -35,6 +35,33 @@ module Catarse
 
           present :tier, result.tier, with: ::Membership::TierEntity
         end
+
+        params do
+          requires :id, type: String
+          requires :tier, type: Hash do
+            optional :project_id, type: String
+            optional :name, type: String
+            optional :description, type: String
+            optional :subscribers_limit, type: Integer
+            optional :request_shipping_address, type: Boolean
+          end
+        end
+
+        put '/tiers/:id' do
+          result = ::Membership::Tiers::Update.result(id: params[:id], attributes: tier_params)
+
+          present :tier, result.tier, with: ::Membership::TierEntity
+        end
+
+        params do
+          requires :id, type: String
+        end
+
+        delete '/tiers/:id' do
+          ::Membership::Tiers::Destroy.result(id: params[:id])
+
+          status :no_content
+        end
       end
     end
   end

--- a/services/catarse/spec/actions/membership/tiers/destroy_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/destroy_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::Tiers::Destroy, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(id: { type: String }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(id: tier_id) }
+
+    context 'when tier doesn`t exist' do
+      let(:tier_id) { 'wrong-id' }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'when tier exists' do
+      let(:tier) { create(:membership_tier) }
+      let(:tier_id) { tier.id }
+
+      it { is_expected.to be_success }
+
+      it 'destroys tier' do
+        result
+
+        expect { tier.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/membership/tiers/update_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/update_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::Tiers::Update, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(id: { type: String }) }
+    it { is_expected.to include(attributes: { type: Hash }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(tier: { type: Membership::Tier }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(id: tier_id, attributes: attributes) }
+
+    context 'when tier doesn`t exist' do
+      let(:tier_id) { 'wrong-id' }
+      let(:attributes) { {} }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'when attributes are valid' do
+      let(:tier) { create(:membership_tier) }
+      let(:tier_id) { tier.id }
+      let(:attributes) { attributes_for(:membership_tier).slice(:name, :description).stringify_keys }
+
+      it { is_expected.to be_success }
+
+      it 'updates tier with given attribute' do
+        result
+
+        expect(tier.reload.attributes).to include(attributes.stringify_keys)
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let(:tier) { create(:membership_tier) }
+      let(:tier_id) { tier.id }
+      let(:attributes) { { name: nil } }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordInvalid) }
+    end
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/membership/tiers_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/membership/tiers_api_spec.rb
@@ -56,4 +56,44 @@ RSpec.describe Catarse::V2::Membership::TiersAPI, type: :api do
       expect(response).to have_http_status(:created)
     end
   end
+
+  describe 'PUT /v2/membership/tiers/:id' do
+    let(:tier) { create(:membership_tier) }
+    let(:tier_params) { attributes_for(:membership_tier).slice(:name, :description).stringify_keys }
+
+    before do
+      allow(Membership::Tiers::Update).to receive(:result)
+        .with(id: tier.id, attributes: tier_params)
+        .and_return(ServiceActor::Result.new(tier: tier))
+    end
+
+    it 'returns updated tier' do
+      put "/api/v2/membership/tiers/#{tier.id}", params: { tier: tier_params }
+      expected_response = { tier: Membership::TierEntity.represent(tier) }.to_json
+
+      expect(response.body).to eq expected_response
+    end
+
+    it 'return status 200 - ok' do
+      put "/api/v2/membership/tiers/#{tier.id}", params: { tier: tier_params }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'DELETE /v2/membership/tiers/:id' do
+    let(:tier) { create(:membership_tier) }
+
+    before do
+      allow(Membership::Tiers::Destroy).to receive(:result)
+        .with(id: tier.id)
+        .and_return(ServiceActor::Result.new(tier: tier))
+    end
+
+    it 'return status 204 - no_content' do
+      delete "/api/v2/membership/tiers/#{tier.id}"
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
 end


### PR DESCRIPTION
### Descrição
Adiciona rotas de edição e remoção à API de níveis de apoio.

### Referência
https://www.notion.so/catarse/Criar-rota-para-edi-o-de-n-veis-de-apoio-f8a57de3e18e4fcdbd6673c658f3d7c2

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
