### PR TITLE
🔥 Corrige exibição de QR nos e-mails pix

### DIFF
--- a/services/catarse/app/decorators/contribution_detail_decorator.rb
+++ b/services/catarse/app/decorators/contribution_detail_decorator.rb
@@ -36,6 +36,11 @@ class ContributionDetailDecorator < Draper::Decorator
     return QRCode::Renderer.as_svg(gateway_data['pix_qr_code']) if gateway_data.present?
   end
 
+  def display_pix_qr_code_base64
+    gateway_data = object.try(:gateway_data)
+    return QRCode::Renderer.as_base64_png(gateway_data['pix_qr_code']) if gateway_data.present?
+  end
+
   def display_status
     state = object.state
     I18n.t("payment.state.#{state}", date: I18n.l(object["#{state}_at".to_sym].to_date))

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
@@ -22,7 +22,7 @@ p Notamos que você não realizou o pagamento do PIX para o projeto #{link_to co
   br
   p
     center
-      <strong>#{details.decorate.display_pix_qr_code.html_safe}</strong>
+      img(src="data:image/png;base64,#{details.decorate.display_pix_qr_code_base64}")
   br
   p Ou se preferir, abra o app ou site do seu banco e informe a chave abaixo:
   br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
@@ -11,7 +11,7 @@ p Use o app do seu banco para escanear o QR Code abaixo:
 br
 p
   center
-    <strong>#{details.decorate.display_pix_qr_code.html_safe}</strong>
+    img(src="data:image/png;base64,#{details.decorate.display_pix_qr_code_base64}")
 br
 p Ou se preferir, abra o app ou site do seu banco e informe a chave abaixo:
 br

--- a/services/catarse/lib/qr_code/renderer.rb
+++ b/services/catarse/lib/qr_code/renderer.rb
@@ -14,5 +14,11 @@ module QRCode
         standalone: true
       )
     end
+
+    def self.as_base64_png(string)
+      qrcode = RQRCode::QRCode.new(string)
+      png = qrcode.as_png(size: 350)
+      Base64.strict_encode64 png.to_blob(:fast_rgb)
+    end
   end
 end


### PR DESCRIPTION
### Descrição
Imagens SVG não são exibidas em clientes de e-mail. O QR Code dos pixs necessitam serem exibidos como base64.

### Referência
...

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
