### PR TITLE
✨ Adiciona endereço ao pagamentos por boletos.

### DIFF
--- a/services/catarse/engines/catarse_pagarme/app/controllers/catarse_pagarme/slip_controller.rb
+++ b/services/catarse/engines/catarse_pagarme/app/controllers/catarse_pagarme/slip_controller.rb
@@ -32,7 +32,7 @@ module CatarsePagarme
     protected
 
     def slip_attributes
-      {
+      attributes = {
         payment_method: 'boleto',
         boleto_rules: ['strict_expiration_date'],
         boleto_expiration_date: payment.slip_expiration_date,
@@ -43,24 +43,59 @@ module CatarsePagarme
           protocol: CatarsePagarme.configuration.protocol
         ),
         customer: {
+          external_id: payment.user.id.to_s,
           email: payment.user.email,
           name: payment.user.name,
           type: payment.user.account_type == 'pf' ? 'individual' : 'corporation',
+          country: contribution.country.try(:code).downcase || 'br',
           documents: [{
             type:  payment.user.account_type == 'pf' ? 'cpf' : 'cnpj',
             number: document_number
           }],
+          phone_numbers: [
+            '+55085999999999'
+          ]
+        },
+        billing: {
+          name: payment.user.name,
+          address: {
+            street: contribution.address_street,
+            neighborhood: neighborhood,
+            zipcode: zip_code,
+            street_number: address_number,
+            city: contribution.address_city,
+            state: contribution.address_state.downcase,
+            country: contribution.country.try(:code).downcase
+          }
         },
         metadata: metadata_attributes.merge({ second_slip: payment.generating_second_slip.to_s })
       }
+
+      if contribution.address_complement.present?
+        attributes[:billing][:address].merge(complementary: contribution.address_complement)
+      end
+
+      attributes
+    end
+
+    def address_number
+      international? ? 100 : contribution.address_number
     end
 
     def document_number
       international? ? '00000000000' : contribution.user.cpf.gsub(/[-.\/_\s]/,'')
     end
 
+    def neighborhood
+      international? ? 'international' : contribution.address_neighbourhood
+    end
+
     def international?
       contribution.international?
+    end
+
+    def zip_code
+      international? ? '00000000' : contribution.address_zip_code.gsub(/[-.]/, '')
     end
   end
 end

--- a/services/payment-service-api/lib/transaction_data_builder.js
+++ b/services/payment-service-api/lib/transaction_data_builder.js
@@ -54,14 +54,39 @@ const bankSlipTransactionData = (context) => {
   const customer = payment.data.customer
   const isIndividual = customer.document_number.length === 11
 
+  let address = {
+    country: customer.address.country_code.toLowerCase(),
+    state: customer.address.state.toLowerCase(),
+    city: customer.address.city,
+    street: customer.address.street,
+    zipcode: customer.address.zipcode.replace(/\D/g, ""),
+    neighborhood: customer.address.neighborhood,
+    street_number: customer.address.street_number,
+    complementary: customer.address.complementary
+  }
+
+  if(!customer.address.complementary) {
+    delete address['complementary'];
+  }
+
   return {
     customer: {
+      external_id: `${customer.document_number}`,
+      email: customer.email,
       name: limitStringSize(customer.name, 100),
       type: isIndividual ? 'individual' : 'corporation',
+      country: address.country,
       documents: [{
         type: isIndividual ? 'cpf' : 'cnpj',
         number: customer.document_number
-      }]
+      }],
+      phone_numbers: [
+        '+55085999999999'
+      ]
+    },
+    billing: {
+      name: customer.name,
+      address: address
     }
   }
 }

