### PR TITLE
✨ Adiciona API de opções de cobrança

### DIFF
--- a/services/catarse/app/actions/membership/billing_options/create.rb
+++ b/services/catarse/app/actions/membership/billing_options/create.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Membership
+  module BillingOptions
+    class Create < Actor
+      input :tier_id, type: String
+      input :attributes, type: Hash
+
+      output :billing_option, type: Membership::BillingOption
+
+      def call
+        tier = Membership::Tier.find(tier_id)
+
+        self.billing_option = tier.billing_options.create!(attributes)
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/membership/billing_options/destroy.rb
+++ b/services/catarse/app/actions/membership/billing_options/destroy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Membership
+  module BillingOptions
+    class Destroy < Actor
+      input :id, type: String
+
+      def call
+        billing_option = Membership::BillingOption.find(id)
+        billing_option.destroy!
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/membership/billing_options/list.rb
+++ b/services/catarse/app/actions/membership/billing_options/list.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Membership
+  module BillingOptions
+    class List < Actor
+      input :tier_id, type: String
+
+      output :billing_options, type: Enumerable
+
+      def call
+        tier = Membership::Tier.find(tier_id)
+
+        self.billing_options = tier.billing_options
+      end
+    end
+  end
+end

--- a/services/catarse/app/actions/membership/billing_options/update.rb
+++ b/services/catarse/app/actions/membership/billing_options/update.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Membership
+  module BillingOptions
+    class Update < Actor
+      input :id, type: String
+      input :attributes, type: Hash
+
+      output :billing_option, type: Membership::BillingOption
+
+      def call
+        self.billing_option = Membership::BillingOption.find(id)
+
+        billing_option.update!(attributes)
+      end
+    end
+  end
+end

--- a/services/catarse/app/api/catarse/v2/membership/base_api.rb
+++ b/services/catarse/app/api/catarse/v2/membership/base_api.rb
@@ -5,6 +5,7 @@ module Catarse
     module Membership
       class BaseAPI < Grape::API
         namespace 'membership' do
+          mount Catarse::V2::Membership::BillingOptionsAPI
           mount Catarse::V2::Membership::TiersAPI
         end
       end

--- a/services/catarse/app/api/catarse/v2/membership/billing_options_api.rb
+++ b/services/catarse/app/api/catarse/v2/membership/billing_options_api.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Catarse
+  module V2
+    module Membership
+      class BillingOptionsAPI < Grape::API
+        helpers do
+          def billing_options_params
+            declared(params, include_missing: false)[:billing_option]
+          end
+        end
+
+        params do
+          requires :tier_id, type: String
+        end
+
+        get '/tiers/:tier_id/billing_options' do
+          result = ::Membership::BillingOptions::List.result(tier_id: params[:tier_id])
+
+          present :billing_options, result.billing_options, with: ::Membership::BillingOptionEntity
+        end
+
+        params do
+          requires :tier_id, type: String
+          requires :billing_option, type: Hash do
+            requires :cadence_in_months, type: Integer
+            requires :amount_cents, type: Integer
+          end
+        end
+
+        post '/tiers/:tier_id/billing_options' do
+          result = ::Membership::BillingOptions::Create.result(
+            tier_id: params[:tier_id], attributes: billing_options_params
+          )
+
+          present :billing_option, result.billing_option, with: ::Membership::BillingOptionEntity
+        end
+
+        params do
+          requires :id, type: String
+          requires :billing_option, type: Hash do
+            optional :cadence_in_months, type: Integer
+            optional :amount_cents, type: Integer
+            optional :enabled, type: Boolean
+          end
+        end
+        put '/billing_options/:id' do
+          result = ::Membership::BillingOptions::Update.result(id: params[:id], attributes: billing_options_params)
+
+          present :billing_option, result.billing_option, with: ::Membership::BillingOptionEntity
+        end
+
+        params do
+          requires :id, type: String
+        end
+
+        delete '/billing_options/:id' do
+          ::Membership::BillingOptions::Destroy.result(id: params[:id])
+
+          status :no_content
+        end
+      end
+    end
+  end
+end

