### PR TITLE
🐞 Envia recibo para o remetente em vez de cópia da mensagem enviada n…

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message_copy.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message_copy.html.slim
@@ -5,11 +5,13 @@
 
 |Olá <strong>#{message.from_name}</strong>
 br
-|Esta é a mensagem que você enviou para o #{link_to to_user.try(:display_name), user_url(to_user)} a partir da página #{link_to message_origin_name, message.data['page_url'], target: :_blank }, referente ao projeto #{link_to project.name, project_url(project)}:
+|Esta é a mensagem que você enviou por email para #{link_to to_user.try(:display_name), user_url(to_user)} a partir da página #{link_to message_origin_name, message.data['page_url'], target: :_blank }, referente ao projeto #{link_to project.name, project_url(project), target: :_blank}:
 br
 br
 p style=("background-color:#f1f4f4; padding: 20px; margin: 20px 30px 50px 30px; border-radius:5px;") == message.content
+br
+p Por questões de privacidade, não podemos informar o email de #{to_user.try(:display_name)} neste recibo de mensagem, logo nossa recomendação é que você espere pela resposta para seguir a sua conversa por lá.
+br
+p Abraços,
 
-p Ao responder este email, <strong>você estará enviando uma mensagem diretamente para o endereço #{to_user.try(:email)}, que é o email de #{to_user.try(:display_name)}</strong>.
-
-p <strong>Importante</strong>: O Catarse não se responsabiliza pelo conteúdo das mensagens enviadas através da plataforma. Caso entenda que o conteúdo da mensagem se trata de spam ou que infringe de alguma forma os nossos Termos de Uso, pedimos que avise a nossa equipe através do email: #{mail_to CatarseSettings[:email_contact]}.
+p Equipe do Catarse

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message_copy_subject.text.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message_copy_subject.text.slim
@@ -1,2 +1,2 @@
 -to_user = User.find @notification.direct_message.to_user_id
-|Cópia de mensagem para #{to_user.try(:display_name)}
+|Recibo de mensagem para #{to_user.try(:display_name)}

--- a/services/catarse/catarse.js/legacy/src/c/owner-message-content.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/owner-message-content.tsx
@@ -76,9 +76,9 @@ const ownerMessageContent = {
                 m('.fa.fa-check-circle.fa-5x.text-success.u-marginbottom-40'),
                 m(
                     'p.fontsize-large',
-                    `Sua mensagem foi enviada com sucesso para ${
-                        state.userDetails.name
-                    }. Você vai receber uma cópia no seu email e pode seguir a conversa por lá!`
+                    `Enviamos um email para ${
+                        state.userDetails.public_name || state.userDetails.name
+                    } com a sua mensagem. Agora é aguardar pela resposta e seguir a conversa pelo email.`
                 ),
             ]),
             contactForm = [
@@ -127,7 +127,6 @@ const ownerMessageContent = {
                                     onchange: m.withAttr('value', state.content),
                                     class: h.validate().hasError(state.content) ? 'error' : '',
                                 }),
-                                m('.u-marginbottom-10.fontsize-smallest.fontcolor-terciary', 'Você receberá uma cópia desta mensagem em seu email.'),
                                 m(
                                     '.w-row',
                                     h.validationErrors().length

--- a/services/catarse/db/migrate/20210901184257_change_send_direct_message_function.rb
+++ b/services/catarse/db/migrate/20210901184257_change_send_direct_message_function.rb
@@ -1,0 +1,19 @@
+class ChangeSendDirectMessageFunction < ActiveRecord::Migration[6.1]
+  def change
+    execute <<-SQL
+    CREATE OR REPLACE FUNCTION public.send_direct_message()
+     RETURNS trigger
+     LANGUAGE plpgsql
+    AS $function$
+            BEGIN
+                INSERT INTO direct_message_notifications(user_id, direct_message_id, from_email, from_name, template_name, locale, created_at, updated_at  )
+                VALUES (new.to_user_id, new.id, new.from_email, new.from_name, 'direct_message', 'pt', current_timestamp, current_timestamp);
+
+                INSERT INTO direct_message_notifications(user_id, direct_message_id, from_email, from_name, template_name, locale, created_at, updated_at  )
+                VALUES (new.user_id, new.id, (SELECT value from settings where name = 'email_no_reply' LIMIT 1), (SELECT value from settings where name = 'company_name' LIMIT 1), 'direct_message_copy', 'pt', current_timestamp, current_timestamp );
+                RETURN NEW;
+            END;
+          $function$
+    SQL
+  end
+end


### PR DESCRIPTION
…o envio de mensagens

### Descrição
Para preservar as informações do realizador, foi removido o acesso ao email do destinatário pelo remetente, mandando um recibo em vez de uma cópia da mensagem enviada.

### Referência
https://www.notion.so/catarse/Deixar-de-exibir-email-do-remetente-em-mensagens-enviadas-pela-plataforma-a0a6089a2193408a9efd9ac16b627a0e

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
