### PR TITLE
🐞 Remove validação de número de dígitos em contas bancárias.

### DIFF
--- a/services/catarse/app/models/bank_account.rb
+++ b/services/catarse/app/models/bank_account.rb
@@ -47,12 +47,6 @@ class BankAccount < ApplicationRecord
 
   def account_validation
 
-    # setup locale custom access
-    account_locale = 'activerecord.errors.models.bank_account.attributes.account'
-    account_equal_locale = I18n.t("#{account_locale}.equal")
-    account_maximum_locale = I18n.t("#{account_locale}.maximum")
-    account_invalid_locale = I18n.t("#{account_locale}.invalid")
-
     errors.delete :account
 
     if account == nil || account.length == 0
@@ -62,42 +56,6 @@ class BankAccount < ApplicationRecord
 
     if account.match? /\D+/
       errors.add(:account, :format)
-      return false
-    end
-
-    if %w[237].include?(bank_code.to_s) && account.length > 7
-      account_error = (account_invalid_locale + account_maximum_locale) % [7]
-      errors.add(:account, account_error)
-      return false
-    end
-
-    if %w[001 033].include?(bank_code.to_s) && account.length > 8
-      account_error = (account_invalid_locale + account_maximum_locale) % [8]
-      errors.add(:account, account_error)
-      return false
-    end
-
-    if %w[341].include?(bank_code.to_s) && account.length != 5
-      account_error = (account_invalid_locale + account_equal_locale) % [5]
-      errors.add(:account, account_error)
-      return false
-    end
-
-    if %w[104].include?(bank_code.to_s) && account.length > 11
-      account_error = (account_invalid_locale + account_maximum_locale) % [11]
-      errors.add(:account, account_error)
-      return false
-    end
-
-    if %w[399].include?(bank_code.to_s) && account.length != 6
-      account_error = (account_invalid_locale + account_equal_locale) % [6]
-      errors.add(:account, account_error)
-      return false
-    end
-
-    if %w[745].include?(bank_code.to_s) && account.length != 7
-      account_error = (account_invalid_locale + account_equal_locale) % [7]
-      errors.add(:account, account_error)
       return false
     end
 


### PR DESCRIPTION
### Descrição
Alterar validação de account_validation do modelo BankAccount para não verificar a quantidade de dígitos de uma conta dependendo do banco, pois eles podem ser alterados.

### Referência
https://www.notion.so/catarse/Ajustar-valida-o-do-tamanho-de-conta-do-itau-7b9831b01b124b1f93643f4586459b56

### Antes de criar esse pull request confira se:
- [] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
