### PR TITLE
✨ Adiciona Dados Fiscais no Frontend

### DIFF
--- a/services/catarse/app/controllers/projects/project_fiscal_controller.rb
+++ b/services/catarse/app/controllers/projects/project_fiscal_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Projects
+  class ProjectFiscalController < ApplicationController
+    before_action :set_date, only: [:inform]
+
+    inherit_resources
+    actions :show
+    belongs_to :project
+
+    def debit_note
+      fiscal_data = ProjectFiscal.where('project_id = ? AND end_date <= ?', params[:project_id],
+        params[:fiscal_date].to_date
+      ).order('end_date desc').first
+      if fiscal_data.nil?
+        redirect_to edit_project_path(params[:project_id], locale: nil)
+      else
+        authorize fiscal_data
+        template = 'project_fiscal_debit_note'
+        render "user_notifier/mailer/#{template}", locals: { fiscal_data: fiscal_data }, layout: 'layouts/email'
+      end
+    end
+
+    def inform
+      fiscal_data = ProjectFiscal.where('project_id = ? AND begin_date >= ? AND end_date <= ?', params[:project_id],
+        @begin_date, @end_date
+      )
+      if fiscal_data.nil?
+        redirect_to edit_project_path(params[:project_id], locale: nil)
+      else
+        template = 'project_fiscal_inform'
+        render "user_notifier/mailer/#{template}", locals: { fiscal_data: fiscal_data }, layout: 'layouts/email'
+      end
+    end
+
+    private
+
+    def set_date
+      @begin_date = "01/#{params[:fiscal_year]}".to_date.beginning_of_month
+      @end_date = "12/#{params[:fiscal_year]}".to_date.end_of_month
+    end
+  end
+end

--- a/services/catarse/app/models/project_fiscal.rb
+++ b/services/catarse/app/models/project_fiscal.rb
@@ -9,11 +9,17 @@ class ProjectFiscal < ApplicationRecord
   validates :begin_date, presence: true
   validates :end_date, presence: true
 
-  monetize :total_amount_cents, numericality: { greater_than_or_equal_to: 1 }
-  monetize :total_catarse_fee_cents, numericality: { greater_than_or_equal_to: 1 }
-  monetize :total_gateway_fee_cents, numericality: { greater_than_or_equal_to: 1 }
+  monetize :total_amount_to_pj_cents, numericality: { greater_than_or_equal_to: 0 }
+  monetize :total_amount_to_pf_cents, numericality: { greater_than_or_equal_to: 0 }
+  monetize :total_catarse_fee_cents, numericality: { greater_than_or_equal_to: 0 }
+  monetize :total_gateway_fee_cents, numericality: { greater_than_or_equal_to: 0 }
+  monetize :total_irrf_cents, numericality: { greater_than_or_equal_to: 0 }
 
   def total_debit_invoice
     total_catarse_fee_cents - total_gateway_fee_cents - total_antifraud_fee_cents
+  end
+
+  def total_amount
+    total_amount_to_pj_cents + total_amount_to_pf_cents
   end
 end

--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
@@ -9,7 +9,7 @@ class CreateProjectFiscalToProjectFlexAndAonAction
 
   def call
     @project_data = new_project_data
-    unless @project_data.total_amount_cents.zero? && @project_data.total_chargeback_cost_cents.zero?
+    if @project_data.total_amount_to_pf_cents.positive? || @project_data.total_amount_to_pj_cents.positive?
       @project_data.save!
       @project_data
     end
@@ -23,20 +23,45 @@ class CreateProjectFiscalToProjectFlexAndAonAction
     ProjectFiscal.new(
       user_id: @project.user_id,
       project_id: @project.id,
-      total_amount_cents: total_amount,
+      total_amount_to_pf_cents: total_amount_to_pj,
+      total_amount_to_pj_cents: total_amount_to_pf,
       total_catarse_fee_cents: total_catarse_fee,
       total_gateway_fee_cents: total_geteway_fee('paid'),
       total_antifraud_fee_cents: total_antifraud_fee('paid'),
       total_chargeback_cost_cents: total_chargeback_cost,
+      total_irrf_cents: total_irrf,
       begin_date: begin_date,
       end_date: end_date
     )
   end
 
