### PR TITLE
🐞Remove um texto em branco nas notificações de reembolso para o saldo

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_refunded.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_refunded.html.slim
@@ -9,9 +9,9 @@ br/
 br/
 
 - if detail.payment_method == 'BoletoBancario' || detail.payment_method == 'Pix'
-  | O projeto #{project.name} foi #{project.decorator.display_mailer_status} e o valor do seu apoio já está disponível para saque em seu <strong>#{link_to 'perfil', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse.
+  | O seu apoio ao projeto #{project.name} foi reembolsado e já está disponível para saque em seu <strong>#{link_to 'saldo', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse.
 - else
-  | O projeto #{project.name} foi #{project.decorator.display_mailer_status} e, por isso, tentamos fazer o estorno do seu apoio para o cartão de crédito. Por algum motivo não foi possível estornar a transação diretamente para o seu cartão. Dessa forma, o valor do apoio está disponível para saque em seu <strong>#{link_to 'perfil', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse.
+  | Por algum motivo não foi possível estornar o seu apoio ao projeto #{project.name} diretamente para o seu cartão de crédito. Dessa forma, o valor está disponível para saque em seu <strong>#{link_to 'saldo', edit_user_url(contribution.user_id, anchor: 'balance')}</strong> no Catarse.
 br/
 br/
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_credit_card.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_credit_card.html.slim
@@ -7,7 +7,7 @@
 |Olá, <strong>#{contribution.user.display_name}</strong>!
 br
 br
-|O projeto #{contribution.project.name} foi #{project.decorator.display_mailer_status} aqui no #{company_name} e por isso reembolsamos o valor do seu apoio. O crédito efetivo deverá acontecer na fatura vigente, caso ela ainda esteja em aberto, ou na subsequente, caso a desse mês já esteja fechada.
+|Nós reembolsamos o seu apoio referente ao projeto #{contribution.project.name} aqui no #{company_name} . O crédito efetivo deverá acontecer na fatura vigente, caso ela ainda esteja em aberto, ou na subsequente, caso a desse mês já esteja fechada.
 br
 br
 - if detail.payment.gateway_data['paid_amount'].present?


### PR DESCRIPTION
### Descrição
Existia um termo nas notificações de reembolso que estava vindo em branco, deixando dúvidas sobre o que estávamos querendo dizer. Como era algo redundante. fiz um ajuste simples para remover o termo e mudei a redação da notificação.

### Referência
https://www.notion.so/catarse/Remove-texto-em-branco-nas-notifica-es-de-reembolso-no-Catarse-4d48356a124548e5be4c0234334c2e09

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
