### PR TITLE
🐞 Ajusta array do contador de recompensas selecionadas para remover i…

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content.js
@@ -23,6 +23,7 @@ const projectContributionReportContent = {
                 projectsContributionReportVM.getAllContributions(vnode.attrs.filterVM).then((data) => {
                     const exceptReceived = _.filter(data, contrib => contrib.delivery_status !== 'received');
                     selectedContributions().push(..._.pluck(exceptReceived, 'id'));
+                    selectedContributions([...new Set(selectedContributions())]);
                     selectedAny(!_.isEmpty(exceptReceived));
                 });
             },


### PR DESCRIPTION
…ds duplicados

### Descrição
Por que você está realizando essas mudanças e quais são as mudanças relevantes que você está enviando?
Aos selecionar todas as recompensas para marcar como `entregue`, o `array` dos `ids` permitia a duplicidade dos mesmos, ocasionando na contagem errada de recompensas selecionadas. Essa alteração remove os `ids` duplicados do `array`.


### Referência
Link para a atividade
https://www.notion.so/catarse/Ajustar-contador-ao-selecionar-uma-faixa-de-recompensas-para-marcar-como-entregue-82f50cacb7c6435c8879539787c6ccb7

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
