### PR TITLE
🐞 Corrige visualização do qr_code do pix no email

### DIFF
--- a/services/catarse/app/decorators/contribution_detail_decorator.rb
+++ b/services/catarse/app/decorators/contribution_detail_decorator.rb
@@ -36,9 +36,9 @@ class ContributionDetailDecorator < Draper::Decorator
     return QRCode::Renderer.as_svg(gateway_data['pix_qr_code']) if gateway_data.present?
   end
 
-  def display_pix_qr_code_base64
+  def pix_qr_code_png
     gateway_data = object.try(:gateway_data)
-    return QRCode::Renderer.as_base64_png(gateway_data['pix_qr_code']) if gateway_data.present?
+    return QRCode::Renderer.as_png(gateway_data['pix_qr_code']) if gateway_data.present?
   end
 
   def display_status

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
@@ -2,7 +2,7 @@
 - expiry_date = contribution.payments.last.gateway_data.try(:[], "pix_expiration_date").try(:to_datetime).try(:strftime, '%d/%m')
 - pix_key = contribution.payments.last.gateway_data.try(:[], "pix_qr_code")
 - details = contribution.details.ordered.first
-- link_url = project_contribution_url(contribution.project, contribution)
+- attachments.inline['pix_qrcode.png'] = details.decorate.pix_qr_code_png if respond_to? :attachments
 
 p Olá, <strong>#{contribution.user.display_name}</strong>!
 
@@ -23,7 +23,11 @@ p Notamos que você não realizou o pagamento do PIX para o projeto #{link_to co
   br
   p
     center
-      <a href="#{link_url}" align="center" style="margin-top: 30px; margin-bottom: 30px; background-color:#7cc142;font-size:18px;color:#ffffff;font-family:HelveticaNeue-Medium;font-weight:bold;text-decoration:none;padding-top:25px;padding-bottom:25px;display:inline-block;width:280px;text-align:center!important;border-radius:5px" bgcolor="#7CC142" target="_blank" data-saferedirecturl="#{link_url}"> Visualizar QR Code </a>
+      strong
+        - if respond_to? :attachments
+          = image_tag attachments[0].url
+        - else
+          = render inline: details.decorate.display_pix_qr_code
   br
   p Ou se preferir, abra o app ou site do seu banco e informe a chave abaixo:
   br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
@@ -2,7 +2,7 @@
 - expiry_date = contribution.payments.last.gateway_data.try(:[], "pix_expiration_date").try(:to_datetime).try(:strftime, '%d/%m')
 - pix_key = contribution.payments.last.gateway_data.try(:[], "pix_qr_code")
 - details = contribution.details.ordered.first
-- link_url = project_contribution_url(contribution.project, contribution)
+- attachments.inline['pix_qrcode.png'] = details.decorate.pix_qr_code_png if respond_to? :attachments
 
 p Olá, <strong>#{contribution.user.display_name}</strong> !
 
@@ -12,7 +12,11 @@ p Use o app do seu banco para escanear o QR Code abaixo:
 br
 p
   center
-    <a href="#{link_url}" align="center" style="margin-top: 30px; margin-bottom: 30px; background-color:#7cc142;font-size:18px;color:#ffffff;font-family:HelveticaNeue-Medium;font-weight:bold;text-decoration:none;padding-top:25px;padding-bottom:25px;display:inline-block;width:280px;text-align:center!important;border-radius:5px" bgcolor="#7CC142" target="_blank" data-saferedirecturl="#{link_url}"> Visualizar QR Code </a>
+    strong
+      - if respond_to? :attachments
+        = image_tag attachments[0].url
+      - else
+        = render inline: details.decorate.display_pix_qr_code
 br
 p Ou se preferir, abra o app ou site do seu banco e informe a chave abaixo:
 br

--- a/services/catarse/lib/qr_code/renderer.rb
+++ b/services/catarse/lib/qr_code/renderer.rb
@@ -15,10 +15,10 @@ module QRCode
       )
     end
 
-    def self.as_base64_png(string)
+    def self.as_png(string)
       qrcode = RQRCode::QRCode.new(string)
       png = qrcode.as_png(size: 350)
-      Base64.strict_encode64 png.to_blob(:fast_rgb)
+      png.to_blob(:fast_rgb)
     end
   end
 end


### PR DESCRIPTION
### Descrição
A atividade corrige a exibição da imagem do QR Code no corpo do email do pix.

### Referência
https://www.notion.so/catarse/Corrigir-exibi-o-do-QR-Code-do-pix-nas-notifica-es-por-email-f28d4c97eb3c45f5ba277a56cedd4a99

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