--- a/services/catarse/app/entities/membership/billing_option_entity.rb
+++ b/services/catarse/app/entities/membership/billing_option_entity.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Membership
+  class BillingOptionEntity < BaseEntity
+    expose :id
+    expose :cadence_in_months
+    expose :amount, with: MoneyEntity
+    expose :enabled
+  end
+end

--- a/services/catarse/app/entities/money_entity.rb
+++ b/services/catarse/app/entities/money_entity.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MoneyEntity < Grape::Entity
+  expose(:value) { |amount| amount.to_d.to_s }
+  expose(:currency) { |amount| amount.currency.iso_code }
+  expose :format, as: :formatted
+end

--- a/services/catarse/app/models/membership/billing_option.rb
+++ b/services/catarse/app/models/membership/billing_option.rb
@@ -6,6 +6,8 @@ module Membership
 
     monetize :amount_cents, numericality: { greater_than_or_equal_to: 1 }
 
+    validates :cadence_in_months, uniqueness: { scope: :tier_id }
+
     validates :cadence_in_months, numericality: { equal_to: 1, only_integer: true }
   end
 end

--- a/services/catarse/spec/actions/membership/billing_options/create_spec.rb
+++ b/services/catarse/spec/actions/membership/billing_options/create_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::BillingOptions::Create, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(tier_id: { type: String }) }
+    it { is_expected.to include(attributes: { type: Hash }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(billing_option: { type: Membership::BillingOption }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(tier_id: tier_id, attributes: attributes) }
+
+    let(:tier) { create(:membership_tier) }
+
+    context 'when attributes are valid' do
+      let(:tier_id) { tier.id }
+      let(:attributes) { attributes_for(:membership_billing_option).except(:tier_id) }
+
+      it { is_expected.to be_success }
+
+      it 'creates billing_option for given tier' do
+        expect { result }.to change(tier.billing_options, :count).by(1)
+      end
+
+      it 'creates billing_option with given attribute' do
+        expect(result.billing_option.attributes).to include(attributes.stringify_keys)
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let(:tier_id) { tier.id }
+      let(:attributes) { { cadence_in_months: nil } }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordInvalid) }
+    end
+
+    context 'when tier doesn`t exist' do
+      let(:tier_id) { 'wrong-id' }
+      let(:attributes) { {} }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+  end
+end

