### PR TITLE
🐞 Adiciona saudação genérica a todos os emails

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/_greetings.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/_greetings.html.slim
@@ -1,4 +1,0 @@
-- if user.public_name.present?
-  |Olá, #{user.public_name}!
-- else
-  |Olá!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/answer_survey.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/answer_survey.html.slim
@@ -5,10 +5,10 @@
 
 
 h2 style="text-align:center; line-height: 45px;"
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 
 br/
-| #{project.user.public_name || project.user.name} precisa confirmar algumas informações para realizar a entrega da sua recompensa ao projeto #{project.name}!
+| #{project.user.display} precisa confirmar algumas informações para realizar a entrega da sua recompensa ao projeto #{project.name}!
 
 p Relembrando as informações do seu apoio:
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_error.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_error.html.slim
@@ -2,7 +2,7 @@
 
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 p
   | Ocorreu um <strong>erro na na transferência</strong> para sua conta bancária.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_request.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transfer_request.html.slim
@@ -3,7 +3,7 @@
 - bank_account = user.bank_account
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | O pedido de saque do dinheiro foi registrado no nosso sistema e o processo de transferência já está <strong>em andamento.</strong> :-)

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transferred.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/balance_transferred.html.slim
@@ -2,7 +2,7 @@
 - balance_transfer = @notification.balance_transfer
 - bank_account = balance_transfer.bank_data
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | O depósito do dinheiro <strong>já foi realizado!</strong> O valor será creditado na conta bancária cadastrada em até <strong>2 dias úteis</strong>.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/categorized_projects_of_the_week.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/categorized_projects_of_the_week.html.slim
@@ -1,7 +1,7 @@
 - user = @notification.user
 - category = @notification.category
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | Novidades dessa semana na categoria #{category.name_pt} do Catarse

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_contribution.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_contribution.html.slim
@@ -4,7 +4,8 @@
 - first_contribution = (total_contributors == 1)
 
 h2 style="text-align:center; line-height: 45px;"
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
+
 br/
 
 | Seu apoio para o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: project.permalink, ref: 'confirm_contribution_notification',utm_source:'notification',utm_medium:'email',utm_campaign:'confirm_contribution_link',utm_content:contribution.project.name))} foi confirmado com sucesso!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_delivery.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/confirm_delivery.html.slim
@@ -1,8 +1,7 @@
 - contribution ||= @notification.contribution
 - owner = contribution.project.user
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
 
 p Há duas semanas, #{contribution.project.user.display_name} mandou um comunicado dizendo que já havia enviado sua recompensa do projeto #{contribution.project.name}.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled.html.slim
@@ -2,7 +2,7 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 | Lamentamos informar que não foi possível processar seu pagamento e seu apoio ao projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink, ref: 'notificacao_cancelado',utm_source:'notification',utm_medium:'email',utm_campaign:'contribution_canceled_link',utm_content:contribution.project.name)} foi cancelado.
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_pix.html.slim
@@ -4,8 +4,7 @@
 - details = contribution.details.ordered.first
 - attachments.inline['pix_qrcode.png'] = details.decorate.pix_qr_code_png if respond_to? :attachments
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
 
 p Notamos que você não realizou o pagamento do PIX para o projeto #{link_to contribution.project.name, project_by_slug_url(contribution.project.permalink, {ref: 'notificacao_cancelado',utm_source:'notification',utm_medium:'email',utm_campaign:'contribution_canceled_pix_link',utm_content:contribution.project.name})}.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_canceled_slip.html.slim
