### PR TITLE
🐞 Cria validação de recompensa esgotada na contribuição.

### DIFF
--- a/services/catarse/app/models/contribution.rb
+++ b/services/catarse/app/models/contribution.rb
@@ -28,6 +28,7 @@ class Contribution < ApplicationRecord
   validates_presence_of :project, :user, :value
   validates_numericality_of :value, greater_than_or_equal_to: 10.00
   validate :banned_user_validation, :on => :update
+  validate :reward_sold_out, :on => :create
 
   scope :not_anonymous, -> { where(anonymous: false) }
   scope :confirmed_last_day, -> { where("EXISTS(SELECT true FROM payments p WHERE p.contribution_id = contributions.id AND p.state = 'paid' AND (current_timestamp - p.paid_at) < '1 day'::interval)") }
@@ -257,6 +258,14 @@ class Contribution < ApplicationRecord
       unless document.nil?
         errors.add(:user, :invalid)
       end
+    end
+  end
+
+  private
+
+  def reward_sold_out
+    if reward.present? && reward.sold_out?
+      errors.add(:reward_sold_out, I18n.t('projects.contributions.edit.reward_sold_out'))
     end
   end
 end

--- a/services/catarse/spec/models/contribution_spec.rb
+++ b/services/catarse/spec/models/contribution_spec.rb
@@ -32,6 +32,35 @@ RSpec.describe Contribution, type: :model do
     it { is_expected.to_not allow_value(9).for(:value) }
     it { is_expected.to allow_value(10).for(:value) }
     it { is_expected.to allow_value(20).for(:value) }
+
+    context 'when the reward isn`t sold out' do
+      subject(:contribution) { build(:contribution, reward: reward, project: project) }
+
+      let!(:project) { create(:project) }
+      let!(:reward) { create(:reward, project: project, maximum_contributions: 2) }
+      let!(:confirmed_contribution) { create(:confirmed_contribution, project: project, reward: reward) }
+
+      it 'doesn`t add invalid reward sold_out error' do
+        contribution.valid?
+
+        expect(contribution.errors[:reward_sold_out]).to be_empty
+      end
+    end
+
+    context 'when the reward is sold out' do
+      subject(:contribution) { build(:contribution, reward: reward, project: project) }
+
+      let!(:project) { create(:project) }
+      let!(:reward) { create(:reward, project: project, maximum_contributions: 1) }
+      let!(:confirmed_contribution) { create(:confirmed_contribution, project: project, reward: reward) }
+
+      it 'adds invalid reward sold_out error message' do
+        contribution.valid?
+
+        error_message = I18n.t('projects.contributions.edit.reward_sold_out')
+        expect(contribution.errors[:reward_sold_out]).to include error_message
+      end
+    end
   end
 
   describe '.confirmed_last_day' do


### PR DESCRIPTION
### Descrição
Um determinado usuário conseguiu criar um contribuição para um recompensa esgotada. Por isso foi criando uma validação no model de Contribuição para essa situação.

### Referência
https://www.notion.so/catarse/Validar-se-a-recompensa-esta-esgotada-ao-criar-uma-contribui-o-7034c3caedad4f9bade187550e910b27

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
