### PR TITLE
🐞 Corrige exibição do código pix como link no email

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
@@ -27,9 +27,9 @@ p Notamos que você não realizou o pagamento do PIX para o projeto #{link_to co
   br
   p Ou se preferir, abra o app ou site do seu banco e informe a chave abaixo:
   br
-  p
-    center
-      <strong>#{pix_key}</strong>
+  p(align="center" style="background-color: #F8F8F7; padding: 30px; border-radius: 10px; color: #000; margin: 20px")
+    a(href="#" style="text-decoration:none; color:#000; cursor:default")
+      strong = pix_key
   br
 
 = render partial: 'user_notifier/mailer/contact_info'

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
@@ -16,9 +16,9 @@ p
 br
 p Ou se preferir, abra o app ou site do seu banco e informe a chave abaixo:
 br
-p
-  center
-    <strong>#{pix_key}</strong>
+p(align="center" style="background-color: #F8F8F7; padding: 30px; border-radius: 10px; color: #000; margin: 20px")
+  a(href="#" style="text-decoration:none; color:#000; cursor:default")
+    strong = pix_key
 br
 p Caso já tenha feito o pagamento, desconsidere este email. Você receberá um outro email com a confirmação do pagamento e também poderá seguir acompanhando o status do seu apoio #{link_to 'em seu perfil do Catarse', edit_user_url(contribution.user.id, anchor: 'contributions'), target: '__blank'}
 


### PR DESCRIPTION
### Descrição
Alterar o estilo do texto e corrigir o problema de adição de link pelo cliente de email.

### Referência
https://www.notion.so/catarse/Deixar-de-exibir-o-c-digo-do-PIX-nas-notifica-es-como-se-fosse-um-link-11fc4acf041941769c7fa356b658a007

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [x] Adicionou o link desse pull request no card da atividade
- [ ] A base de conhecimento foi atualizada (Isso para quando tivermos uma)
