### PR TITLE
Informa prazo correto de encerramento de projeto flex

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-announce-expiration.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-announce-expiration.js
@@ -34,7 +34,7 @@ const projectAnnounceExpiration = {
                                                 'Em quantos dias, contados a partir de agora, você quer encerrar a sua arrecadação?',
                                                 m('br'),
                                                 m('span.fontsize-smaller.fontweight-semibold',
-                                                    '(mínimo de 2 dias)'
+                                                    '(mínimo de 1 dia)'
                                                 )
                                             ])
                                         ),


### PR DESCRIPTION
### Descrição
Ao tentar definir um prazo de finalização de projeto em flex quando o projeto já est´å online, o realizador é informado que precisa definir um prazo com no mínimo 2 dias (quando na realidade é de 1 dia). Essa atividade muda esse texto somente.

### Referência
https://www.notion.so/catarse/Ajusta-prazo-que-informamos-de-encerramento-do-Flex-no-fluxo-de-defini-o-de-prazo-2f147515000c4b56a959c51dd835f3f2

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
