### PR TITLE
✨ Busca por ids no admin/saques

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/admin-balance-transfer-item.js
+++ b/services/catarse/catarse.js/legacy/src/c/admin-balance-transfer-item.js
@@ -36,10 +36,17 @@ const adminBalanceTransferItem = {
             ]),
             m('.w-col.w-col-2.w-hidden-small.w-hidden-tiny', [
                 m('span', item.state),
-                (item.transfer_id ? m('.fontcolor-secondary.fontsize-smallest',
-                    m(`a[href="https://dashboard.pagar.me/#/transfers/${item.transfer_id}"]`,
-                        `ID: ${item.transfer_id}`))
-                    : '')
+                (
+                    item.transfer_id &&
+                    m('.fontcolor-secondary.fontsize-smallest',
+                        m(`a[href="https://dashboard.pagar.me/#/transfers/${item.transfer_id}"]`,
+                            `ID Pagarme: ${item.transfer_id}`
+                        )
+                    )
+                ),
+                m('.fontcolor-secondary.fontsize-smallest', `ID Catarse: ${item.id}`),
+                item.transfeera_id && m('.fontcolor-secondary.fontsize-smallest', `ID TR: ${item.transfeera_id}`),
+                item.batch_id && m('.fontcolor-secondary.fontsize-smallest', `LOTE: ${item.batch_id}`)
             ]),
             m('.w-col.w-col-2', [
                 m('.fontsize-smallest', [

--- a/services/catarse/catarse.js/legacy/src/c/filter-number.js
+++ b/services/catarse/catarse.js/legacy/src/c/filter-number.js
@@ -1,0 +1,20 @@
+import m from 'mithril';
+
+const filterNumber = {
+    view: function({attrs}) {
+        return m('.w-col.w-col-3.w-col-small-6', [
+            m(`label.fontsize-smaller[for="${attrs.index}"]`, attrs.label),
+            m('.w-row', [
+                m('.w-col.w-col-12.w-col-small-12.w-col-tiny-12', [
+                    m(`input.w-input.text-field.positive[id="${attrs.index}"][type="text"]`, {
+                        placeholder: attrs.placeholder || '',
+                        onchange: m.withAttr('value', attrs.first),
+                        value: attrs.first()
+                    })
+                ]),
+            ])
+        ]);
+    }
+};
+
+export default filterNumber;

--- a/services/catarse/catarse.js/legacy/src/root/admin-balance-tranfers.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/admin-balance-tranfers.tsx
@@ -10,6 +10,7 @@ import filterMain from '../c/filter-main';
 import filterDropdown from '../c/filter-dropdown';
 import filterDateRange from '../c/filter-date-range';
 import filterNumberRange from '../c/filter-number-range';
+import filterNumber from '../c/filter-number';
 import modalBox from '../c/modal-box';
 import adminBalanceTransferItem from '../c/admin-balance-transfer-item';
 import adminBalanceTransferItemDetail from '../c/admin-balance-transfer-item-detail';
@@ -31,6 +32,30 @@ const adminBalanceTranfers = {
                     data: {
                         vm: filterVM.full_text_index,
                         placeholder: 'Busque pelo email, ids do usuario, ids de transferencia e eventos de saldo'
+                    }
+                },
+                {
+                    component: filterNumber,
+                    data: {
+                        label: 'ID do Lote',
+                        first: filterVM.batch_id,
+                        placeholder: 'ID do Lote',
+                    }
+                },
+                {
+                    component: filterNumber,
+                    data: {
+                        label: 'ID Catarse',
+                        first: filterVM.id,
+                        placeholder: 'ID Catarse',
+                    }
+                },
+                {
+                    component: filterNumber,
+                    data: {
+                        label: 'ID Transfeera',
+                        first: filterVM.transfeera_id,
+                        placeholder: 'ID Transfeera',
                     }
                 },
                 {
@@ -91,7 +116,7 @@ const adminBalanceTranfers = {
                         first: filterVM.amount.gte,
                         last: filterVM.amount.lte
                     }
-                }
+                },
             ],
             selectedItemsIDs = prop([]),
             displayApprovalModal = h.toggleProp(false, true),

--- a/services/catarse/catarse.js/legacy/src/vms/balance-transfer-filter-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/balance-transfer-filter-vm.js
@@ -12,7 +12,10 @@ const context = () => {
         transfer_id: 'eq',
         created_date: 'between',
         transferred_date: 'between',
-        amount: 'between'
+        amount: 'between',
+        batch_id: 'eq',
+        id: 'eq',
+        transfeera_id: 'eq'
     });
 
     const paramToString = p => (p || '').toString().trim();

--- a/services/catarse/db/migrate/20210709221606_balance_transfers_fix_transfer_date_batch_info.rb
+++ b/services/catarse/db/migrate/20210709221606_balance_transfers_fix_transfer_date_batch_info.rb
@@ -1,0 +1,95 @@
+class BalanceTransfersFixTransferDateBatchInfo < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+
+    CREATE OR REPLACE VIEW "1"."balance_transfers" AS
+    SELECT bt.id,
+        bt.user_id,
+        bt.project_id,
+        bt.amount,
+        bt.transfer_id as transfer_id,
+        zone_timestamp(bt.created_at) AS created_at,
+        transfer_limit_date(bt.*) AS transfer_limit_date,
+        current_state(bt.*) AS state,
+        btt.metadata AS last_transition_metadata,
+        zone_timestamp(transferred_transition.created_at) AS transferred_at,
+        (zone_timestamp(transferred_transition.created_at))::date AS transferred_date,
+        (zone_timestamp(bt.created_at))::date AS created_date,
+        bt.full_text_index,
+        u.name AS user_name,
+        u.public_name AS user_public_name,
+        u.email AS user_email,
+        CASE
+            WHEN ("current_user"() = 'admin'::name) THEN bt.admin_notes
+            ELSE NULL::text
+        END AS admin_notes,
+        bt.batch_id,
+        btt.metadata->'data'->>'id' as transfeera_id
+      FROM (((balance_transfers bt
+        JOIN users u ON ((u.id = bt.user_id)))
+        LEFT JOIN balance_transfer_transitions btt ON (((btt.balance_transfer_id = bt.id) AND btt.most_recent)))
+        LEFT JOIN LATERAL ( SELECT btt1.id,
+               btt1.to_state,
+               btt1.metadata,
+               btt1.sort_key,
+               btt1.balance_transfer_id,
+               btt1.most_recent,
+               coalesce((to_timestamp(((btt1.metadata -> 'transfer_data'::text) ->> 'date_created'::text), 'YYYY-MM-DD HH24:MI:SS'::text))::timestamp without time zone, btt1.created_at::timestamp without time zone) AS created_at,
+               btt1.updated_at
+              FROM balance_transfer_transitions btt1
+             WHERE ((btt1.balance_transfer_id = bt.id) AND ((btt1.to_state)::text = 'transferred'::text))
+             ORDER BY btt1.id DESC
+            LIMIT 1) transferred_transition ON (true))
+     WHERE is_owner_or_admin(bt.user_id);
+
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+
+    drop view "1".balance_transfers;
+
+    CREATE OR REPLACE VIEW "1"."balance_transfers" AS
+    SELECT bt.id,
+        bt.user_id,
+        bt.project_id,
+        bt.amount,
+        bt.transfer_id,
+        zone_timestamp(bt.created_at) AS created_at,
+        transfer_limit_date(bt.*) AS transfer_limit_date,
+        current_state(bt.*) AS state,
+        btt.metadata AS last_transition_metadata,
+        zone_timestamp(transferred_transition.created_at) AS transferred_at,
+        (zone_timestamp(transferred_transition.created_at))::date AS transferred_date,
+        (zone_timestamp(bt.created_at))::date AS created_date,
+        bt.full_text_index,
+        u.name AS user_name,
+        u.public_name AS user_public_name,
+        u.email AS user_email,
+            CASE
+                WHEN ("current_user"() = 'admin'::name) THEN bt.admin_notes
+                ELSE NULL::text
+            END AS admin_notes
+      FROM (((balance_transfers bt
+        JOIN users u ON ((u.id = bt.user_id)))
+        LEFT JOIN balance_transfer_transitions btt ON (((btt.balance_transfer_id = bt.id) AND btt.most_recent)))
+        LEFT JOIN LATERAL ( SELECT btt1.id,
+                btt1.to_state,
+                btt1.metadata,
+                btt1.sort_key,
+                btt1.balance_transfer_id,
+                btt1.most_recent,
+                ((to_timestamp(((btt1.metadata -> 'transfer_data'::text) ->> 'date_created'::text), 'YYYY-MM-DD HH24:MI:SS'::text))::timestamp without time zone) AS created_at,
+                btt1.updated_at
+              FROM balance_transfer_transitions btt1
+              WHERE ((btt1.balance_transfer_id = bt.id) AND ((btt1.to_state)::text = 'transferred'::text))
+              ORDER BY btt1.id DESC
+            LIMIT 1) transferred_transition ON (true))
+      WHERE is_owner_or_admin(bt.user_id);
+
+    grant select on "1".balance_transfers to admin, web_user;
+
+    SQL
+  end
+end


### PR DESCRIPTION
### Descrição
Adiciona campos de busca para as transferências pelos ids no admin/saques. 

Adiciona o ajuste da data de transferência que já foi corrigido no banco em produção pelo @devton.

### Referência
https://www.notion.so/catarse/Permitir-que-o-time-administrativo-saiba-os-IDs-de-transfer-ncia-e-possa-pesquis-los-3443db22e1c1448da68a9f93613f1c76

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