@@ -2,8 +2,8 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
+
 p
   | Notamos que você não realizou o pagamento do boleto para o projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink, ref: 'notificacao_cancelado',utm_source:'notification',utm_medium:'email',utm_campaign:'contribution_canceled_slip_link',utm_content:contribution.project.name)}.
 p Como o prazo de pagamento já venceu, enviamos abaixo a 2ª via do boleto para que você possa finalizar o seu apoio. :-)

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_donated.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_donated.html.slim
@@ -3,8 +3,8 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+p Olá!
+
 
 p Muito obrigado! A sua doação é essencial para mantermos independente e livre esse vibrante ecossistema de viabilizacão de projetos que é o Catarse. Dessa forma você ajuda a gente a investir em inovação, a seguir firme na missão de democratizar o financiamento coletivo no Brasil e a tornar a prática um hábito no país.
 p Seguem todos os dados da doação:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_successful.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_successful.html.slim
@@ -1,7 +1,7 @@
 - contribution ||= @notification.contribution
 
 h2 style="text-align:center; line-height: 45px;"
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
   br/
   | Parabéns! O projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink, utm_source:'notification',utm_medium:'email',utm_campaign:'contribution_project_successful_link',utm_content:contribution.project.name))} que,
   |  incluindo você, teve #{contribution.project.total_contributors} apoiadores, foi financiado com sucesso no #{CatarseSettings[:company_name]}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_credit_card.html.slim
@@ -1,7 +1,7 @@
 - contribution = @notification.contribution
 - details = contribution.details.first
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 | Infelizmente o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} que você apoiou não atingiu a meta estabelecida no #{CatarseSettings[:company_name]}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_pix_no_account.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_pix_no_account.html.slim
@@ -3,8 +3,7 @@
 - project = contribution.project
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
 p
   |O projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} não atingiu a meta de arrecadação estabelecida e, segundo as regras do Catarse, o seu apoio no valor de #{number_to_currency detail.value} ao projeto #{contribution.project.name} será devolvido a você.
 p

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_slip_no_account.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_project_unsuccessful_slip_no_account.html.slim
@@ -4,7 +4,7 @@
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
 p
-  = render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+  | Olá!
 p
   |O projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} não atingiu a meta de arrecadação estabelecida e, segundo as regras do Catarse, o seu apoio no valor de #{number_to_currency detail.value} ao projeto #{contribution.project.name} será devolvido a você.
 p

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_refunded.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contribution_refunded.html.slim
@@ -4,7 +4,7 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br/
 br/
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contributions_project_unsuccessful_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contributions_project_unsuccessful_pix.html.slim
@@ -3,7 +3,7 @@
 - user = @notification.contribution.user
 - bank_account = user.bank_account
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 | Infelizmente o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} que você apoiou não atingiu a meta estabelecida no #{CatarseSettings[:company_name]}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contributions_project_unsuccessful_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/contributions_project_unsuccessful_slip.html.slim
@@ -3,7 +3,7 @@
 - user = @notification.contribution.user
 - bank_account = user.bank_account
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 | Infelizmente o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} que você apoiou não atingiu a meta estabelecida no #{CatarseSettings[:company_name]}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_approaching.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_approaching.html.slim
@@ -1,8 +1,8 @@
 - project = @notification.project
 - company_name = CatarseSettings[:company_name]
 - email_contact = CatarseSettings[:email_contact]
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+
+p Olá!
 
 p Estamos enviando essa mensagem para te lembrar que, pela estimativa que você publicou na sua  #{link_to 'página da sua campanha', project_by_slug_url(permalink: project.permalink)}, nesse próximo mês já começam os envios das recompensas para as pessoas que contribuíram com o seu projeto!
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_confirmed.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_confirmed.html.slim
@@ -2,8 +2,7 @@
 - owner = contribution.project.user
 - detail = contribution.details.ordered.first
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
 
 - if !@notification.metadata.try(:[], 'message').present?
   p #{contribution.project.user.display_name} acabou de marcar que a sua recompensa do projeto #{contribution.project.name} foi <strong>enviada</strong>.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_error.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_error.html.slim
