### PR TITLE
🐞 Corrige link de conectar com facebook.

### DIFF
--- a/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
+++ b/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
@@ -2153,6 +2153,12 @@ a:hover {
   position: relative;
 }
 
+.btn-link {
+  background-color: transparent;
+  border: 1px solid transparent;
+  padding-left: 0px;
+}
+
 .btn-terciary {
   border: 2px solid rgba(121, 128, 139, 0.78);
   background-color: transparent;

--- a/services/catarse/app/controllers/application_controller.rb
+++ b/services/catarse/app/controllers/application_controller.rb
@@ -81,13 +81,8 @@ class ApplicationController < ActionController::Base
   end
 
   def connect_facebook
-    if user_signed_in? && current_user.has_fb_auth?
-      FbFriendCollectorWorker.perform_async(current_user.fb_auth.id)
-      redirect_to follow_fb_friends_path
-    else
-      session[:return_to] = follow_fb_friends_path
-      redirect_to user_facebook_omniauth_authorize_path
-    end
+    FbFriendCollectorWorker.perform_async(current_user.fb_auth.id)
+    redirect_to follow_fb_friends_path
   end
 
   def public_settings

--- a/services/catarse/catarse.js/legacy/src/c/connect-facebook.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/connect-facebook.tsx
@@ -1,0 +1,30 @@
+import m from 'mithril';
+import h from '../h';
+import { getCurrentUserCached } from '../shared/services/user/get-current-user-cached';
+import { isLoggedIn } from '../shared/services/user/is-logged-in';
+import { withHooks } from 'mithril-hooks'
+
+export default withHooks<ConnectFacebookProps>(ConnectFacebook)
+
+type ConnectFacebookProps = {
+    linkClass: string
+    label: string
+    buttonClass: string
+}
+
+function ConnectFacebook({ label, linkClass, buttonClass} : ConnectFacebookProps) {
+    const currentUser = getCurrentUserCached();
+    const hasFBAuth = isLoggedIn(currentUser) && currentUser.has_fb_auth;
+
+    return (
+        hasFBAuth ?
+        m(`${linkClass}[href="/connect-facebook"]`, label) :
+        m('form.button_to', {
+            action: '/users/auth/facebook',
+            method: 'POST',
+        }, [
+            m(`${buttonClass}[type="submit"][value="${label}"]`),
+            m(`input[name='authenticity_token'][type='hidden'][value='${h.authenticityToken()}']`),
+        ])
+    )
+}

--- a/services/catarse/catarse.js/legacy/src/c/project-row-with-header.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-row-with-header.js
@@ -2,6 +2,7 @@ import m from 'mithril';
 import _ from 'underscore';
 import h from '../h';
 import projectCard from './project-card';
+import connectFacebook from './connect-facebook';
 
 const projectRowWithHeader = {
     view: function ({ attrs }) {
@@ -12,8 +13,11 @@ const projectRowWithHeader = {
             wrapper = attrs.wrapper || `.section.u-marginbottom-40${attrs.isOdd ? '.bg-gray' : ''}`,
             showFriendsLinkComponent = (
                 showFriends ?
-                    m(`a.btn.btn-small.btn-terciary.btn-inline.u-right-big-only.btn-no-border[href="/connect-facebook?ref=${ref}"]`,
-                        'Encontrar amigos') : ''
+                    m(connectFacebook, {
+                        label: 'Encontrar amigos',
+                        linkClass: 'a.btn.btn-small.btn-terciary.btn-inline.u-right-big-only.btn-no-border',
+                        buttonClass: 'input.btn.btn-small.btn-terciary.btn-inline.u-right-big-only.btn-no-border.w-button',
+                    }) : ''
             ),
             collectionHeaderComponent = (
                 (!_.isUndefined(collection.title) || !_.isUndefined(collection.hash)) ?

--- a/services/catarse/catarse.js/legacy/src/c/project-row.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-row.js
@@ -2,6 +2,7 @@ import m from 'mithril';
 import _ from 'underscore';
 import h from '../h';
 import projectCard from './project-card';
+import connectFacebook from './connect-facebook';
 
 const projectRow = {
     view: function({attrs}) {
@@ -20,9 +21,15 @@ const projectRow = {
                         ]),
                         m((showFriends ? '.w-col.w-col-4.w-col-small-6.w-col-tiny-6' : '.w-col.w-col-2.w-col-small-6.w-col-tiny-6'), [
                             m('.w-row', [
-                                (showFriends ? m('.w-col.w-col-6', [
-                                    m(`a.btn.btn-no-border.btn-small.btn-terciary[href="/connect-facebook?ref=${ref}"]`, 'Encontrar amigos')
-                                ]) : ''),
+                                (showFriends ? m('.w-col.w-col-6',
+                                    [
+                                        m(connectFacebook, {
+                                            label: 'Encontrar amigos',
+                                            linkClass: 'a.btn.btn-no-border.btn-small.btn-terciary',
+                                            buttonClass: 'input.btn.btn-no-border.btn-small.btn-terciary.w-buttonn',
+                                        })
+                                    ]) : ''
+                                ),
                                 m((showFriends ? '.w-col.w-col-6' : '.w-col.w-col-12'),
                                     m(`a.btn.btn-small.btn-terciary[href="/explore?ref=${ref}&filter=${collection.hash}"]`, {
                                         oncreate: m.route.link

--- a/services/catarse/catarse.js/legacy/src/c/signed-friend-facebook-connect.js
+++ b/services/catarse/catarse.js/legacy/src/c/signed-friend-facebook-connect.js
@@ -1,6 +1,7 @@
 import m from 'mithril';
 import _ from 'underscore';
 import h from '../h';
+import connectFacebook from './connect-facebook';
 
 const SignedFriendFacebookConnect = {
     oninit: function(vnode) {
@@ -28,7 +29,13 @@ const SignedFriendFacebookConnect = {
                             m('.u-marginbottom-20', [
                                 _.map(state.mapWithAvatar(), item => m(`img.thumb.small.u-round.u-marginbottom-10[src="${item.avatar}"]`)),
                             ]),
-                                (total > 0 ? m('a.w-button.btn.btn-large[href="/follow-fb-friends"]', 'Procure seus amigos') : m('a.w-button.btn.btn-fb.btn-large.u-margintop-30.u-marginbottom-10[href="/connect-facebook"]', 'Conecte seu facebook'))
+                                (total > 0 ?
+                                    m(connectFacebook, {
+                                        label: 'Procure seus amigos',
+                                        linkClass: 'a.w-button.btn.btn-large',
+                                        buttonClass: 'input.btn.btn-fb.btn-large.u-margintop-30.u-marginbottom-10.w-button',
+                                    }) : ''
+                                )
                         ])
                     ])
                 ])

--- a/services/catarse/catarse.js/legacy/src/c/unsigned-friend-facebook-connect.js
+++ b/services/catarse/catarse.js/legacy/src/c/unsigned-friend-facebook-connect.js
@@ -1,6 +1,7 @@
 import m from 'mithril';
 import _ from 'underscore';
 import h from '../h';
+import connectFacebook from './connect-facebook';
 
 const UnsignedFriendFacebookConnect = {
     oninit: function(vnode) {
@@ -23,7 +24,11 @@ const UnsignedFriendFacebookConnect = {
                             m('.fontsize-small', 'O universo do Catarse junto com a sua rede do Facebook te farão descobrir projetos incríveis!')
                         ]),
                         m('.w-col.w-col-4', [
-                            m('a.w-button.btn.btn-fb.btn-large.u-margintop-30.u-marginbottom-10[href="/connect-facebook"]', 'Conecte seu facebook'),
+                            m(connectFacebook, {
+                                label: 'Conecte seu facebook',
+                                linkClass: 'a.w-button.btn.btn-fb.btn-large.u-margintop-30.u-marginbottom-10',
+                                buttonClass: 'input.btn.btn-fb.btn-large.u-margintop-30.u-marginbottom-10.w-button'
+                            }),
                             m('.fontsize-smallest.fontcolor-secondary.u-text-center', 'Nós nunca postaremos nada no facebook sem sua permissão')
                         ])
                     ])

--- a/services/catarse/catarse.js/legacy/src/shared/services/user/user-details-access-wrapper.ts
+++ b/services/catarse/catarse.js/legacy/src/shared/services/user/user-details-access-wrapper.ts
@@ -122,6 +122,10 @@ export class UserDetailsAccessWrapper implements UserDetails {
         this._user.id = value
     }
 
+    get has_fb_auth(): boolean {
+        return tryAccessPropertyValue('user', this._user, 'has_fb_auth')
+    }
+
     get is_admin(): boolean {
         return tryAccessPropertyValue('user', this._user, 'is_admin')
     }


### PR DESCRIPTION
### Descrição
Atualmente a action /users/auth/facebook só pode ser acessada pelo método post, a solução é alterar o link de conectar com Facebook (e visualizar amigos e seguidores) por um button.

### Referência
https://www.notion.so/catarse/Conectar-com-Facebook-e-visualizar-amigos-e-seguidores-n-o-est-funcionando-ae595e822a3c45a5ab1beca629ad7df4

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
