### PR TITLE
🐞 Corrige cabeçalho da página de projetos

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-header.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/project-header.tsx
@@ -5,8 +5,9 @@ import { ProjectHighlight } from '../root/projects/project-highlight';
 import projectSidebar from './project-sidebar';
 import userContributionDetail from './user-contribution-detail';
 import userSubscriptionDetail from './user-subscription-detail';
-import contributionVM from '../vms/contribution-vm';
-import projectVM from '../vms/project-vm';
+import contributionVM from '@/vms/contribution-vm';
+import projectVM from '@/vms/project-vm';
+import userVM from '@/vms/user-vm';
 import { getCurrentUserCached } from '../shared/services/user/get-current-user-cached';
 import { isLoggedIn } from '../shared/services/user/is-logged-in';
 
@@ -38,6 +39,7 @@ const projectHeader = {
             rewardDetails = attrs.rewardDetails,
             activeSubscriptions = _.filter(state.userProjectSubscriptions(), sub => sub.status === 'active'),
             sortedSubscriptions = _.sortBy(state.userProjectSubscriptions(), sub => _.indexOf(['active', 'started', 'canceling', 'inactive', 'canceled'], sub.status));
+        const projectOwnerName = project().user ? userVM.displayName(project().user) : (project().owner_public_name || project().owner_name);
         const hasContribution =  m('.div', [
            (
                 (!_.isEmpty(state.projectContributions()) || state.hasSubscription()) ?
@@ -91,7 +93,7 @@ const projectHeader = {
                             ])
                             :
                             m('h2.u-text-center.fontsize-base.lineheight-looser',
-                                `por ${project().name}`
+                                `por ${projectOwnerName}`
                             )
                         )
                     ]),


### PR DESCRIPTION
### Descrição
Ao corrigir um problema no deploy anterior, foi necessário deixar de usar um componente e usar um código adaptado. Na adaptação do código passou despercido que ao invés de colocar o nome do realizador abaixo do título do projeto estava sendo replicado o nome do projeto. Esse PR corrige isso, coloca o nome do usuário ao invés do nome do projeto.

### Referência
https://www.notion.so/catarse/Corrigir-cabe-alho-da-landing-page-do-projeto-para-mostrar-nome-p-blico-do-realizador-78631c1d46e5454a86567fb5c7a24a5b

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
