### PR TITLE
🐞 Remove botão de tradução do google

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/layouts/_google_translate.slim
+++ b/services/catarse/app/views/catarse_bootstrap/layouts/_google_translate.slim
@@ -1,6 +1,0 @@
-javascript:
-	function googleTranslateElementInit() {
-    new google.translate.TranslateElement({pageLanguage: 'pt', includedLanguages: 'de,en,es,fr,it', layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL, autoDisplay: false, gaTrack: true, gaId: 'UA-51266701-1'}, 'google_translate_element');
-  }
-
-script(async src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit")

--- a/services/catarse/app/views/catarse_bootstrap/layouts/catarse_bootstrap.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/layouts/catarse_bootstrap.html.slim
@@ -74,7 +74,6 @@ html
     = yield :js
   - if Rails.env.production?
     = render 'layouts/optinmonster'
-  = render 'layouts/google_translate'
   - if content_for? :js_after
     /page specific JS files
     = yield :js_after

--- a/services/catarse/app/views/catarse_bootstrap/shared/_footer.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/shared/_footer.html.slim
@@ -16,5 +16,3 @@ footer.footer-simple
         a.link-footer href="#{terms_of_use_path}"  #{t('layouts.footer.links.terms')}
       li.footer-simple-links-list
         a.link-footer href="#{privacy_policy_path}"  #{t('layouts.footer.links.privacy')}
-  .w-container
-    #google_translate_element

--- a/services/catarse/app/views/catarse_bootstrap/shared/_footer_big.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/shared/_footer_big.html.slim
@@ -18,9 +18,6 @@ footer.main-footer.main-footer-neg
           = render_facebook_like colorscheme: "dark"
         .w-widget.w-widget-twitter
           = link_to "Follow @#{CatarseSettings[:twitter_username]}", "http://twitter.com/#{CatarseSettings[:twitter_username]}", :class => 'twitter-follow-button', :"data-button"=>"blue", :"data-text-color" => "#ffffff", :"data-link-color"=>"#fffffff", :"data-width" => "224px"
-        .u-margintop-30
-          .footer-full-signature-text.fontsize-small Change language
-          #google_translate_element
   .w-container
     .footer-full-copyleft 
       = image_tag "logo-footer.png", class: "u-marginbottom-20"

--- a/services/catarse/catarse.js/legacy/src/root/footer.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/footer.tsx
@@ -178,10 +178,6 @@ const footer = {
                                             ]
                                         )
                                     ),
-                                    m('.footer-full-signature-text.fontsize-small',
-                                        'Change language'
-                                    ),
-                                    m('[id=\'google_translate_element\']')
                                 ]
                             )
                         ]


### PR DESCRIPTION
### Descrição
Removendo botão de tradução automática do google, pois não estava funcionando corretamente.

### Referência
https://www.notion.so/catarse/Remover-bot-o-de-Translate-do-rodap-do-site-9609742910e14eac8ed9131fc3c982ed?d=05d1a6839004427598229a7932ee74bf

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