@@ -2,8 +2,8 @@
 - owner = contribution.project.user
 - detail = contribution.details.ordered.first
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
+
 - if !@notification.metadata.try(:[], 'message').present?
   p #{contribution.project.user.display_name} acabou de sinalizar na plataforma que aconteceu um <strong>ERRO NO ENVIO</strong> de sua recompensa do projeto #{contribution.project.name}.
 - else

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/direct_message.html.slim
@@ -3,7 +3,7 @@
 - project = Project.find message.project_id
 - message_origin_name = message.data['page_title'].present? && message.data['page_title'].length > 0 ? message.data['page_title'] : message.data['page_url']
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: to_user }
+| Olá!
 br
 
 |Você recebeu uma nova mensagem de #{link_to message.user.try(:display_name), user_url(message.user)}  a partir da página #{link_to(message_origin_name, message.data['page_url'], target: :_blank) }, referente ao projeto #{link_to project.name, project_url(project)}:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/expiring_rewards.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/expiring_rewards.html.slim
@@ -3,7 +3,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+| Olá!
 br/
 br/
 p Você criou recompensas com estimativa de entrega daqui a <strong>1 mês</strong>, porém ainda não definiu uma data de encerramento do seu projeto.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/in_analysis_project.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/in_analysis_project.html.slim
@@ -4,7 +4,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br
 br
 | Muito obrigado por nos enviar o projeto #{link_to project.name, project_link, target: '__blank'}

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_finish.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_finish.html.slim
@@ -2,7 +2,7 @@
 - user = project.user
 - edit_url = edit_project_url(project.id, anchor: 'user_settings')
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user.decorator }
+| Olá!
 br/
 br/
 | Detectamos que existem erro(s) ou ausência de preenchimento em algum(s) dos campos obrigatórios do seu projeto. Para que não isso não atrase <a href="http://suporte.catarse.me/hc/pt-br/articles/217916143-tudo-sobre-REPASSE#etapas" target="blank">os processos de finalização da campanha</a>, <strong>precisamos que você corrija esse(s) campo(s) o mais rápido possível.</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_refund.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_refund.html.slim
@@ -3,7 +3,7 @@
 - detail = contribution.details.ordered.first
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 
 p O seu reembolso não foi efetuado devido a algum erro em seus dados bancários preenchidos:
 p

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/late_delivery.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/late_delivery.html.slim
@@ -2,8 +2,7 @@
 - first_deliver = project.rewards.order(:deliver_at).first.deliver_at.try(:strftime, '%m/%Y')
 - email_contact = CatarseSettings[:email_contact]
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+p Olá!
 
 p Em seu projeto #{project.name} você ofereceu recompensas com estimativa de entrega para #{first_deliver}, porém ainda não marcou suas recompensas como enviadas para os seus apoiadores.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/missing_contribution_address.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/missing_contribution_address.html.slim
@@ -3,7 +3,7 @@
 - contribution = @notification.contribution
 - project = contribution.project
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | Vimos que você fez uma contribuição aqui no #{company_name} para o projeto #{project.name} e que o seu apoio já foi confirmado no sistema. Apesar disso, notamos que <strong>você não informou todos seus dados</strong> no momento do apoio. O preenchimento do <strong>nome</strong>, <strong>CPF</strong> e do <strong>endereço completo (!)</strong> é fundamental para garantir a <strong>segurança do apoio, o controle do realizador</strong> e a <strong>entrega de recompensas.</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_terms_2016.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_terms_2016.html.slim
@@ -1,5 +1,4 @@
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: @notification.user }
+p Olá!
 p Enviamos esse email para lembrá-los sobre as novidades do #{link_to ' Catarse ', 'https://catarse.me', target: '_blank'} e sobre a atualização dos nossos Termos de Uso, que passou a valer a partir do dia 20 de Junho de 2016.
 p Abaixo, um resumo das principais mudanças:
 strong Lançamento de uma nova modalidade: Catarse Flex

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_registration.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_registration.html.slim
@@ -2,7 +2,7 @@
 
 h2 style="text-align:center; line-height: 45px;"
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
   br/
   | Bem-vindo(a) ao Catarse!
 br/

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_settings.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_settings.html.slim
@@ -2,7 +2,7 @@
 - settings_link = -> (text) { link_to text, edit_user_url(user, anchor: 'settings') }
 - ispf = user.account_type == 'pf'
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user.decorate }
+| Olá!
 br/
 br/
 | A fim de melhorar a sua experiência no Catarse, estamos trabalhando para reorganizar suas informações dentro da plataforma e reforçar alguns processos de segurança. Dá só uma olhada no que mudou:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_card_pending_review.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_card_pending_review.html.slim
