### PR TITLE
🐞 Corrige texto quebrado de questionário sem data no relatório de apoio.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content-card.js
@@ -265,7 +265,9 @@ const projectContributionReportContentCard = {
                                             window.I18n.t('survey.survey', contributionScope())
                                         ),
                                         m('.fontsize-smaller.lineheight-tighter.u-marginbottom-20',
-                                            window.I18n.t('survey.answered_at', contributionScope({ date: moment(survey.survey_answered_at).format('DD/MM/YYYY') }))
+                                            survey.survey_answered_at != null ?
+                                               window.I18n.t('survey.answered_at', contributionScope({ date: moment(survey.survey_answered_at).format('DD/MM/YYYY') })) :
+                                               window.I18n.t('survey.not_answered', contributionScope())
                                         ),
                                         survey.confirm_address && survey.address ? [
                                             m('.fontsize-small', [

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.en.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.en.yml
@@ -33,6 +33,7 @@ en:
         address_title: Name and address
         address_neighbourhood: 'Neighborhood:'
         answered_at: Answered on %{date}
+        not_answered: Not Answered
       report:
         info: Info
         profile: Profile

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/contributions.pt.yml
@@ -33,6 +33,7 @@ pt:
         address_title: Nome e endereço
         address_neighbourhood: 'Bairro:'
         answered_at: "Respondido em %{date}"
+        not_answered: Não Respondido
       report:
         info: Info
         profile: Perfil


### PR DESCRIPTION
### Descrição
Ao criar um questionário que não foi respondido, não existe uma data e a resposta que aparece no relatório de apoio é invalid_date. Para resolver essa caso, foi criado uma condicional que mostra um novo texto.

### Referência
https://www.notion.so/catarse/Texto-quebrado-no-relatorio-de-apoios-quando-o-questionario-n-o-tem-data-ea6eb41779374d9792e50ca9018211f4

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
