### PR TITLE
🐞 Remove public name from empty posts tab

### DIFF
--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/project.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/project.pt.yml
@@ -58,7 +58,7 @@ pt:
           image: 'https://s3.amazonaws.com/cdn.catarse/assets/banner-home-landing-publicacoes.jpg'                
     new_feature_badge: 'Novidade'
     posts:
-      empty: '<span class="fontweight-semibold">%{project_user_name}</span> ainda não publicou nenhuma novidade. <a href="/projects/%{project_id}/contributions/new" class="alt-link">Faça um apoio</a> e receba em seu email todas as notícias do projeto assim que elas forem publicadas!'
+      empty: 'Este projeto ainda não publicou nenhuma novidade. <a href="/projects/%{project_id}/contributions/new" class="alt-link">Faça um apoio</a> e receba em seu email todas as notícias do projeto assim que elas forem publicadas!'
     publish:
       aon: 'Tudo ou nada'
       sub: 'Assinatura'


### PR DESCRIPTION
### Descrição
Estamos removendo o nome público do realizador da aba de Novidades, quando não existem posts criados.

### Referência
https://www.notion.so/catarse/Remover-o-nome-do-realizador-na-aba-de-Novidades-b1c43f49bdf849b8bdea2ec3b2c495e4

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