@@ -1,7 +1,6 @@
 - contribution = @notification.contribution
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
 
 p O seu apoio está sendo <strong>processado</strong> por nossos meios de pagamento e poderá ficar em análise por até 48h.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_pix.html.slim
@@ -4,8 +4,8 @@
 - details = contribution.details.ordered.first
 - attachments.inline['pix_qrcode.png'] = details.decorate.pix_qr_code_png if respond_to? :attachments
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
+
 
 p O seu código PIX para apoiar o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} foi gerado com sucesso! Você tem até o dia #{expiry_date} para efetuar o pagamento.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/payment_slip.html.slim
@@ -2,8 +2,7 @@
 - expire_date = contribution.payments.last.gateway_data.try(:[], "boleto_expiration_date").try(:to_datetime).try(:strftime, '%d/%m')
 - details = contribution.details.ordered.first
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+p Olá!
 
 p O seu boleto para apoiar o projeto #{link_to(contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink))} foi gerado com sucesso!
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/pending_payment.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/pending_payment.html.slim
@@ -1,6 +1,6 @@
 - contribution = @notification.contribution
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 ' Verificamos que você iniciou um apoio para o projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink, ref: 'notificacao_pending',utm_source:'notification',utm_medium:'email',utm_campaign:'pending_payment_link',utm_content:contribution.project.name)},

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_approved.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_approved.html.slim
@@ -3,7 +3,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+| Olá!
 | O <strong>#{link_to 'seu projeto foi aprovado', project_link}</strong> e pode ir ao ar quando você desejar.
 br/
 br/

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_confirmed_after_finished.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_confirmed_after_finished.html.slim
@@ -2,7 +2,7 @@
 - contribution = @notification.contribution
 - project = contribution.project
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user.decorate }
+| Olá!
 br/
 br/
 | Uma nova contribuição foi confirmada para o seu projeto após ter sido finalizado.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_refunded_after_successful_pledged.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_contribution_refunded_after_successful_pledged.html.slim
@@ -7,7 +7,7 @@
 - company_name = CatarseSettings[:company_name]
 
 p
-  = render partial: 'user_notifier/mailer/greetings', locals: { user: project.user.decorate }
+  | Olá!
 
 p
   | O apoio realizado pelo #{contribution.user.decorate.display_name} foi cancelado e reembolsado.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_in_waiting_funds.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_in_waiting_funds.html.slim
@@ -3,7 +3,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+| Olá!
 br/
 br/
 | O prazo do projeto #{link_to project.name, project_link} no #{company_name} chegou ao fim.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_chargeback.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_chargeback.html.slim
@@ -9,7 +9,7 @@
 - value_without_fee = (contribution.value - (contribution.value * project.service_fee))
 - fmt_value_without_fee = number_to_currency(value_without_fee, precision: 2)
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+| Olá!
 br/
 p
   | O apoiador #{contributor.display_name} contestou o apoio para o seu projeto junto à operadora de cartão de crédito.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_contribution_confirmed.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_owner_contribution_confirmed.html.slim
@@ -4,7 +4,7 @@
 - project_link = project_by_slug_url(permalink: project.permalink)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user.decorate }