-  def total_amount
-    query = Payment.joins(:contribution).where(contribution: { project_id: @project.id }, state: 'paid')
+  def total_amount_to_pj
+    query = Payment.joins(contribution: :user).where(
+      contribution: { project_id: @project.id },
+      user: { account_type: %w[pj mei] }, state: 'paid'
+    )
 
     time_interval(query, 'payments', 'paid').sum(:value)
+  end
+
+  def total_amount_to_pf
+    query = Payment.joins(contribution: :user).where(
+      contribution: { project_id: @project.id },
+      user: { account_type: 'pf' }, state: 'paid'
+    )
+
+    time_interval(query, 'payments', 'paid').sum(:value)
+  end
+
+  def total_irrf
+    return 0 if total_catarse_fee > 666.66
+
+    query = Payment.joins(contribution: :user).where(
+      contribution: { project_id: @project.id },
+      user: { account_type: %w[pj mei] }, state: 'paid'
+    )
+
+    0.015 * time_interval(query, 'payments', 'paid').sum(:value)
   end
 
   def total_catarse_fee

--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_sub_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_sub_action.rb
@@ -11,7 +11,7 @@ class CreateProjectFiscalToProjectSubAction
 
   def call
     @project_data = new_project_data
-    unless @project_data.total_amount_cents.zero? && @project_data.total_chargeback_cost_cents.zero?
+    if @project_data.total_amount_to_pf_cents.positive? || @project_data.total_amount_to_pj_cents.positive?
       @project_data.save!
       @project_data
     end
@@ -25,20 +25,45 @@ class CreateProjectFiscalToProjectSubAction
     ProjectFiscal.new(
       user_id: @project.user_id,
       project_id: @project.id,
-      total_amount_cents: total_amount,
+      total_amount_to_pf_cents: total_amount_to_pf,
+      total_amount_to_pj_cents: total_amount_to_pj,
       total_catarse_fee_cents: total_catarse_fee,
       total_gateway_fee_cents: total_geteway_fee('paid'),
       total_antifraud_fee_cents: total_antifraud_fee('paid'),
       total_chargeback_cost_cents: total_chargeback_cost,
+      total_irrf_cents: total_irrf,
       begin_date: begin_date,
       end_date: end_date
     )
   end
 
-  def total_amount
-    query = Payment.joins(:contribution).where(contribution: { project_id: @project.id }, state: 'paid')
+  def total_amount_to_pj
+    query = Payment.joins(contribution: :user).where(
+      contribution: { project_id: @project.id },
+      user: { account_type: %w[pj mei] }, state: 'paid'
+    )
 
     time_interval(query, 'payments', 'paid').sum(:value)
+  end
+
+  def total_amount_to_pf
+    query = Payment.joins(contribution: :user).where(
+      contribution: { project_id: @project.id },
+      user: { account_type: 'pf' }, state: 'paid'
+    )
+
+    time_interval(query, 'payments', 'paid').sum(:value)
+  end
+
+  def total_irrf
+    return 0 if total_catarse_fee > 666.66
+
+    query = Payment.joins(contribution: :user).where(
+      contribution: { project_id: @project.id },
+      user: { account_type: %w[pj mei] }, state: 'paid'
+    )
+
+    0.015 * time_interval(query, 'payments', 'paid').sum(:value)
   end
 
   def total_catarse_fee

