### PR TITLE
✨ Identifica projeto ao enviar menssagem pelo histórico de apoios.

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message.html.slim
@@ -1,11 +1,12 @@
 - message = @notification.direct_message
 - to_user = User.find message.to_user_id
+- project = Project.find message.project_id
 - message_origin_name = message.data['page_title'].present? && message.data['page_title'].length > 0 ? message.data['page_title'] : message.data['page_url']
 
 |Olá <strong>#{to_user.try(:display_name)}</strong>
 br
 
-|Você recebeu uma nova mensagem de #{link_to message.user.try(:display_name), user_url(message.user)}  a partir da página #{link_to(message_origin_name, message.data['page_url'], target: :_blank) }:
+|Você recebeu uma nova mensagem de #{link_to message.user.try(:display_name), user_url(message.user)}  a partir da página #{link_to(message_origin_name, message.data['page_url'], target: :_blank) }, referente ao projeto #{link_to project.name, project_url(project)}:
 br
 br
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message_copy.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message_copy.html.slim
@@ -1,10 +1,11 @@
 - message = @notification.direct_message
 - to_user = User.find message.to_user_id
+- project = Project.find message.project_id
 - message_origin_name = message.data['page_title'].present? && message.data['page_title'].length > 0 ? message.data['page_title'] : message.data['page_url']
 
 |Olá <strong>#{message.from_name}</strong>
 br
-|Esta é a mensagem que você enviou para o #{link_to to_user.try(:display_name), user_url(to_user)} a partir da página #{link_to message_origin_name, message.data['page_url'], target: :_blank }:
+|Esta é a mensagem que você enviou para o #{link_to to_user.try(:display_name), user_url(to_user)} a partir da página #{link_to message_origin_name, message.data['page_url'], target: :_blank }, referente ao projeto #{link_to project.name, project_url(project)}:
 br
 br
 p style=("background-color:#f1f4f4; padding: 20px; margin: 20px 30px 50px 30px; border-radius:5px;") == message.content


### PR DESCRIPTION
### Descrição
O email de direct_message não informa o projeto, tornando difícil para os organizadores de vários projetos identificar de qual projeto se refere a mensagem enviado pelo histórico de apoios do usuários.

### Referência
https://www.notion.so/catarse/Projeto-n-o-identificado-ao-enviar-mensagem-para-realizador-pelo-hist-rico-de-apoios-6fb8cc72d018437b949f543b31100531

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
