### PR TITLE
🐞 Ajusta type do input de título de recompensa.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/edit-reward-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/edit-reward-card.js
@@ -294,7 +294,7 @@ const editRewardCard = {
                             )
                         ),
                         m('.w-col.w-col-7',
-                            m('input.w-input.text-field.positive[aria-required=\'true\'][autocomplete=\'off\'][type=\'tel\']', {
+                            m('input.w-input.text-field.positive[aria-required=\'true\'][autocomplete=\'off\'][type=\'text\']', {
                                 value: state.reward.title(),
                                 oninput: m.withAttr('value', state.reward.title)
                             })


### PR DESCRIPTION
### Descrição
Ajustar o type do campo de titulo do recompensa para texto.

### Referência
https://www.notion.so/catarse/Ajustar-type-do-input-de-titulo-de-recompensa-b69cd57aad8a461486152daf353874c8

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