--- a/services/catarse/app/policies/project_fiscal_policy.rb
+++ b/services/catarse/app/policies/project_fiscal_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProjectFiscalPolicy < ApplicationPolicy
+  def debit_note?
+    done_by_owner_or_admin?
+  end
+
+  def inform?
+    done_by_owner_or_admin?
+  end
+end

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_debit_note.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_debit_note.slim
@@ -1,0 +1,60 @@
+- fiscal_data ||= @notification.fiscal_data
+- project = fiscal_data.project
+- user = fiscal_data.user
+- address = fiscal_data.user.address
+- project_link = project_by_slug_url(permalink: project['permalink'])
+- begin_date = fiscal_data.begin_date.strftime('%d/%m/%Y')
+- end_date = fiscal_data.end_date.strftime('%d/%m/%Y')
+
+center
+  h1 style="line-height: 5px" NOTA DE DÉBITO
+
+hr/
+
+br/
+h3 EMITENTE
+p style="margin:0;" Grupo Comum Consultoria e Intermediação de Negócios Ltda ME
+p style="margin:0;" CNPJ: 14.512.425/0001-94 | CCM 4.675.208-0
+p style="margin:0;"  Endereço: Av. Paulista 171, 4º andar – Bela Vista – São Paulo/SP
+p style="margin:0;"  CEP: 01311-000
+
+h3 DEVEDOR
+
+p style="margin:0;"  Nome/Razão Social: #{user['name']}
+p style="margin:0;"  CPF/CNPJ: #{user['cpf']}
+- if address
+  p style="margin:0;"  Endereço: #{address['address_street']}, #{address['address_number']} #{address['address_complement']}, #{address['address_neighbourhood']}, #{address['address_city']}, #{address['address_state']}, #{address['address_zip_code']}
+
+h3 DISCRIMINAÇÃO DOS DÉBITOS
+
+table style="border: 1px solid;max-width:100%;border-collapse: collapse;"
+  tr
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Data
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Histórico
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Valor
+  tr
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{begin_date} - #{end_date}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;"
+      span Tarifas dos meios de pagamento dos apoios ao projeto "#{project['name']}".
+      br/
+      span #{project_link}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency fiscal_data.total_gateway_fee_cents, precision: 2}
+  trproject_link
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{begin_date} - #{end_date}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;"
+      span Tarifas das análises de antifraude dos apoios ao projeto "#{project['name']}".
+      br/
+      span #{project_link}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency fiscal_data.total_antifraud_fee_cents, precision: 2}
+
+br/
+p Declaro para os devidos fins ter recebido a importância acima discriminada dando plena e irrevogável quitação.
+br/
+p style="text-align:center;" São Paulo
+  p #{begin_date} - #{end_date}
+
+p Catarse - GRUPO COMUM CONSULTORIA E INTERMEDIAÇÃO DE NEGÓCIOS

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_inform.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_inform.slim
@@ -1,0 +1,92 @@
+- fiscal_data ||= @notification.fiscal_data
+- project = fiscal_data.last.project
+- user = fiscal_data.last.user
+- finished_date = fiscal_data.last.end_date.strftime('%d/%m/%Y')
+
+center
+  h1 style="line-height: 5px" INFORME DE RENDIMENTOS
+
+hr/
+
+br/
+p style="margin:0;"
+  span style="font-weight:bold;" Projeto:
+  span #{project.name}
+p style="margin:0;"
+  span style="font-weight:bold;" Beneficiário:
+  span #{user.name}
+p style="margin:0;"
+  span style="font-weight:bold;" CPF/CNPJ:
+  span #{user.cpf}
+
+
+- unless fiscal_data.sum(:total_amount_to_pf_cents).zero?
+  h3 PESSOAS FÍSICAS:
+  table style="border: 1px solid;width:100%;border-collapse: collapse;"
+    tr
+      td style="border: 1px solid;text-align:center;font-weight:bold;" INTERVALO
+      td style="border: 1px solid;text-align:center;font-weight:bold;" VALOR
+    - fiscal_data.each do |fiscal|
+      tr
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{fiscal.begin_date.strftime('%d/%m/%Y')} - #{fiscal.end_date.strftime('%d/%m/%Y')}
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{number_to_currency fiscal.total_amount_to_pf_cents, precision: 2}
+
+- unless fiscal_data.sum(:total_amount_to_pj_cents).zero?
+  h3 PESSOAS JURÍDICAS:
+  table style="border: 1px solid;width:100%;border-collapse: collapse;"
+    tr
+      td style="border: 1px solid;text-align:center;font-weight:bold;" INTERVALO
+      td style="border: 1px solid;text-align:center;font-weight:bold;" VALOR
+    - fiscal_data.each do |fiscal|
+      tr
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{fiscal.begin_date.strftime('%d/%m/%Y')} - #{fiscal.end_date.strftime('%d/%m/%Y')}
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{number_to_currency fiscal.total_amount_to_pj_cents, precision: 2}
+
+h3 DISCRIMINAÇÃO DOS RENDIMENTOS:
+
+table style="border: 1px solid;width:100%;border-collapse: collapse;"
+  tr
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Valor Arrecadado
+    td style="border: 1px solid;text-align:center;font-weight:bold;"
+      span #{number_to_currency fiscal_data.sum(:total_amount_to_pf_cents) + fiscal_data.sum(:total_amount_to_pj_cents), precision: 2}
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span Meio de Pagamento (-)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency fiscal_data.sum(:total_gateway_fee_cents), precision: 2}
+
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span Custo do Antifraude (-)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency fiscal_data.sum(:total_antifraud_fee_cents), precision: 2}
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span Taxa Líquida Catarse (-)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency -fiscal_data.sum(:total_catarse_fee_cents) - (fiscal_data.sum(:total_gateway_fee_cents) || 0) - (fiscal_data.sum(:total_antifraud_fee_cents) || 0) , precision: 2}
+  - unless fiscal_data.sum(:total_irrf_cents).zero?
+    tr
+      td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+        span Retenção IRRF (+)
+      td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+        span #{number_to_currency fiscal_data.sum(:total_irrf_cents), precision: 2}
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span style="font-weight:bold;"
+        span Repasse líquido (#{(1-project.service_fee)*100}%
+        - unless fiscal_data.sum(:total_irrf_cents).zero?
+          span + Retenções
+        span ) (=)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{number_to_currency fiscal_data.sum(:total_amount_to_pf_cents) + fiscal_data.sum(:total_amount_to_pj_cents) -fiscal_data.sum(:total_catarse_fee_cents) - (fiscal_data.sum(:total_gateway_fee_cents) || 0) - (fiscal_data.sum(:total_antifraud_fee_cents) || 0), precision: 2}
+
+br/
+p style="text-align:right;" São Paulo #{finished_date}
+
+p style="margin:0;" GRUPO COMUM CONSULTORIA E INTERMEDIAÇÃO DE NEGÓCIOS
+p style="margin:0;" CNPJ 14.512.425/0001-94

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -110,6 +110,8 @@ Catarse::Application.routes.draw do
         get 'debit_note/:fiscal_date', to: 'projects/project_fiscal_data#debit_note'
         get 'inform/:fiscal_year', to: 'projects/project_fiscal_data#inform'
 
