### PR TITLE
🐞 Volta a mostrar que o usuário já apoia/assina o projeto

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-header.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/project-header.tsx
@@ -39,31 +39,35 @@ const projectHeader = {
             rewardDetails = attrs.rewardDetails,
             activeSubscriptions = _.filter(state.userProjectSubscriptions(), sub => sub.status === 'active'),
             sortedSubscriptions = _.sortBy(state.userProjectSubscriptions(), sub => _.indexOf(['active', 'started', 'canceling', 'inactive', 'canceled'], sub.status));
+        const hasContribution = {
+            view: () => (
+                (!_.isEmpty(state.projectContributions()) || state.hasSubscription()) ?
+                m(`.card.card-terciary.u-radius.u-marginbottom-40${projectVM.isSubscription(project) ? '.fontcolor-primary' : ''}`, [
+                    m('.fontsize-small.u-text-center', [
+                        m('span.fa.fa-thumbs-up'),
+                        m('span.fontweight-semibold', (!projectVM.isSubscription(project) ? ' Você é apoiador deste projeto! ' : ' Você tem uma assinatura neste projeto! ')),
+                        m('a.alt-link[href=\'javascript:void(0);\']', {
+                            onclick: state.showContributions.toggle
+                        }, 'Detalhes')
+                    ]),
+                    state.showContributions() ? m('.u-margintop-20.w-row',
+                        (!projectVM.isSubscription(project) ?
+                            _.map(state.projectContributions(), contribution => m(userContributionDetail, {
+                                contribution,
+                                rewardDetails
+                            })) :
+                        _.map(activeSubscriptions.length > 0 ? activeSubscriptions : sortedSubscriptions, subscription => m(userSubscriptionDetail, {
+                            subscription,
+                            project: project()
+                        }))
+                        )
+                    ) : ''
+                ])
+                :
+                ''
+            )
+        }
 
-        const hasContribution = (
-            (!_.isEmpty(state.projectContributions()) || state.hasSubscription()) ?
-            m(`.card.card-terciary.u-radius.u-marginbottom-40${projectVM.isSubscription(project) ? '.fontcolor-primary' : ''}`, [
-                m('.fontsize-small.u-text-center', [
-                    m('span.fa.fa-thumbs-up'),
-                    m('span.fontweight-semibold', (!projectVM.isSubscription(project) ? ' Você é apoiador deste projeto! ' : ' Você tem uma assinatura neste projeto! ')),
-                    m('a.alt-link[href=\'javascript:void(0);\']', {
-                        onclick: state.showContributions.toggle
-                    }, 'Detalhes')
-                ]),
-                state.showContributions() ? m('.u-margintop-20.w-row',
-                    (!projectVM.isSubscription(project) ?
-                        _.map(state.projectContributions(), contribution => m(userContributionDetail, {
-                            contribution,
-                            rewardDetails
-                        })) :
-                     _.map(activeSubscriptions.length > 0 ? activeSubscriptions : sortedSubscriptions, subscription => m(userSubscriptionDetail, {
-                         subscription,
-                         project: project()
-                     }))
-                    )
-                ) : ''
-            ]) :
-            '');
         const hasBackground = Boolean(project().cover_image);
 
         return !_.isUndefined(project()) ? m('#project-header', { style: attrs.style }, [
@@ -74,7 +78,7 @@ const projectHeader = {
             }, [
                 m(ProjectHeaderTitle, {
                     project: project(),
-                    children: hasContribution
+                    Component: hasContribution,
                 }),
                 m(`.w-section.project-main${projectVM.isSubscription(project) ? '.transparent-background' : ''}`, [
                     m('.w-container', [

--- a/services/catarse/catarse.js/legacy/src/root/projects/project-header-title.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/projects/project-header-title.tsx
@@ -9,12 +9,12 @@ import { withHooks } from 'mithril-hooks';
 
 export type ProjectHeaderTitleProps = {
     project: ProjectDetails
-    children?: JSX.Element
+    Component?: JSX.Element
 }
 
 export const ProjectHeaderTitle = withHooks<ProjectHeaderTitleProps>(_ProjectHeaderTitle)
 
-function _ProjectHeaderTitle({project, children}: ProjectHeaderTitleProps) {
+function _ProjectHeaderTitle({project, Component}: ProjectHeaderTitleProps) {
     if (project) {
         const projectNameOrEmpty = project.name || project['project_name'] || ''
         const isSubscriptionMode = projectVM.isSubscription(project)
@@ -23,7 +23,7 @@ function _ProjectHeaderTitle({project, children}: ProjectHeaderTitleProps) {
         return (
             <div class={`w-section page-header ${isSubscriptionMode ? 'transparent-background' : ''}`}>
                 <div class="w-container">
-                    {children}
+                    {!!Component && <Component />}
                     <h1 class="u-text-center fontsize-larger fontweight-semibold project-name">
                         {projectNameOrEmpty}
                     </h1>


### PR DESCRIPTION
### Descrição
Volta a mostrar a indicação para o usuário que ele já apoia/assina o projeto.

### Referência
https://www.notion.so/catarse/Projetos-n-o-exibem-mais-informa-o-voc-apoiador-deste-projeto-35db4f9540a047b78540cfb7e53bf81f

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
