### PR TITLE
✨ Adiciona link para o pagame no admin assinaturas.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/admin-subscription-detail.js
+++ b/services/catarse/catarse.js/legacy/src/c/admin-subscription-detail.js
@@ -241,7 +241,9 @@ const adminSubscriptionDetail = {
                         m('br'),
                         `Id pagamento: ${currentPayment().id}`,
                         m('br'),
-                        `Id gateway: ${currentPayment().gateway_id}`,
+                        m(`a[href="https://beta.dashboard.pagar.me/#/transactions/${currentPayment().gateway_id}"]`,
+                            `ID gateway: ${currentPayment().gateway_id}`
+                        ),
                         m('br'),
                         'Apoio:',
                         m.trust('&nbsp;'),


### PR DESCRIPTION
### Descrição
O usuário admin deseja um link em detalhes do admin assinaturas para consultar a transação no pagarme. 

### Referência
https://www.notion.so/catarse/Link-para-o-pagar-me-no-admin-assinaturas-ef64b3f65ab94d8d98a56bf5e1c8be4b

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