+        get 'project_debit_note/:fiscal_date', to: 'projects/project_fiscal#debit_note'
+        get 'project_inform/:fiscal_year', to: 'projects/project_fiscal#inform'
         resources :contributions, { except: [:index], controller: 'projects/contributions' } do
           collection do
             get :fallback_create, to: 'projects/contributions#create'

--- a/services/catarse/db/migrate/20210824110814_add_total_irrf_on_project_fiscals.rb
+++ b/services/catarse/db/migrate/20210824110814_add_total_irrf_on_project_fiscals.rb
@@ -1,0 +1,5 @@
+class AddTotalIrrfOnProjectFiscals < ActiveRecord::Migration[6.1]
+  def change
+    add_monetize :project_fiscals, :total_irrf
+  end
+end

--- a/services/catarse/db/migrate/20210825113905_add_total_amount_to_pj_on_project_fiscals.rb
+++ b/services/catarse/db/migrate/20210825113905_add_total_amount_to_pj_on_project_fiscals.rb
@@ -1,0 +1,5 @@
+class AddTotalAmountToPjOnProjectFiscals < ActiveRecord::Migration[6.1]
+  def change
+    add_monetize :project_fiscals, :total_amount_to_pj
+  end
+end

--- a/services/catarse/db/migrate/20210825113934_add_total_amount_to_pf_on_project_fiscals.rb
+++ b/services/catarse/db/migrate/20210825113934_add_total_amount_to_pf_on_project_fiscals.rb
@@ -1,0 +1,5 @@
+class AddTotalAmountToPfOnProjectFiscals < ActiveRecord::Migration[6.1]
+  def change
+    add_monetize :project_fiscals, :total_amount_to_pf
+  end
+end

