### PR TITLE
🐞 Pagamentos reembolsados devem ser tratados como pagamento pago

### DIFF
--- a/services/service-core-db/migrations/2021-08-17-103910_refunded_should_be_like_paid/down.sql
+++ b/services/service-core-db/migrations/2021-08-17-103910_refunded_should_be_like_paid/down.sql
@@ -1,0 +1,78 @@
+-- This file should undo anything in `up.sql`
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION payment_service.next_charge_at(s payment_service.subscriptions)
+ RETURNS timestamp without time zone
+ LANGUAGE sql
+ STABLE
+AS $function$
+        select coalesce(
+            (select cp.created_at + core.get_setting('subscription_interval')::interval
+                from payment_service.catalog_payments cp
+                    where cp.subscription_id = $1.id
+                        and cp.status in ('paid')
+                        order by cp.created_at desc
+                        limit 1)::date
+            , now()::date)::timestamp
+    $function$;
+
+CREATE OR REPLACE FUNCTION payment_service.subscriptions_charge()
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _result json;
+            _subscription payment_service.subscriptions;
+            _last_paid_payment payment_service.catalog_payments;
+            _new_payment payment_service.catalog_payments;
+            _affected_subscriptions_ids uuid[];
+            _total_affected integer;
+        begin
+            _total_affected := 0;
+            -- get all subscriptions that not have any pending payment and last paid payment is over interval
+            for _subscription IN (select s.*
+                from payment_service.subscriptions s
+                join project_service.projects p
+                    on p.id = s.project_id
+                        and p.platform_id = s.platform_id
+                left join lateral (
+                    -- get last paid payment after interval
+                    select
+                        cp.*
+                    from payment_service.catalog_payments cp
+                    where cp.subscription_id = s.id
+                        and cp.status = 'paid'
+                    order by cp.created_at desc limit 1
+                ) as last_paid_payment on true
+                left join lateral (
+                    -- get last paymnent (sometimes we can have a pending, refused... after a paid)
+                    -- and ensure that payment is greater or same that is paid
+                    select
+                        cp.*
+                    from payment_service.catalog_payments cp
+                        where cp.subscription_id = s.id
+                            and cp.status <> 'deleted'
+                            and cp.created_at > last_paid_payment.created_at
+                    order by cp.created_at desc limit 1
+                ) as last_payment on true
+                where last_paid_payment.id is not null
+                    and payment_service.next_charge_at(s) <= now()
+                    and (last_payment.id is null or last_payment.status in ('paid'))
+                    -- check only for subscriptions that in paid
+                    and p.status = 'online'
+                    and s.status in ('active'))
+            loop
+                _new_payment := payment_service.generate_new_catalog_payment(_subscription);
+                if _new_payment.id is not null then
+                    _total_affected := _total_affected + 1;
+                    _affected_subscriptions_ids := array_append(_affected_subscriptions_ids, _subscription.id);
+                end if;
+            end loop;
+
+            _result := json_build_object(
+                'total_affected', _total_affected,
+                'affected_ids', _affected_subscriptions_ids
+            );
+
+            return _result;
+        end;
+    $function$

--- a/services/service-core-db/migrations/2021-08-17-103910_refunded_should_be_like_paid/up.sql
+++ b/services/service-core-db/migrations/2021-08-17-103910_refunded_should_be_like_paid/up.sql
@@ -1,0 +1,77 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION payment_service.next_charge_at(s payment_service.subscriptions)
+ RETURNS timestamp without time zone
+ LANGUAGE sql
+ STABLE
+AS $function$
+        select coalesce(
+            (select cp.created_at + core.get_setting('subscription_interval')::interval
+                from payment_service.catalog_payments cp
+                    where cp.subscription_id = $1.id
+                        and cp.status in ('paid', 'refunded')
+                        order by cp.created_at desc
+                        limit 1)::date
+            , now()::date)::timestamp
+    $function$;
+
+CREATE OR REPLACE FUNCTION payment_service.subscriptions_charge()
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _result json;
+            _subscription payment_service.subscriptions;
+            _last_paid_payment payment_service.catalog_payments;
+            _new_payment payment_service.catalog_payments;
+            _affected_subscriptions_ids uuid[];
+            _total_affected integer;
+        begin
+            _total_affected := 0;
+            -- get all subscriptions that not have any pending payment and last paid payment is over interval
+            for _subscription IN (select s.*
+                from payment_service.subscriptions s
+                join project_service.projects p
+                    on p.id = s.project_id
+                        and p.platform_id = s.platform_id
+                left join lateral (
+                    -- get last paid payment after interval
+                    select
+                        cp.*
+                    from payment_service.catalog_payments cp
+                    where cp.subscription_id = s.id
+                        and cp.status = 'paid'
+                    order by cp.created_at desc limit 1
+                ) as last_paid_payment on true
+                left join lateral (
+                    -- get last paymnent (sometimes we can have a pending, refused... after a paid)
+                    -- and ensure that payment is greater or same that is paid
+                    select
+                        cp.*
+                    from payment_service.catalog_payments cp
+                        where cp.subscription_id = s.id
+                            and cp.status <> 'deleted'
+                            and cp.created_at > last_paid_payment.created_at
+                    order by cp.created_at desc limit 1
+                ) as last_payment on true
+                where last_paid_payment.id is not null
+                    and payment_service.next_charge_at(s) <= now()
+                    and (last_payment.id is null or last_payment.status in ('paid', 'refunded'))
+                    -- check only for subscriptions that in paid
+                    and p.status = 'online'
+                    and s.status in ('active'))
+            loop
+                _new_payment := payment_service.generate_new_catalog_payment(_subscription);
+                if _new_payment.id is not null then
+                    _total_affected := _total_affected + 1;
+                    _affected_subscriptions_ids := array_append(_affected_subscriptions_ids, _subscription.id);
+                end if;
+            end loop;
+
+            _result := json_build_object(
+                'total_affected', _total_affected,
+                'affected_ids', _affected_subscriptions_ids
+            );
+
+            return _result;
+        end;
+    $function$;


### PR DESCRIPTION
### Descrição
Quando um pagamento de assinatura vira para o status refunded a assinatura permanece ativa mas não gera uma próxima cobrança

### Referência
https://www.notion.so/catarse/Pagamentos-reembolsados-devem-ser-tratados-como-pagamento-pago-73a08d6f70964d17b59ddd54dcff2e2c

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