+| Olá!
 br
 br
 | Nas últimas 24 horas de campanha, seu projeto recebeu #{link_to "#{confirmed_contributions_today.length} novos apoios", contributions_report_project_url(project)}, parabéns!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_received.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_received.html.slim
@@ -4,7 +4,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | Obrigado por iniciar o processo de inscrição de um projeto no #{company_name}!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_report_exports.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_report_exports.html.slim
@@ -1,6 +1,6 @@
 - report = @notification.try(:report) || @notification.report
 center
-  = render partial: 'user_notifier/mailer/greetings', locals: { user: report.project.user }
+  | Olá!
 center
   p A exportação do relatório #{report.report_name_locale} está pronta.
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_success.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_success.html.slim
@@ -3,7 +3,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+| Uhuu!
 br/
 p Parabéns pela campanha! O projeto #{link_to project.name, project_link} foi financiado \o/
 p

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_unsuccessful.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_unsuccessful.html.slim
@@ -3,7 +3,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+| Olá!
 br/
 br/
 | Infelizmente o projeto #{link_to project.name, project_link } não alcançou a meta de financiamento no #{company_name}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_visible.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_visible.html.slim
@@ -4,7 +4,7 @@
 - project_link = edit_project_url(project)
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user.decorate }
+| Olá!
 br/
 br/
 | <strong>O projeto #{link_to project.name, project_link, target: '__blank'} está no ar e já pode receber apoios!</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_credit_card.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_credit_card.html.slim
@@ -4,7 +4,7 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 |Nós reembolsamos o seu apoio referente ao projeto #{contribution.project.name} aqui no #{company_name} . O crédito efetivo deverá acontecer na fatura vigente, caso ela ainda esteja em aberto, ou na subsequente, caso a desse mês já esteja fechada.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_pix.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_pix.html.slim
@@ -5,7 +5,7 @@
 - user = @notification.contribution.user
 - bank_account = user.bank_account
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 |A devolução do valor do seu apoio para o projeto #{contribution.project.name} no #{company_name} acabou de ser realizada para a conta bancária:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_slip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_completed_slip.html.slim
@@ -5,7 +5,7 @@
 - user = @notification.contribution.user
 - bank_account = user.bank_account
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 |A devolução do valor do seu apoio para o projeto #{contribution.project.name} no #{company_name} acabou de ser realizada para a conta bancária:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_moip.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_moip.html.slim
@@ -1,6 +1,6 @@
 - user = @notification.user
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
-| Tudo bem?
+
+| Olá! Tudo bem?
 br
 |Sabe quando você acha aquela nota de dinheiro no bolso de uma calça que não usava faz tempo? Pois esse e-mail é pra relembrarmos essa gostosa sensação. =D
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_paypal.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refund_paypal.html.slim
@@ -1,6 +1,6 @@
 - user = @notification.user
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
-| Tudo bem?
+
+| Olá! Tudo bem?
 br
 |Sabe quando você acha aquela nota de dinheiro no bolso de uma calça que não usava faz tempo? Pois esse e-mail é pra relembrarmos essa gostosa sensação. =D
 br

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refunded_and_canceled.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/refunded_and_canceled.html.slim
@@ -3,7 +3,7 @@
 - company_name = CatarseSettings[:company_name]
 - contact_email = CatarseSettings[:email_contact]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: contribution.user }
+| Olá!
 br
 br
 | Seu reembolso foi realizado com sucesso e o pagamento para o projeto #{link_to contribution.project.name, project_by_slug_url(permalink: contribution.project.permalink)}, cancelado.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/reminder.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/reminder.html.slim
@@ -2,7 +2,7 @@
 - user = @notification.user
 - company_name = CatarseSettings[:company_name]
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br
 br
 | Este é o lembrete de que o projeto #{link_to project.name, project_by_slug_url(permalink: project.permalink, ref: 'notificacao-reminder', utm_source:'notification',utm_medium:'email',utm_campaign:'reminder_link',utm_content:project.name)} está terminando em breve!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/rewards_manager.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/rewards_manager.html.slim
