### PR TITLE
🐞 Desabilita aba 'Assinantes' de projetos de assinatura

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-tabs.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-tabs.js
@@ -58,7 +58,8 @@ const projectTabs = {
     },
     view: function({state, attrs}) {
         const project = attrs.project,
-            rewards = attrs.rewardDetails;
+            rewards = attrs.rewardDetails,
+            isSubscription = projectVM.isSubscription(project);
 
         return m('nav-wrapper', { style: attrs.style }, project() ? [
             m('.w-section.project-nav', {
@@ -72,8 +73,8 @@ const projectTabs = {
                                     style: 'float: left;',
                                     onclick: h.analytics.event({
                                         cat: 'project_view', act: 'project_rewards_view', project: project() })
-                                }, 'Recompensas') 
-                                : 
+                                }, 'Recompensas')
+                                :
                                 m(`a[id="rewards-link"][class="w-hidden-main w-hidden-medium dashboard-nav-link mf ${(h.hashMatch('#contribution_suggestions') || (h.mobileScreen() && h.hashMatch('')) ? 'selected' : '')}"][href="/${project().permalink}#contribution_suggestions"]`, {
                                     style: 'float: left;',
                                     onclick: h.analytics.event({
@@ -92,18 +93,20 @@ const projectTabs = {
                                 'Novidades ',
                                 m('span.badge', project() ? project().posts_count : '')
                             ]),
-                            m(`a[id="contributions-link"][class="w-hidden-small w-hidden-tiny dashboard-nav-link mf ${(h.hashMatch('#contributions') ? 'selected' : '')}"][href="#contributions"]`, {
-                                style: 'float: left;',
-                                onclick: h.analytics.event({
-                                    cat: 'project_view', act: 'project_contributions_view', project: project() })
-                            }, projectVM.isSubscription(project) ? [
-                                'Assinantes ',
-                                m('span.badge.w-hidden-small.w-hidden-tiny', attrs.subscriptionData() ? attrs.subscriptionData().total_subscriptions : '-')
-                            ] : [
-                                'Apoiadores ',
-                                m('span.badge.w-hidden-small.w-hidden-tiny', project() ? project().total_contributors : '-')
-                            ]
-                            ),
+                            !isSubscription ?
+                                m(`a[id="contributions-link"][class="w-hidden-small w-hidden-tiny dashboard-nav-link mf ${(h.hashMatch('#contributions') ? 'selected' : '')}"][href="#contributions"]`, {
+                                    style: 'float: left;',
+                                    onclick: h.analytics.event({
+                                        cat: 'project_view', act: 'project_contributions_view', project: project() })
+                                }, isSubscription ? [
+                                    'Assinantes ',
+                                    m('span.badge.w-hidden-small.w-hidden-tiny', attrs.subscriptionData() ? attrs.subscriptionData().total_subscriptions : '-')
+                                ] : [
+                                    'Apoiadores ',
+                                    m('span.badge.w-hidden-small.w-hidden-tiny', project() ? project().total_contributors : '-')
+                                ]
+                                )
+                            : '',
                             m(`a[id="comments-link"][class="dashboard-nav-link mf ${(h.hashMatch('#comments') ? 'selected' : '')}"][href="#comments"]`, {
                                 style: 'float: left;',
                                 onclick: h.analytics.event({


### PR DESCRIPTION
### Descrição
Essa alteração desabilita a aba 'Assinantes', já que não está carregando as informações. O código não foi removido, pois ainda será decidido o que será feito em definitivo.

### Referência
https://www.notion.so/catarse/LGPD-Remover-aba-de-Assinantes-de-projetos-de-Assinatura-e723a4d146fc4e8581c10abd36ad559c

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
