### PR TITLE
🔥 Corrige data de expiração do pix.

### DIFF
--- a/services/catarse/app/models/payment.rb
+++ b/services/catarse/app/models/payment.rb
@@ -55,7 +55,7 @@ class Payment < ApplicationRecord
   def pix_expiration_date
     # If payment does not exist gives expiration date based on current_timestamp
     if id.nil?
-      self.class.connection.select_one("SELECT public.weekdays_from(public.pix_expiration_weekdays(), current_timestamp::timestamp) at time zone 'America/Sao_Paulo' as weekdays_from")['weekdays_from'].try(:to_datetime)
+      2.days.from_now
     else
       pluck_from_database("pix_expires_at").try(:to_datetime)
     end

--- a/services/catarse/db/migrate/20210730120734_adjust_pix_expires_at_function.rb
+++ b/services/catarse/db/migrate/20210730120734_adjust_pix_expires_at_function.rb
@@ -1,0 +1,41 @@
+class AdjustPixExpiresAtFunction < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.pix_expiration_weekdays()
+      RETURNS int
+      LANGUAGE sql
+      STABLE
+      AS $function$
+          SELECT 2;
+          $function$;
+
+      CREATE OR REPLACE FUNCTION public.pix_expires_at(payments)
+      RETURNS timestamp without time zone
+      LANGUAGE sql
+      STABLE
+      AS $function$
+      SELECT weekdays_from(public.pix_expiration_weekdays(), public.zone_timestamp(coalesce(($1.gateway_data->>'pix_expiration_date'::text)::timestamp, $1.created_at)))::date + 1 - '1 second'::interval;
+          $function$;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.pix_expiration_weekdays()
+      RETURNS int
+      LANGUAGE sql
+      STABLE
+      AS $function$
+          SELECT 2;
+          $function$;
+
+      CREATE OR REPLACE FUNCTION public.pix_expires_at(payments)
+      RETURNS timestamp without time zone
+      LANGUAGE sql
+      STABLE
+      AS $function$
+      SELECT weekdays_from(public.pix_expiration_weekdays(), public.zone_timestamp(coalesce(($1.gateway_data->>'boleto_expiration_date'::text)::timestamp, $1.created_at)))::date + 1 - '1 second'::interval;
+          $function$;
+    SQL
+  end
+end

--- a/services/catarse/engines/catarse_pagarme/spec/dummy/app/models/payment.rb
+++ b/services/catarse/engines/catarse_pagarme/spec/dummy/app/models/payment.rb
@@ -22,7 +22,7 @@ class Payment < ActiveRecord::Base
   end
 
   def pix_expiration_date
-    2.weekdays_from_now
+    2.days.from_now
   end
 
   def generate_key


### PR DESCRIPTION
### Descrição
Os Pixs estão sendo gerado com prazo de validade de 2 dias úteis e deveria ser de 2 dias corridos.

### Referência
https://www.notion.so/catarse/Prazo-de-expira-o-do-PIX-precisa-ser-de-2-dias-corridos-e-n-o-2-dias-teis-80dddc96a0144495b2b73240f84dc57d

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