@@ -2,8 +2,7 @@
 
 - project_link = contributions_report_project_url(project)
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: project.user }
+p Olá!
 
 p Na semana passada, lançamos uma novidade: agora você pode <strong>controlar o envio das recompensas</strong> diretamente no <strong>Relatório de Apoios</strong> do seu projeto. Nosso objetivo é facilitar o seu controle de entregas e ter feedbacks sobre o status das contrapartidas prometidas a seus apoiadores.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/segmented_hq.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/segmented_hq.html.slim
@@ -1,6 +1,6 @@
 - user = @notification.user
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | No início desse ano anunciamos nossa parceria com o primeiro serviço de streaming de quadrinhos do Brasil: o Social Comics!

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/subscription_report.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/subscription_report.html.slim
@@ -5,8 +5,7 @@
 - new_inactive = transitions.where(to_status: 'inactive')
 - new_canceled = transitions.where(to_status: 'canceled')
 
-h3
-= render partial: 'user_notifier/mailer/greetings', locals: { user: owner }
+h3 Olá!
 h3 Seu saldo atual no Catarse é R$#{owner.total_balance}.
 br
 p Nas últimas 24h da sua campanha:

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/terms_update.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/terms_update.html.slim
@@ -1,6 +1,6 @@
 - user = @notification.user
 
-= render partial: 'user_notifier/mailer/greetings', locals: { user: user }
+| Olá!
 br/
 br/
 | Enviamos este email para avisar sobre a atualização dos nossos #{link_to 'Termos de Uso', 'http://www.catarse.me/pt/terms-of-use', target: '__blank'} e #{link_to 'Política de Privacidade', 'http://www.catarse.me/pt/privacy-policy', target: '__blank' }, que passam a valer para todos os Usuários do Catarse, a partir de hoje, dia 22 de Março de 2018.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/user_deactivate.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/user_deactivate.html.slim
@@ -1,5 +1,5 @@
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: @notification.user }
+p Olá!
+
 p
   | Sua conta no Catarse já está desativada. Caso sinta saudades, você pode reativar a sua conta a qualquer momento, basta #{link_to('clicar aqui', reactivate_user_url(@notification.user, token: @notification.user.reactivate_token))} e voltar a apoiar ou realizar projetos incríveis.
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/video_200k.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/video_200k.html.slim
@@ -1,8 +1,8 @@
 = link_to 'https://www.youtube.com/watch?v=CRqXvKk5A1Q', target: :blank do
   img src="https://s3.amazonaws.com/catarse.files/video.jpg"
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: @notification.user }
+p Olá!
+
 
 p
   'Você é o apoiador número <strong>#{@notification.user.contributor_number}</strong>

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/video_200k_project_owner.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/video_200k_project_owner.html.slim
@@ -1,8 +1,7 @@
 = link_to 'https://www.youtube.com/watch?v=CRqXvKk5A1Q', target: :blank do
   img src="https://s3.amazonaws.com/catarse.files/video.jpg"
 
-p
-= render partial: 'user_notifier/mailer/greetings', locals: { user: @notification.user }
+p Olá!
 
 p
   'Estamos muito felizes em anunciar que ultrapassamos a marca de 200 mil apoiadores de projetos no Catarse.


### PR DESCRIPTION
### Descrição
Depois de várias tentativas para colocar uma saudação genérica nos emails caso o usuário não possua nome público, essa alteração adiciona a saudação genérica `Olá!` em todos os emails.

### Referência
https://www.notion.so/catarse/Exibir-vocativo-gen-rico-nas-notifica-es-quando-o-usu-rio-n-o-possuir-nome-cadastrado-d2dca9fd88744b38b7f9e9e897016223?d=2751b5e1eb7146e6b7dde98fb51a4b3d

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
