### PR TITLE
🎨 Corrige alinhamento dos botões de cancelar/deletar projeto

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-cancel-button.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-cancel-button.js
@@ -22,8 +22,8 @@ const projectCancelButton = {
             }) : ''),
             m('.w-row.before-footer',
               m('.w-col.w-col-12',
-                m('.w-container',
-                    m('button.btn.btn-cancel.btn-inline.btn-no-border.btn-small.btn-terciary.u-marginbottom-20.u-right.w-button', { onclick: state.displayCancelModal.toggle, style: { transition: 'all 0.5s ease 0s' } },
+                m('.w-container.u-text-center',
+                    m('button.btn.btn-cancel.btn-inline.btn-no-border.btn-small.btn-terciary.u-marginbottom-20.w-button', { onclick: state.displayCancelModal.toggle, style: { transition: 'all 0.5s ease 0s' } },
                         [
                             m('span.fa.fa-times-circle', ''),
                             m.trust('&nbsp;'),

--- a/services/catarse/catarse.js/legacy/src/c/project-delete-button.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-delete-button.js
@@ -22,8 +22,8 @@ const projectDeleteButton = {
                 content: [deleteProjectModalContent, { displayDeleteModal: state.displayDeleteModal, project: attrs.project }]
             }) : ''),
             m('.u-margintop-80',
-              m('.w-container',
-                m('a.btn.btn-inline.btn-no-border.btn-small.btn-terciary.u-marginbottom-20.u-right.w-button[href=\'javascript:void(0);\']', { onclick: state.displayDeleteModal.toggle, style: { transition: 'all 0.5s ease 0s' } },
+              m('.w-container.u-text-center',
+                m('a.btn.btn-inline.btn-no-border.btn-small.btn-terciary.u-marginbottom-20.w-button[href=\'javascript:void(0);\']', { onclick: state.displayDeleteModal.toggle, style: { transition: 'all 0.5s ease 0s' } },
                     [
                         m.trust('&nbsp;'),
                         'Deletar projeto ',


### PR DESCRIPTION
### Descrição
O botão de deletar ou cancelar projeto, no painel de control de projetos, fica escondido embaixo do widget do Zendesk. Essa atividade move o botão da direita da tela para o centro.
(Fiz o QA e reparei que tinha um errinho ali, estou mandando esse PR consertando esse erro)

### Referência
https://www.notion.so/catarse/Centraliza-bot-o-de-deletar-projeto-no-painel-de-controle-79b7c30ae4f048c98a7544856d48fc59

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [X] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
