### PR TITLE
🐞 Ajusta chamada dos elementos do hash de informações para aspas simples

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_friends_contributions.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_friends_contributions.html.slim
@@ -4,7 +4,7 @@
 h1 style="text-align:center;display:block;margin:0;padding:0;color:#3f4752;font-family:Helvetica;font-size:20px;font-style:normal;font-weight:bold;line-height:125%;letter-spacing:normal"  Campanhas apoiadas por seus amigos
 
 - projects_friends.each do |info|
-  - project = Project.find(info[:project_id])
+  - project = Project.find(info['project_id'])
   tr
     td style="background-color:#ffffff;border-top:0;border-bottom:0;padding-top:20px;padding-bottom:20px" valign="top"
       table border="0" cellpadding="0" cellspacing="0" style="min-width:100%;border-collapse:collapse" width="100%"
@@ -16,7 +16,7 @@ h1 style="text-align:center;display:block;margin:0;padding:0;color:#3f4752;font-
                   tr
                     td style="padding-top:0;padding-right:18px;padding-bottom:9px;padding-left:18px;word-break:break-word;color:#3f4752;font-family:Helvetica;font-size:16px;line-height:150%;text-align:center" valign="top"
                       div style="text-align:center"
-                        - friends = User.where(id: info[:friends_ids])
+                        - friends = User.where(id: info['friends_ids'])
                         - friends.each do |friend|
                           img.CToWUd src="#{friend.display_image}" style="border-radius:50%;width:35px;border:0;min-height:auto!important;outline:none;text-decoration:none;min-height:auto!important" /
                         br/


### PR DESCRIPTION
### Descrição
Altera a chamada dos elementos do hash de symbol `:` para aspas simples `'`, pois estava gerando erro.

### Referência
https://www.notion.so/catarse/Corrigir-sincroniza-o-das-informa-es-no-email-autom-tico-de-contribui-es-de-amigos-d34e9a3a945246eb9e26eafb31dec6d6?d=6ce90340-ccd9-41ba-9502-4a289b5d4828

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