--- a/services/catarse/db/migrate/20210825113959_remove_total_amount_on_project_fiscals.rb
+++ b/services/catarse/db/migrate/20210825113959_remove_total_amount_on_project_fiscals.rb
@@ -1,0 +1,5 @@
+class RemoveTotalAmountOnProjectFiscals < ActiveRecord::Migration[6.1]
+  def remove
+    remove_monetize :project_fiscals, :total_amount
+  end
+end

--- a/services/catarse/spec/models/project_fiscal_spec.rb
+++ b/services/catarse/spec/models/project_fiscal_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe ProjectFiscal, type: :model do
     it { is_expected.to validate_presence_of(:end_date) }
     it { is_expected.to validate_presence_of(:begin_date) }
 
-    it { is_expected.to validate_numericality_of(:total_amount).is_greater_than_or_equal_to(1) }
-    it { is_expected.to validate_numericality_of(:total_catarse_fee).is_greater_than_or_equal_to(1) }
-    it { is_expected.to validate_numericality_of(:total_gateway_fee).is_greater_than_or_equal_to(1) }
+    it { is_expected.to validate_numericality_of(:total_amount_to_pf).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:total_amount_to_pj).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:total_catarse_fee).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:total_gateway_fee).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:total_irrf).is_greater_than_or_equal_to(0) }
   end
 end

--- a/services/catarse/spec/old_actions/create_project_fiscal_to_project_flex_and_aon_action_spec.rb
+++ b/services/catarse/spec/old_actions/create_project_fiscal_to_project_flex_and_aon_action_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreateProjectFiscalToProjectFlexAndAonAction, type: :action do
-  let(:value) { 10 }
+  let(:value) { 700 }
   let(:project) { create(:project, state: 'online') }
 
   describe '#call' do
@@ -13,6 +13,7 @@ RSpec.describe CreateProjectFiscalToProjectFlexAndAonAction, type: :action do
       [
         create(:confirmed_contribution, value: value, project: project),
         create(:confirmed_contribution, value: value, project: project),
+        create(:confirmed_contribution, value: value, project: project),
         create(:contribution, value: value, project: project)
       ]
     end
