### PR TITLE
🔧 Ajusta salvamento dos links do perfil do usuário

### DIFF
--- a/services/catarse/app/controllers/users_controller.rb
+++ b/services/catarse/app/controllers/users_controller.rb
@@ -151,10 +151,11 @@ class UsersController < ApplicationController
 
   def update_user
     params[:user][:confirmed_email_at] = DateTime.now if params[:user].try(:[], :confirmed_email_at).present?
-    params[:user][:links_attributes] = params[:user].try(:links_attributes) || []
+    params[:user].delete(:links_attributes) unless params[:user][:links_attributes].present?
     @user.publishing_project = params[:user][:publishing_project].presence
     @user.publishing_user_about = params[:user][:publishing_user_about].presence
     @user.publishing_user_settings = params[:user][:publishing_user_settings].presence
+
     email_update?
     drop_and_create_subscriptions
     update_reminders


### PR DESCRIPTION
### Descrição
Ajusta o salvamento dos links do perfil do usuário checando se há dados nos atributos dos links enviados na requisição.

### Referência
https://www.notion.so/catarse/Editar-ou-Deletar-os-links-do-perfil-do-usu-rio-n-o-est-o-funcionando-39ae539e518540969c70c4d895e16917

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