--- a/services/catarse/spec/actions/membership/billing_options/destroy_spec.rb
+++ b/services/catarse/spec/actions/membership/billing_options/destroy_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::BillingOptions::Destroy, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(id: { type: String }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(id: billing_option_id) }
+
+    context 'when billing_option doesn`t exist' do
+      let(:billing_option_id) { 'wrong-id' }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'when billing_option exists' do
+      let(:billing_option) { create(:membership_billing_option) }
+      let(:billing_option_id) { billing_option.id }
+
+      it { is_expected.to be_success }
+
+      it 'destroys billing_option' do
+        result
+
+        expect { billing_option.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/actions/membership/billing_options/list_spec.rb
+++ b/services/catarse/spec/actions/membership/billing_options/list_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::BillingOptions::List, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(tier_id: { type: String }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(billing_options: { type: Enumerable }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(tier_id: tier_id) }
+
+    context 'when tier exists' do
+      let(:tier) { create(:membership_tier) }
+      let!(:billing_options) { create_list(:membership_billing_option, 1, tier: tier) }
+      let(:tier_id) { tier.id }
+
+      it { is_expected.to be_success }
+
+      it 'returns tier`s billing_options list' do
+        expect(result.billing_options.to_a).to match_array billing_options
+      end
+    end
+
+    context 'when tier doesn`t exist' do
+      let(:tier_id) { 'not-found' }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+  end
+end

--- a/services/catarse/spec/actions/membership/billing_options/update_spec.rb
+++ b/services/catarse/spec/actions/membership/billing_options/update_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::BillingOptions::Update, type: :action do
+  describe 'Inputs' do
+    subject { described_class.inputs }
+
+    it { is_expected.to include(id: { type: String }) }
+    it { is_expected.to include(attributes: { type: Hash }) }
+  end
+
+  describe 'Outputs' do
+    subject { described_class.outputs }
+
+    it { is_expected.to include(billing_option: { type: Membership::BillingOption }) }
+  end
+
+  describe '#call' do
+    subject(:result) { described_class.result(id: billing_option_id, attributes: attributes) }
+
+    context 'when billing_option doesn`t exist' do
+      let(:billing_option_id) { 'wrong-id' }
+      let(:attributes) { {} }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'when attributes are valid' do
+      let(:billing_option) { create(:membership_billing_option) }
+      let(:billing_option_id) { billing_option.id }
+      let(:attributes) { attributes_for(:membership_billing_option).except(:tier_id).stringify_keys }
+
+      it { is_expected.to be_success }
+
+      it 'updates billing_option with given attribute' do
+        result
+
+        expect(billing_option.reload.attributes).to include(attributes.stringify_keys)
+      end
+    end
+
+    context 'when attributes are invalid' do
+      let(:billing_option) { create(:membership_billing_option) }
+      let(:billing_option_id) { billing_option.id }
+      let(:attributes) { { cadence_in_months: nil } }
+
+      it { expect { result }.to raise_error(ActiveRecord::RecordInvalid) }
+    end
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/membership/billing_options_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/membership/billing_options_api_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Catarse::V2::Membership::BillingOptionsAPI, type: :api do
+  mock_request_authentication
+
+  include_examples 'authenticate routes'
+
+  describe 'GET /v2/membership/tiers/:tier_id/billing_options' do
+    let(:billing_option) { create(:membership_billing_option) }
+
+    before do
+      allow(Membership::BillingOptions::List).to receive(:result)
+        .with(tier_id: billing_option.tier_id)
+        .and_return(ServiceActor::Result.new(billing_options: [billing_option]))
+    end
+
+    it 'returns tier`s billing options' do
+      get "/api/v2/membership/tiers/#{billing_option.tier_id}/billing_options"
+      expected_response = { billing_options: Membership::BillingOptionEntity.represent([billing_option]) }.to_json
+
+      expect(response.body).to eq expected_response
+    end
+
+    it 'return status 200 - ok' do
+      get "/api/v2/membership/tiers/#{billing_option.tier_id}/billing_options"
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /v2/membership/tiers/:tier_id/billing_options' do
+    let(:tier_id) { Faker::Internet.uuid }
+    let(:billing_option) { build(:membership_billing_option) }
+    let(:billing_option_params) { billing_option.attributes.slice('cadence_in_months', 'amount_cents') }
+
+    before do
+      allow(Membership::BillingOptions::Create).to receive(:result)
+        .with(tier_id: tier_id, attributes: billing_option_params)
+        .and_return(ServiceActor::Result.new(billing_option: billing_option))
+    end
+
+    it 'returns created billing option' do
+      post "/api/v2/membership/tiers/#{tier_id}/billing_options", params: { billing_option: billing_option_params }
+      expected_response = { billing_option: Membership::BillingOptionEntity.represent(billing_option) }.to_json
+
+      expect(response.body).to eq expected_response
+    end
+
+    it 'return status 201 - created' do
+      post "/api/v2/membership/tiers/#{tier_id}/billing_options", params: { billing_option: billing_option_params }
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+
+  describe 'PUT /v2/membership/billing_options/:id' do
+    let(:billing_option) { create(:membership_billing_option) }
+    let(:billing_option_params) { attributes_for(:membership_billing_option).slice(:enabled).stringify_keys }
+
+    before do
+      allow(Membership::BillingOptions::Update).to receive(:result)
+        .with(id: billing_option.id, attributes: billing_option_params)
+        .and_return(ServiceActor::Result.new(billing_option: billing_option))
+    end
+
+    it 'returns updated billing_option' do
+      put "/api/v2/membership/billing_options/#{billing_option.id}", params: { billing_option: billing_option_params }
+      expected_response = { billing_option: Membership::BillingOptionEntity.represent(billing_option) }.to_json
+
+      expect(response.body).to eq expected_response
+    end
+
+    it 'return status 200 - ok' do
+      put "/api/v2/membership/billing_options/#{billing_option.id}", params: { billing_option: billing_option_params }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'DELETE /v2/membership/billing_options/:id' do
+    let(:billing_option) { create(:membership_billing_option) }
+
+    before do
+      allow(Membership::BillingOptions::Destroy).to receive(:result)
+        .with(id: billing_option.id)
+        .and_return(ServiceActor::Result.new(billing_option: billing_option))
+    end
+
+    it 'return status 204 - no_content' do
+      delete "/api/v2/membership/billing_options/#{billing_option.id}"
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/services/catarse/spec/api/catarse/v2/membership/tiers_api_spec.rb
+++ b/services/catarse/spec/api/catarse/v2/membership/tiers_api_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Catarse::V2::Membership::TiersAPI, type: :api do
         .and_return(ServiceActor::Result.new(tiers: tiers))
     end
 
-    it 'returns created tier' do
+    it 'returns project tiers' do
       get '/api/v2/membership/tiers', params: { project_id: project_id }
       expected_response = { tiers: Membership::TierEntity.represent(tiers) }.to_json
 

--- a/services/catarse/spec/entities/membership/billing_option_entity_spec.rb
+++ b/services/catarse/spec/entities/membership/billing_option_entity_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Membership::BillingOptionEntity, type: :entity do
+  let(:resource) { build(:membership_billing_option, :with_fake_id) }
+  let(:serializable_hash) { described_class.new(resource).serializable_hash }
+
+  it 'exposes id' do
+    expect(serializable_hash[:id]).to eq resource.id
+  end
+
+  it 'exposes cadence_in_months' do
+    expect(serializable_hash[:cadence_in_months]).to eq resource.cadence_in_months
+  end
+
+  it 'exposes amount' do
+    amount_hash = MoneyEntity.represent(resource.amount).serializable_hash
+
+    expect(serializable_hash[:amount]).to eq amount_hash
+  end
+
+  it 'exposes enabled' do
+    expect(serializable_hash[:enabled]).to eq resource.enabled
+  end
+end

--- a/services/catarse/spec/entities/money_entity_spec.rb
+++ b/services/catarse/spec/entities/money_entity_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MoneyEntity, type: :entity do
+  let(:resource) { Money.new(1000, 'BRL') }
+  let(:serializable_hash) { described_class.new(resource).serializable_hash }
+
+  describe 'exposes amount' do
+    it 'exposes value' do
+      expect(serializable_hash[:value]).to eq resource.to_d.to_s
+    end
+
+    it 'exposes currency' do
+      expect(serializable_hash[:currency]).to eq resource.currency.iso_code
+    end
+
+    it 'exposes formatted' do
+      expect(serializable_hash[:formatted]).to eq resource.format
+    end
+  end
+end

--- a/services/catarse/spec/factories/membership/billing_options_factories.rb
+++ b/services/catarse/spec/factories/membership/billing_options_factories.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :membership_billing_option, class: 'Membership::BillingOption' do
-    association :tier
+    association :tier, factory: :membership_tier
     cadence_in_months { 1 }
-    amount { Faker::Number.number(digits: 4) }
+    amount_cents { Faker::Number.number(digits: 4) }
     enabled { Faker::Boolean.boolean }
   end
 end

--- a/services/catarse/spec/factories/membership/subscriptions_factories.rb
+++ b/services/catarse/spec/factories/membership/subscriptions_factories.rb
@@ -10,6 +10,6 @@ FactoryBot.define do
     billing_option { association :membership_billing_option, tier: tier }
     state { Membership::SubscriptionStateMachine.states.sample }
     cadence_in_months { 1 }
-    amount { Faker::Number.number(digits: 4) }
+    amount_cents { Faker::Number.number(digits: 4) }
   end
 end

--- a/services/catarse/spec/models/membership/billing_option_spec.rb
+++ b/services/catarse/spec/models/membership/billing_option_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Membership::BillingOption, type: :model do
   end
 
   describe 'Validations' do
+    it do
+      billing_option = create(:membership_billing_option)
+      expect(billing_option).to validate_uniqueness_of(:cadence_in_months).scoped_to(:tier_id)
+    end
+
     it { is_expected.to validate_numericality_of(:cadence_in_months).is_equal_to(1).only_integer }
     it { is_expected.to validate_numericality_of(:amount).is_greater_than_or_equal_to(1) }
   end


### PR DESCRIPTION
### Descrição
Criando API para gerenciamento (criação, edição, remoção, listagem) das opções de cobrança dos níveis de apoio.

### Referência
https://www.notion.so/catarse/Criar-rota-para-cria-o-de-op-o-de-cobran-a-10586c47d60e4bb98c4893d612317049

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