@@ -20,7 +21,8 @@ RSpec.describe CreateProjectFiscalToProjectFlexAndAonAction, type: :action do
       [
         contribution[0].payments.last,
         contribution[1].payments.last,
-        create(:payment, state: 'chargeback', contribution: contribution[2], value: value,
+        contribution[2].payments.last,
+        create(:payment, state: 'chargeback', contribution: contribution[3], value: value,
           created_at: Time.zone.now - 1.month
         )
       ]
@@ -29,41 +31,52 @@ RSpec.describe CreateProjectFiscalToProjectFlexAndAonAction, type: :action do
     let!(:antifraud) do
       [
         create(:antifraud_analysis, payment: payment[0], created_at: Time.zone.now - 1.month),
-        create(:antifraud_analysis, payment: payment[1], created_at: Time.zone.now - 2.months),
-        create(:antifraud_analysis, payment: payment[2], created_at: Time.zone.now - 1.month)
+        create(:antifraud_analysis, payment: payment[1], created_at: Time.zone.now - 1.month),
+        create(:antifraud_analysis, payment: payment[2], created_at: Time.zone.now - 2.months),
+        create(:antifraud_analysis, payment: payment[3], created_at: Time.zone.now - 1.month)
       ]
     end
 
     before do
       payment[0].update(created_at: Time.zone.now - 1.month)
-      payment[1].update(created_at: Time.zone.now - 2.months)
+      payment[1].update(created_at: Time.zone.now - 1.month)
+      payment[2].update(created_at: Time.zone.now - 2.months)
+      contribution[0].user.update(account_type: 'pf')
+      contribution[1].user.update(account_type: 'pj')
+      contribution[2].user.update(account_type: 'pf')
+      contribution[3].user.update(account_type: 'pj')
     end
 
     it 'returns project fiscals attributes' do
       expect(result.reload.attributes).to include(
         'user_id' => project.user_id,
         'project_id' => project.id,
-        'total_amount_cents' => (payment[1].value + payment[0].value).to_i,
-        'total_catarse_fee_cents' => (project.service_fee * (payment[1].value + payment[0].value)).to_i,
-        'total_gateway_fee_cents' => (payment[1].gateway_fee + payment[0].gateway_fee).to_i,
-        'total_antifraud_fee_cents' => (antifraud[0].cost + antifraud[1].cost).to_i,
+        'total_irrf_cents' => (0.015 * payment[1].value).to_i,
+        'total_amount_to_pj_cents' => (payment[1].value + payment[1].value).to_i,
+        'total_amount_to_pf_cents' => payment[0].value.to_i,
+        'total_catarse_fee_cents' => (project.service_fee *
+          (payment[2].value + payment[1].value + payment[0].value)).to_i,
+        'total_gateway_fee_cents' => (payment[2].gateway_fee + payment[1].gateway_fee + payment[0].gateway_fee).to_i,
+        'total_antifraud_fee_cents' => (antifraud[0].cost + antifraud[1].cost + antifraud[2].cost).to_i,
         'total_chargeback_cost_cents' => (payment[2].gateway_fee + antifraud[2].cost).to_i
       )
     end
 
     context 'when there are already fiscal projects' do
       before do
-        create(:project_fiscal, project: project, created_at: Time.zone.tomorrow - 2.months)
+        create(:project_fiscal, project: project, created_at: Time.zone.tomorrow - 60.days)
       end
 
       it 'returns project fiscals attributes' do
         expect(result.reload.attributes).to include(
           'user_id' => project.user_id,
           'project_id' => project.id,
-          'total_amount_cents' => payment[0].value.to_i,
-          'total_catarse_fee_cents' => (project.service_fee * payment[0].value).to_i,
-          'total_gateway_fee_cents' => payment[0].gateway_fee.to_i,
-          'total_antifraud_fee_cents' => antifraud[0].cost.to_i,
+          'total_irrf_cents' => (0.015 * payment[1].value).to_i,
+          'total_amount_to_pj_cents' => payment[1].value.to_i,
+          'total_amount_to_pf_cents' => payment[0].value.to_i,
+          'total_catarse_fee_cents' => (project.service_fee * (payment[1].value + payment[0].value)).to_i,
+          'total_gateway_fee_cents' => (payment[0].gateway_fee + payment[1].gateway_fee).to_i,
+          'total_antifraud_fee_cents' => (antifraud[0].cost + antifraud[1].cost).to_i,
           'total_chargeback_cost_cents' => (payment[2].gateway_fee + antifraud[2].cost).to_i
         )
       end

--- a/services/catarse/spec/old_actions/create_project_fiscal_to_project_sub_action_spec.rb
+++ b/services/catarse/spec/old_actions/create_project_fiscal_to_project_sub_action_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreateProjectFiscalToProjectSubAction, type: :action do
-  let(:value) { 10 }
+  let(:value) { 700 }
 
   describe '#call' do
     subject(:result) do
@@ -18,6 +18,7 @@ RSpec.describe CreateProjectFiscalToProjectSubAction, type: :action do
     let(:contribution) do
       [
         create(:confirmed_contribution, value: value, project: subscription_project),
+        create(:confirmed_contribution, value: value, project: subscription_project),
         create(:confirmed_contribution, value: value, project: subscription_project,
           created_at: Time.zone.now - 2.months
         ),
@@ -27,30 +28,36 @@ RSpec.describe CreateProjectFiscalToProjectSubAction, type: :action do
     let!(:payment) do
       [
         contribution[0].payments.last,
-        create(:payment, state: 'chargeback', contribution: contribution[2], value: value)
+        contribution[1].payments.last,
+        create(:payment, state: 'chargeback', contribution: contribution[3], value: value)
       ]
     end
     let!(:antifraud) do
       [
         create(:antifraud_analysis, payment: payment[0]),
-        create(:antifraud_analysis, payment: payment[1])
+        create(:antifraud_analysis, payment: payment[1]),
+        create(:antifraud_analysis, payment: payment[2]),
+        create(:antifraud_analysis, payment: contribution[2].payments.last, created_at: Time.zone.now - 2.months)
       ]
     end
 
     before do
-      contribution[1].payments.last.update(created_at: Time.zone.now - 2.months)
-      create(:antifraud_analysis, payment: contribution[1].payments.last, created_at: Time.zone.now - 2.months)
+      contribution[0].user.update(account_type: 'pj')
+      contribution[1].user.update(account_type: 'pf')
+      contribution[2].payments.last.update(created_at: Time.zone.now - 2.months)
     end
 
     it 'returns project fiscals attributes' do
       expect(result.attributes).to include(
         'user_id' => subscription_project.user_id,
         'project_id' => subscription_project.id,
-        'total_amount_cents' => payment[0].value.to_i,
-        'total_catarse_fee_cents' => (subscription_project.service_fee * payment[0].value).to_i,
-        'total_gateway_fee_cents' => payment[0].gateway_fee.to_i,
-        'total_antifraud_fee_cents' => antifraud[0].cost.to_i,
-        'total_chargeback_cost_cents' => (payment[1].gateway_fee + antifraud[1].cost).to_i
+        'total_irrf_cents' => (0.015 * payment[1].value).to_i,
+        'total_amount_to_pj_cents' => payment[0].value.to_i,
+        'total_amount_to_pf_cents' => payment[1].value.to_i,
+        'total_catarse_fee_cents' => (subscription_project.service_fee * (payment[0].value + payment[1].value)).to_i,
+        'total_gateway_fee_cents' => (payment[0].gateway_fee + payment[1].gateway_fee).to_i,
+        'total_antifraud_fee_cents' => (antifraud[0].cost + antifraud[1].cost).to_i,
+        'total_chargeback_cost_cents' => (payment[2].gateway_fee + antifraud[2].cost).to_i
       )
     end
   end

--- a/services/catarse/spec/state_machines/aon_project_machine_spec.rb
+++ b/services/catarse/spec/state_machines/aon_project_machine_spec.rb
@@ -808,6 +808,7 @@ RSpec.describe AonProjectMachine, type: :model do
         project.state_machine.transition_to!(:online)
         contribution = create(:confirmed_contribution, value: 10, project: project)
         contribution.payments.last.update(created_at: Time.zone.now - 1.month)
+        contribution.user.update(account_type: 'pf')
         create(:antifraud_analysis, payment: contribution.payments.last, created_at: Time.zone.now - 1.month)
 
         allow(project).to receive(:expired?).and_return(true)

--- a/services/catarse/spec/state_machines/flex_project_machine_spec.rb
+++ b/services/catarse/spec/state_machines/flex_project_machine_spec.rb
@@ -265,6 +265,7 @@ RSpec.describe FlexProjectMachine, type: :model do
       flexible_project.state_machine.transition_to!(:online)
       contribution = create(:confirmed_contribution, value: 10, project: flexible_project)
       contribution.payments.last.update(created_at: Time.zone.now - 1.month)
+      contribution.user.update(account_type: 'pf')
       create(:antifraud_analysis, payment: contribution.payments.last, created_at: Time.zone.now - 1.month)
 
       allow(flexible_project).to receive(:expired?).and_return(true)


### PR DESCRIPTION
### Descrição
Utiliza a tabela nova de project fiscals, para fornecer os dados para o frontend na aba de documentos fiscais. Além disso, foi feito uma alteração com adicionação de novos dados na tabela de ProjectFiscal.

### Referência
https://www.notion.so/catarse/Utilizar-os-dados-da-nova-estrutura-de-dados-fiscais-no-frontend-do-projeto-2431c6f98bc74a028717607f3a5a01d4

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
