### PR TITLE
🔧  Ajusta mensagem do salvamento dos dados do usuário na edição do projeto

### DIFF
--- a/services/catarse/catarse.js/legacy/src/root/project-edit-user-settings.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/project-edit-user-settings.tsx
@@ -12,15 +12,19 @@ const projectEditUserSettings = {
 
         const user = prop({});
 
-        getUserDetailsWithUserId(vnode.attrs.user_id)
+
+        function reloadUserData() {
+            getUserDetailsWithUserId(vnode.attrs.user_id)
             .then((userDate) => {
                 user(userDate);
                 h.redraw();
             });
+        }
 
-        vnode.state = {
-            user
-        };
+        reloadUserData()
+
+        vnode.state.user = user
+        vnode.state.reloadUserData = reloadUserData
     },
 
     view: function({state, attrs}) {
@@ -30,7 +34,8 @@ const projectEditUserSettings = {
             hideCreditCards: true,
             useFloatBtn: true,
             publishingUserSettings: true,
-            isProjectUserEdit: true
+            isProjectUserEdit: true,
+            reloadUserData: state.reloadUserData,
         }) : m('div', h.loader()));
     }
 };


### PR DESCRIPTION
### Descrição
Correção da mensagem de salvamento dos dados cadastrais na edição do projeto.

### Referência
https://www.notion.so/catarse/Salvamento-da-aba-Dados-cadastrais-no-projeto-exibe-mensagem-de-erro-mesmo-salvando-corretamente-e47413bba950443d8cdcb606eb1f40c4

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
