### PR TITLE
✨ Criar rotina de geração  de ProjectFiscal

### DIFF
--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
@@ -8,15 +8,19 @@ class CreateProjectFiscalToProjectFlexAndAonAction
   end
 
   def call
-    create_project_data
+    @project_data = new_project_data
+    unless @project_data.total_amount_cents.zero? && @project_data.total_chargeback_cost_cents.zero?
+      @project_data.save!
+      @project_data
+    end
   rescue StandardError => e
     Sentry.capture_exception(e, level: :fatal)
   end
 
   private
 
-  def create_project_data
-    ProjectFiscal.create(
+  def new_project_data
+    ProjectFiscal.new(
       user_id: @project.user_id,
       project_id: @project.id,
       total_amount_cents: total_amount,

--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_sub_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_sub_action.rb
@@ -10,15 +10,19 @@ class CreateProjectFiscalToProjectSubAction
   end
 
   def call
-    create_project_data
+    @project_data = new_project_data
+    unless @project_data.total_amount_cents.zero? && @project_data.total_chargeback_cost_cents.zero?
+      @project_data.save!
+      @project_data
+    end
   rescue StandardError => e
     Sentry.capture_exception(e, level: :fatal)
   end
 
   private
 
-  def create_project_data
-    ProjectFiscal.create(
+  def new_project_data
+    ProjectFiscal.new(
       user_id: @project.user_id,
       project_id: @project.id,
       total_amount_cents: total_amount,

--- a/services/catarse/app/state_machines/aon_project_machine.rb
+++ b/services/catarse/app/state_machines/aon_project_machine.rb
@@ -21,5 +21,9 @@ class AonProjectMachine < FlexProjectMachine
     guard_transition(to: :successful) do |project|
       project.reached_goal?
     end
+
+    after_transition(to: :successful) do |project|
+      CreateProjectFiscalToProjectFlexAndAonAction.new(project_id: project.id).call
+    end
   end
 end

--- a/services/catarse/app/state_machines/flex_project_machine.rb
+++ b/services/catarse/app/state_machines/flex_project_machine.rb
@@ -90,6 +90,7 @@ class FlexProjectMachine
 
     after_transition(to: :successful) do |project|
       BalanceTransaction.insert_successful_project_transactions(project.id)
+      CreateProjectFiscalToProjectFlexAndAonAction.new(project_id: project.id).call
     end
 
     after_transition(after_commit: true, to: :deleted) do |project|

--- a/services/catarse/lib/tasks/cron.rake
+++ b/services/catarse/lib/tasks/cron.rake
@@ -249,6 +249,26 @@ namespace :cron do
     end
   end
 
+  desc 'create project fiscal to project flex and aon'
+  task create_project_fiscal_to_project_flex_and_aon: :environment do
+    Project.joins(:project_fiscals).where(mode: %i[aon flex], state: %i[waiting_funds successful])
+      .where("project_fiscals.end_date > ?", Time.zone.now - 2.months).each do |project|
+        CreateProjectFiscalToProjectFlexAndAonAction.new(project_id: project.id).call
+    end
+  end
+
+  desc 'create project fiscal to project sub'
+  task create_project_fiscal_to_project_sub: :environment do
+    Project.where(mode: %i[sub], state: %i[online]).each do |project|
+      CreateProjectFiscalToProjectSubAction.new(project_id: project.id, month: Time.zone.now.month, year: Time.zone.now.year).call
+    end
+
+    Project.joins(:project_fiscals).where(mode: %i[sub], state: %i[successful])
+      .where("project_fiscals.end_date > ?", Time.zone.now - 2.months).each do |project|
+        CreateProjectFiscalToProjectSubAction.new(project_id: project.id, month: Time.zone.now.month, year: Time.zone.now.year).call
+    end
+  end
+
   desc 'sync FB friends'
   task sync_fb_friends: [:environment] do
     Authorization.where("last_token is not null and updated_at >= current_timestamp - '24 hours'::interval").each do |authorization|


### PR DESCRIPTION
### Descrição
Criar duas rotinas para emitir os dados fiscais de pagamentos para projetos flex/aon e outra p/ sub.

### Referência
https://www.notion.so/catarse/Criar-rotina-para-gerar-os-dados-fiscais-de-pagamentos-feitos-ap-s-a-gera-o-dos-dados-fiscais-a55c6beca5764d0e87cded676ed9cfb7

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