--- a/services/payment-service-api/test/lib/transaction_data_builder_test.js
+++ b/services/payment-service-api/test/lib/transaction_data_builder_test.js
@@ -133,39 +133,123 @@ test('test buildTransactionData - saved credit card', async t => {
 })
 
 test('test buildTransactionData - bank slip for individual person', async t => {
-  const contextOvewrite = {  payment: { data: { customer: { document_number: '12345678901' } } } }
+  const contextOvewrite = {  
+    payment: { 
+      data: { 
+        customer: {
+          name: 'Tommy Oliver',
+          email: 'mopheus@nabucodonozor.com',
+          phone: { ddd: '11', ddi: '55', number: '888889999' },
+          address: {
+            city: 'São Paulo',
+            state: 'SP',
+            street: 'Avenida Brigadeiro Faria Lima',
+            country: 'Brasil',
+            zipcode: '01451001',
+            country_code: 'BR',
+            neighborhood: 'Jardim Paulistano',
+            complementary: 'Casa Azul',
+            street_number: '1811' 
+          },
+          document_number: '12345678901'
+        } 
+      } 
+    } 
+  }
   const context = sampleContext(bankSlipContextData(contextOvewrite))
   const transactionData = buildTransactionData(context)
   const expectedResponse = {
     customer: {
+      external_id: `${context.payment.data.customer.document_number}`,
+      email: context.payment.data.customer.email,
+      country: 'br',
       name: context.payment.data.customer.name,
       type: 'individual',
       documents: [{
         type: 'cpf',
         number: context.payment.data.customer.document_number
-      }]
+      }],
+      phone_numbers: [
+        '+55085999999999'
+      ]
+    },
+    billing: {
+      name: context.payment.data.customer.name,
+      address: {
+        city: context.payment.data.customer.address.city,
+        state: context.payment.data.customer.address.state.toLowerCase(),
+        street: context.payment.data.customer.address.street,
+        zipcode: context.payment.data.customer.address.zipcode.replace(/\D/g, ""),
+        country: context.payment.data.customer.address.country_code.toLowerCase(),
+        neighborhood: context.payment.data.customer.address.neighborhood,
+        complementary: context.payment.data.customer.address.complementary,
+        street_number: context.payment.data.customer.address.street_number 
+      }
     }
   }
 
   t.is(transactionData.payment_method, 'boleto')
   t.deepEqual(transactionData.customer, expectedResponse.customer)
+  t.deepEqual(transactionData.billing, expectedResponse.billing)
 })
 
 test('test buildTransactionData - bank slip for corporation', async t => {
-  const contextOvewrite = {  payment: { data: { customer: { document_number: '12345678901234' } } } }
+  const contextOvewrite = {
+    payment: { 
+      data: { 
+        customer: {
+          name: 'Tommy Oliver',
+          email: 'mopheus@nabucodonozor.com',
+          phone: { ddd: '11', ddi: '55', number: '888889999' },
+          address: {
+            city: 'São Paulo',
+            state: 'SP',
+            street: 'Avenida Brigadeiro Faria Lima',
+            country: 'Brasil',
+            zipcode: '01451001',
+            country_code: 'BR',
+            neighborhood: 'Jardim Paulistano',
+            complementary: 'Casa Azul',
+            street_number: '1811' 
+          },
+          document_number: '12345678901234'
+        } 
+      } 
+    } 
+  }
   const context = sampleContext(bankSlipContextData(contextOvewrite))
   const transactionData = buildTransactionData(context)
   const expectedResponse = {
     customer: {
+      external_id: `${context.payment.data.customer.document_number}`,
+      email: context.payment.data.customer.email,
+      country: 'br',
       name: context.payment.data.customer.name,
       type: 'corporation',
       documents: [{
         type: 'cnpj',
         number: context.payment.data.customer.document_number
-      }]
+      }],
+      phone_numbers: [
+        '+55085999999999'
+      ]
+    },
+    billing: {
+      name: context.payment.data.customer.name,
+      address: {
+        city: context.payment.data.customer.address.city,
+        state: context.payment.data.customer.address.state.toLowerCase(),
+        street: context.payment.data.customer.address.street,
+        zipcode: context.payment.data.customer.address.zipcode.replace(/\D/g, ""),
+        country: context.payment.data.customer.address.country_code.toLowerCase(),
+        neighborhood: context.payment.data.customer.address.neighborhood,
+        complementary: context.payment.data.customer.address.complementary,
+        street_number: context.payment.data.customer.address.street_number 
+      }
     }
   }
 
   t.is(transactionData.payment_method, 'boleto')
   t.deepEqual(transactionData.customer, expectedResponse.customer)
+  t.deepEqual(transactionData.billing, expectedResponse.billing)
 })


### PR DESCRIPTION
### Descrição
A pagarme nos enviou uma aviso que o Banco Central exigirá o envio do endereço de clientes quando for gerado um boleto, então adicionaremos essa informação dentro do billing para geração de pagamentos com boletos.

### Referência
https://www.notion.so/catarse/Informar-o-endere-o-na-hora-de-gerar-um-boleto-ef3b049977aa4e6b8fb46bdb1a38c2c0

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
