### PR TITLE
✨ Adiciona Dados Fiscais no Frontend.

### DIFF
--- a/services/catarse/app/controllers/projects/project_fiscal_controller.rb
+++ b/services/catarse/app/controllers/projects/project_fiscal_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Projects
+  class ProjectFiscalController < ApplicationController
+    before_action :set_date, only: [:inform]
+
+    inherit_resources
+    actions :show
+    belongs_to :project
+
+    def debit_note
+      project_fiscal = ProjectFiscal.find_by(id: params[:id])
+
+      if project_fiscal.blank?
+        redirect_to edit_project_path(params[:project_id], locale: nil)
+      else
+        authorize project_fiscal
+        render(
+          'user_notifier/mailer/project_fiscal_debit_note',
+          locals: { project_fiscal: project_fiscal },
+          layout: 'layouts/email'
+        )
+      end
+    end
+
+    def inform
+      where_clause = 'project_id = :project_id AND begin_date >= :begin_date AND end_date <= :end_date'
+      project_fiscals = ProjectFiscal.where(
+        where_clause, project_id: params[:project_id], begin_date: @begin_date, end_date: @end_date
+      )
+
+      if project_fiscals.blank?
+        redirect_to edit_project_path(params[:project_id], locale: nil)
+      else
+        authorize project_fiscals.first
+        render(
+          'user_notifier/mailer/project_fiscal_inform',
+          locals: { project_fiscals: project_fiscals },
+          layout: 'layouts/email'
+        )
+      end
+    end
+
+    def inform_years
+      project_fiscal = ProjectFiscal.find_by(project_id: params[:project_id])
+      authorize project_fiscal if project_fiscal.present?
+
+      result = ProjectFiscal.select("DATE_PART('year', end_date) as year")
+        .where(project_id: params[:project_id]).distinct.map(&:year)
+
+      result = result.select { |year| year > Time.zone.now.year }
+      render json: { result: result }
+    end
+
+    def debit_note_end_dates
+      project_fiscals = Project.find(params[:project_id])&.project_fiscals
+      authorize project_fiscals.first if project_fiscals.present?
+      result = []
+
+      project_fiscals.each do |project_fiscal|
+        result << {
+          project_fiscal_id: project_fiscal.id,
+          project_id: project_fiscal.project_id,
+          end_date: I18n.l(project_fiscal.end_date.to_date)
+        }
+      end
+      render json: { result: result }
+    end
+
+    private
+
+    def set_date
+      @begin_date = "01/#{params[:fiscal_year]}".to_date.beginning_of_month
+      @end_date = "12/#{params[:fiscal_year]}".to_date.end_of_month
+    end
+  end
+end

--- a/services/catarse/app/controllers/projects_controller.rb
+++ b/services/catarse/app/controllers/projects_controller.rb
@@ -93,6 +93,10 @@ class ProjectsController < ApplicationController
     authorize resource, :update?
   end
 
+  def project_fiscal
+    authorize resource, :update?
+  end
+
   def insights
     authorize resource, :update?
   end

--- a/services/catarse/app/policies/project_fiscal_policy.rb
+++ b/services/catarse/app/policies/project_fiscal_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ProjectFiscalPolicy < ApplicationPolicy
+  def debit_note?
+    done_by_owner_or_admin?
+  end
+
+  def inform?
+    done_by_owner_or_admin?
+  end
+
+  def inform_years?
+    done_by_owner_or_admin?
+  end
+
+  def debit_note_end_dates?
+    done_by_owner_or_admin?
+  end
+end

--- a/services/catarse/app/views/catarse_bootstrap/projects/project_fiscal.slim
+++ b/services/catarse/app/views/catarse_bootstrap/projects/project_fiscal.slim
@@ -1,0 +1,9 @@
+- content_for :title, "#{@project.name} · #{CatarseSettings[:company_name]}"
+
+- parameters = { project_id: @project.id, user_id: @project.user_id, project_state: @project.state }.to_json
+
+#application data-parameters=parameters
+
+- content_for :application_js do
+  = javascript_include_tag 'api/application'
+  = javascript_include_tag 'api/catarse'

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_debit_note.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_debit_note.slim
@@ -1,0 +1,60 @@
+- project_fiscal ||= @notification.project_fiscal
+- project = project_fiscal.project
+- user = project_fiscal.user
+- address = project_fiscal.user.address
+- project_link = project_by_slug_url(permalink: project['permalink'])
+- begin_date = I18n.l(project_fiscal.begin_date.to_date)
+- end_date = I18n.l(project_fiscal.end_date.to_date)
+
+center
+  h1 style="line-height: 5px" NOTA DE DÉBITO
+
+hr/
+
+br/
+h3 EMITENTE
+p style="margin:0;" Grupo Comum Consultoria e Intermediação de Negócios Ltda ME
+p style="margin:0;" CNPJ: 14.512.425/0001-94 | CCM 4.675.208-0
+p style="margin:0;"  Endereço: Av. Paulista 171, 4º andar – Bela Vista – São Paulo/SP
+p style="margin:0;"  CEP: 01311-000
+
+h3 DEVEDOR
+
+p style="margin:0;"  Nome/Razão Social: #{user['name']}
+p style="margin:0;"  CPF/CNPJ: #{user['cpf']}
+- if address
+  p style="margin:0;"  Endereço: #{address['address_street']}, #{address['address_number']} #{address['address_complement']}, #{address['address_neighbourhood']}, #{address['address_city']}, #{address['address_state']}, #{address['address_zip_code']}
+
+h3 DISCRIMINAÇÃO DOS DÉBITOS
+
+table style="border: 1px solid;max-width:100%;border-collapse: collapse;"
+  tr
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Data
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Histórico
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Valor
+  tr
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{begin_date} - #{end_date}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;"
+      span Tarifas dos meios de pagamento dos apoios ao projeto "#{project['name']}".
+      br/
+      span #{project_link}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{project_fiscal.total_gateway_fee.format}
+  trproject_link
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{begin_date} - #{end_date}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;"
+      span Tarifas das análises de antifraude dos apoios ao projeto "#{project['name']}".
+      br/
+      span #{project_link}
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{project_fiscal.total_antifraud_fee.format}
+
+br/
+p Declaro para os devidos fins ter recebido a importância acima discriminada dando plena e irrevogável quitação.
+br/
+p style="text-align:center;" São Paulo
+p #{begin_date} - #{end_date}
+
+p Catarse - GRUPO COMUM CONSULTORIA E INTERMEDIAÇÃO DE NEGÓCIOS

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_inform.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_inform.slim
@@ -1,0 +1,100 @@
+- project_fiscals ||= @notification.project_fiscals
+- project = project_fiscals.last.project
+- user = project_fiscals.last.user
+- finished_date = I18n.l(project_fiscals.last.end_date.to_date)
+
+- total_amount_to_pj = project_fiscals.sum(&:total_amount_to_pj)
+- total_amount_to_pf = project_fiscals.sum(&:total_amount_to_pf)
+- total_amount = total_amount_to_pj + total_amount_to_pf
+- total_gateway_fee = project_fiscals.sum(&:total_gateway_fee)
+- total_antifraud_fee = project_fiscals.sum(&:total_antifraud_fee)
+- total_total_catarse_fee = project_fiscals.sum(&:total_catarse_fee)
+- total_irrf = project_fiscals.sum(&:total_irrf)
+
+center
+  h1 style="line-height: 5px" INFORME DE RENDIMENTOS
+
+hr/
+
+br/
+p style="margin:0;"
+  span style="font-weight:bold;" Projeto:
+  span #{project.name}
+p style="margin:0;"
+  span style="font-weight:bold;" Beneficiário:
+  span #{user.name}
+p style="margin:0;"
+  span style="font-weight:bold;" CPF/CNPJ:
+  span #{user.cpf}
+
+
+- if total_amount_to_pf.positive?
+  h3 PESSOAS FÍSICAS:
+  table style="border: 1px solid;width:100%;border-collapse: collapse;"
+    tr
+      td style="border: 1px solid;text-align:center;font-weight:bold;" INTERVALO
+      td style="border: 1px solid;text-align:center;font-weight:bold;" VALOR
+    - project_fiscals.each do |fiscal|
+      tr
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{I18n.l(fiscal.begin_date.to_date)} - #{I18n.l(fiscal.end_date.to_date)}
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{fiscal.total_amount_to_pf.format}
+
+- if total_amount_to_pj.positive?
+  h3 PESSOAS JURÍDICAS:
+  table style="border: 1px solid;width:100%;border-collapse: collapse;"
+    tr
+      td style="border: 1px solid;text-align:center;font-weight:bold;" INTERVALO
+      td style="border: 1px solid;text-align:center;font-weight:bold;" VALOR
+    - project_fiscals.each do |fiscal|
+      tr
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{I18n.l(fiscal.begin_date.to_date)} - #{I18n.l(fiscal.end_date.to_date)}
+        td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+          span #{fiscal.total_amount_to_pj.format}
+
+h3 DISCRIMINAÇÃO DOS RENDIMENTOS:
+
+table style="border: 1px solid;width:100%;border-collapse: collapse;"
+  tr
+    td style="border: 1px solid;text-align:center;font-weight:bold;" Valor Arrecadado
+    td style="border: 1px solid;text-align:center;font-weight:bold;"
+      span #{total_amount.format}
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span Meio de Pagamento (-)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{total_gateway_fee.format}
+
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span Custo do Antifraude (-)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{total_antifraud_fee.format}
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span Taxa Líquida Catarse (-)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{project_fiscals.sum { |pf| -pf.total_catarse_fee - pf.total_gateway_fee - pf.total_antifraud_fee }.format}
+  - unless total_irrf.positive?
+    tr
+      td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+        span Retenção IRRF (+)
+      td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+        span #{total_irrf.format}
+  tr
+    td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
+      span style="font-weight:bold;"
+        span Repasse líquido (#{(1-project.service_fee)*100}%
+        - unless total_irrf.positive?
+          span + Retenções
+        span ) (=)
+    td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
+      span #{project_fiscals.sum { |pf| pf.total_amount_to_pf + pf.total_amount_to_pj - pf.total_catarse_fee - pf.total_gateway_fee - pf.total_antifraud_fee }.format }
+
+br/
+p style="text-align:right;" São Paulo, #{finished_date}
+
+p style="margin:0;" GRUPO COMUM CONSULTORIA E INTERMEDIAÇÃO DE NEGÓCIOS
+p style="margin:0;" CNPJ 14.512.425/0001-94

--- a/services/catarse/catarse.js/legacy/src/app.ts
+++ b/services/catarse/catarse.js/legacy/src/app.ts
@@ -140,6 +140,7 @@ m.trust = (text) => h.trust(text);
                 }),
                 '/projects/:project_id/surveys': Wrap(c.root.Surveys, { menuTransparency: false, footerBig: false, menuShort: true }),
                 '/projects/:project_id/fiscal': Wrap(c.root.ProjectsFiscal, { menuTransparency: false, footerBig: false, menuShort: true }),
+                '/projects/:project_id/project_fiscal': Wrap(c.root.ProjectFiscals, { menuTransparency: false, footerBig: false, menuShort: true }),
                 '/projects/:project_id/posts': Wrap(c.root.Posts, { menuTransparency: false, footerBig: false }),
                 '/projects/:project_id/posts/:post_id': Wrap(c.root.ProjectsShow, { menuTransparency: false, footerBig: true }),
                 [urlWithLocale('/projects/:project_id/posts')]: Wrap(c.root.Posts, { menuTransparency: false, footerBig: false }),

--- a/services/catarse/catarse.js/legacy/src/modules.js
+++ b/services/catarse/catarse.js/legacy/src/modules.js
@@ -34,6 +34,7 @@ export { default as ProjectEdit } from './root/project-edit';
 export { default as ProjectsPayment } from './root/projects-payment';
 export { default as ProjectsReward } from './root/projects-reward';
 export { default as ProjectsFiscal } from './root/projects-fiscal';
+export { default as ProjectFiscals } from './root/project-fiscals';
 export { default as Publish } from './root/publish';
 export { default as Start } from './root/start';
 export { default as Team } from './root/team';

--- a/services/catarse/catarse.js/legacy/src/root/project-fiscals.js
+++ b/services/catarse/catarse.js/legacy/src/root/project-fiscals.js
@@ -1,0 +1,184 @@
+import m from 'mithril';
+import prop from 'mithril/stream';
+import { catarse } from '../api';
+import _ from 'underscore';
+import h from '../h';
+import models from '../models';
+import projectDashboardMenu from '../c/project-dashboard-menu';
+import projectVM from '../vms/project-vm';
+
+const fiscalScope = _.partial(h.i18nScope, 'projects.dashboard_fiscal');
+
+const projectFiscals = {
+    oninit: function(vnode) {
+        const loader = catarse.loaderWithToken,
+            filterVM = catarse.filtersVM({
+                project_id: 'eq'
+            }),
+            {
+                project_id
+            } = vnode.attrs,
+            projectDetail = h.RedrawStream({}),
+            debitNotes = h.RedrawStream({}),
+            informs = h.RedrawStream({});
+        filterVM.project_id(project_id);
+
+        const getRowOptions = models.projectDetail.getRowOptions(filterVM.parameters());
+        const l = catarse.loaderWithToken(getRowOptions);
+        l.load().then((data) => {
+            projectDetail(_.first(data) || {});
+        });
+
+        const listInfomrs = {
+            submit: () => {
+                m.request({
+                    method: 'GET',
+                    url: `/projects/${vnode.attrs.project_id}/inform_years`,
+                    config: h.setCsrfToken
+                }).then((data) => {
+                   informs(_.map(data.result));
+                }).catch(() => {
+                    informs({})
+                });
+            }
+        };
+
+        const listDebitNotes = {
+            submit: () => {
+                m.request({
+                    method: 'GET',
+                    url: `/projects/${vnode.attrs.project_id}/debit_note_end_dates`,
+                    config: h.setCsrfToken
+                }).then((data) => {
+                    debitNotes(_.map(data));
+                }).catch(() => {
+                    debitNotes({})
+                });
+            }
+        };
+
+        listInfomrs.submit();
+        listDebitNotes.submit();
+
+        vnode.state = {
+            l,
+            projectDetail,
+            debitNotes,
+            informs
+        };
+    },
+    view: function({state, attrs}) {
+        const project = state.projectDetail();
+        const debitNotes = state.debitNotes();
+        const informs = state.informs();
+        const loading = state.l();
+        const hasData = !loading && (!_.isEmpty(debitNotes[0]) || !_.isEmpty(informs[0]));
+        console.log(_.map(debitNotes[0]));
+        return m('.project-fiscal',
+            (project.is_owner_or_admin ? m(projectDashboardMenu, {
+                project: prop(project)
+            }) : ''),
+            m('.section',
+                m('.w-container',
+                    m('.w-row', [
+                        m('.w-col.w-col-2'),
+                        m('.w-col.w-col-8', [
+                            m('.fontsize-larger.fontweight-semibold.lineheight-looser.u-text-center',
+                                window.I18n.t('title', fiscalScope())
+                            ),
+                            m('.fontsize-base.u-text-center',
+                                window.I18n.t('subtitle', fiscalScope())
+                            ),
+                            m('.u-margintop-20.u-text-center',
+                                m('.w-inline-block.card.fontsize-small.u-radius', [
+                                    m('span.fa.fa-lightbulb-o',
+                                        ''
+                                    ),
+                                    m.trust('&nbsp;'),
+                                    m.trust(window.I18n.t('help_link', fiscalScope()))
+                                ])
+                            )
+                        ]),
+                        m('.w-col.w-col-2')
+                    ])
+                )
+            ),
+            m('.divider'),
+            (!loading ?
+            m('.before-footer.section',
+                m('.w-container', [
+                    (!hasData ?
+                        m('.w-row', [
+                            m('.w-col.w-col-2'),
+                            m('.w-col.w-col-8',
+                                m('.card.card-message.u-marginbottom-40.u-radius',
+                                    m('.fontsize-base', [
+                                        m('span.fa.fa-exclamation-circle',
+                                            ''
+                                        ),
+                                        window.I18n.t(!projectVM.isSubscription(project) ?
+                                            'nodoc_explanation'
+                                            : 'nodoc_explanation_sub', fiscalScope())
+                                    ])
+                                )
+                            ),
+                            m('.w-col.w-col-2')
+                        ])
+                        :
+                        m('.w-row', [
+                            m('.w-col.w-col-2'),
+                            m('.w-col.w-col-8',
+                                m('.card.u-radius.u-marginbottom-20.card-terciary', [
+                                    m('.fontsize-small.fontweight-semibold.u-marginbottom-20', [
+                                        m('span.fa.fa-download',
+                                            m.trust('&nbsp;')
+                                        ),
+                                        window.I18n.t('doc_download', fiscalScope())
+                                    ]),
+                                    m('.card.u-radius.u-marginbottom-20', [
+                                        m('span.fontweight-semibold',
+                                            m.trust('Atenção:')
+                                        ),
+                                        m.trust(window.I18n.t('doc_download_explanation', fiscalScope()))
+                                    ]),
+                                    m('ul.w-list-unstyled', _.map(informs, (inform, idx) => [
+                                        (idx > 0 ? m('li.divider.u-marginbottom-10') : ''),
+                                        m('li.fontsize-smaller.u-marginbottom-10',
+                                            m('div', [
+                                                'Informe de Rendimentos -',
+                                                m.trust('&nbsp;'),
+                                                m(`a.alt-link[href='/projects/${project.project_id}/project_inform/${inform}']`,
+                                                    inform
+                                                ),
+                                                m.trust('&nbsp;')
+                                            ])
+                                        )])
+                                    ),
+                                    m('ul.w-list-unstyled', _.map(debitNotes[0], (note, idx) => [
+                                        (idx > 0 || !_.isEmpty(debitNotes[0]) ? m('li.divider.u-marginbottom-10') : ''),
+                                        m('li.fontsize-smaller.u-marginbottom-10',
+                                            m('div', [
+                                                'Nota de Débito -',
+                                                m.trust('&nbsp;'),
+                                                m(`a.alt-link[href='/projects/${project.project_id}/project_debit_note/${note.project_fiscal_id}']`,
+                                                   note.end_date
+                                                ),
+                                                m.trust('&nbsp;')
+                                            ])
+                                        )])
+                                    )
+                                ])
+                            ),
+                            m('.w-col.w-col-2')
+                        ])
+
+                    ),
+                ]
+                )
+            )
+            : h.loader())
+        );
+    }
+};
+
+export default projectFiscals;

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -110,6 +110,10 @@ Catarse::Application.routes.draw do
         get 'debit_note/:fiscal_date', to: 'projects/project_fiscal_data#debit_note'
         get 'inform/:fiscal_year', to: 'projects/project_fiscal_data#inform'
 
+        get 'project_debit_note/:id', to: 'projects/project_fiscal#debit_note'
+        get 'project_inform/:fiscal_year', to: 'projects/project_fiscal#inform'
+        get 'inform_years', to: 'projects/project_fiscal#inform_years'
+        get 'debit_note_end_dates', to: 'projects/project_fiscal#debit_note_end_dates'
         resources :contributions, { except: [:index], controller: 'projects/contributions' } do
           collection do
             get :fallback_create, to: 'projects/contributions#create'
@@ -137,6 +141,7 @@ Catarse::Application.routes.draw do
           get 'posts'
           get 'surveys'
           get 'fiscal'
+          get 'project_fiscal'
           get 'contributions_report'
           get 'subscriptions_report'
           get 'subscriptions_report_download'

--- a/services/catarse/spec/controllers/projects/project_fiscal_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects/project_fiscal_controller_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Projects::ProjectFiscalController, type: :controller do
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe 'GET project_debit_note/:id' do
+    context 'when project fiscal not exist' do
+      before do
+        get :debit_note, params: { project_id: project.id, id: '1' }
+      end
+
+      let(:project) { create(:project) }
+      let(:user) {  project.user }
+
+      it { is_expected.to redirect_to edit_project_path(project.id, locale: nil) }
+    end
+
+    context 'when project fiscal exist and user isn`t not project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :debit_note, params: { project_id: project.id, id: project_fiscal.id }
+      end
+
+      it { is_expected.to redirect_to root_path }
+    end
+
+    context 'when project fiscal exist and user is admin' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user, admin: true) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :debit_note, params: { project_id: project.id, id: project_fiscal.id }
+      end
+
+      it { is_expected.to render_template('user_notifier/mailer/project_fiscal_debit_note') }
+    end
+
+    context 'when project fiscal exist and user is project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) {  project_fiscal.user }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :debit_note, params: { project_id: project.id, id: project_fiscal.id }
+      end
+
+      it { is_expected.to render_template('user_notifier/mailer/project_fiscal_debit_note') }
+    end
+  end
+
+  describe 'GET project_inform/:fiscal_year' do
+    context 'when project fiscal not exist' do
+      before do
+        get :inform, params: { project_id: project.id, fiscal_year: '2021' }
+      end
+
+      let(:project) { create(:project) }
+      let(:user) {  project.user }
+
+      it { is_expected.to redirect_to edit_project_path(project.id, locale: nil) }
+    end
+
+    context 'when project fiscal exist and user isn`t not project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :inform, params: { project_id: project.id, fiscal_year: project_fiscal.end_date.year.to_s }
+      end
+
+      it { is_expected.to redirect_to root_path }
+    end
+
+    context 'when project fiscal exist and user is admin' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user, admin: true) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :inform, params: { project_id: project.id, fiscal_year: project_fiscal.end_date.year.to_s }
+      end
+
+      it { is_expected.to render_template('user_notifier/mailer/project_fiscal_inform') }
+    end
+
+    context 'when project fiscal exist and user is project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) {  project_fiscal.user }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :inform, params: { project_id: project.id, fiscal_year: project_fiscal.end_date.year.to_s }
+      end
+
+      it { is_expected.to render_template('user_notifier/mailer/project_fiscal_inform') }
+    end
+  end
+
+  describe 'GET /inform_years' do
+    context 'when project fiscal not exist' do
+      before do
+        get :inform_years, params: { project_id: project.id }
+      end
+
+      let(:project) { create(:project) }
+      let(:user) {  project.user }
+
+      it 'result null' do
+        param = JSON.parse(response.body).with_indifferent_access
+        expect(param['result']).to eq([])
+      end
+    end
+
+    context 'when project fiscal exist and user isn`t not project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :inform_years, params: { project_id: project.id }
+      end
+
+      it { is_expected.to redirect_to root_path }
+    end
+
+    context 'when project fiscal exist and user is admin' do
+      let(:project) { create(:project) }
+      let(:user) { build(:user, admin: true) }
+      let!(:project_fiscal_2) do
+        create(:project_fiscal, project: project, end_date: 1.year.from_now)
+      end
+
+      before do
+        create(:project_fiscal, project: project)
+        get :inform_years, params: { project_id: project.id }
+      end
+
+      it 'returns result' do
+        param = JSON.parse(response.body).with_indifferent_access
+        expect(param['result']).to eq([project_fiscal_2.end_date.strftime('%Y').to_i])
+      end
+    end
+
+    context 'when project fiscal exist and user is project owner' do
+      let(:project) { create(:project) }
+      let(:user) { project.user }
+      let!(:project_fiscal_2) do
+        create(:project_fiscal, user: user, project: project, end_date: 1.year.from_now)
+      end
+
+      before do
+        create(:project_fiscal, project: project, user: user)
+        get :inform_years, params: { project_id: project.id }
+      end
+
+      it 'returns result' do
+        param = JSON.parse(response.body).with_indifferent_access
+        expect(param['result']).to eq([project_fiscal_2.end_date.strftime('%Y').to_i])
+      end
+    end
+  end
+
+  describe 'GET /debit_note_end_dates' do
+    context 'when project fiscal not exist' do
+      before do
+        get :debit_note_end_dates, params: { project_id: project.id }
+      end
+
+      let(:project) { create(:project) }
+      let(:user) { project.user }
+
+      it 'result null' do
+        param = JSON.parse(response.body).with_indifferent_access
+        expect(param['result']).to eq([])
+      end
+    end
+
+    context 'when project fiscal exist and user isn`t not project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :debit_note_end_dates, params: { project_id: project.id }
+      end
+
+      it { is_expected.to redirect_to root_path }
+    end
+
+    context 'when project fiscal exist and user is admin' do
+      let(:project) { project_fiscal.project }
+      let(:user) { build(:user, admin: true) }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :debit_note_end_dates, params: { project_id: project.id }
+      end
+
+      it 'returns result' do
+        param = JSON.parse(response.body).with_indifferent_access
+        expect(param['result']).to eq([
+                                        {
+                                          'project_fiscal_id' => project_fiscal.id,
+                                          'project_id' => project_fiscal.project_id,
+                                          'end_date' => I18n.l(project_fiscal.end_date.to_date)
+                                        }
+                                      ]
+                                     )
+      end
+    end
+
+    context 'when project fiscal exist and user is project owner' do
+      let(:project) { project_fiscal.project }
+      let(:user) {  project_fiscal.user }
+      let!(:project_fiscal) { create(:project_fiscal) }
+
+      before do
+        get :debit_note_end_dates, params: { project_id: project.id }
+      end
+
+      it 'returns result' do
+        param = JSON.parse(response.body).with_indifferent_access
+        expect(param['result']).to eq([
+                                        {
+                                          'project_fiscal_id' => project_fiscal.id,
+                                          'project_id' => project_fiscal.project_id,
+                                          'end_date' => I18n.l(project_fiscal.end_date.to_date)
+                                        }
+                                      ]
+                                     )
+      end
+    end
+  end
+end

--- a/services/catarse/spec/policies/project_fiscal_policy_spec.rb
+++ b/services/catarse/spec/policies/project_fiscal_policy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectFiscalPolicy do
+  subject { described_class }
+
+  shared_examples_for 'access permissions' do
+    it 'denies access if user is nil' do
+      expect(subject).not_to permit(nil, ProjectFiscal.new)
+    end
+
+    it 'denies access if user is not project_fiscal owner' do
+      expect(subject).not_to permit(User.new, ProjectFiscal.new(user: User.new))
+    end
+
+    it 'permits access if user is project_fiscal owner' do
+      new_user = User.new
+      expect(subject).to permit(new_user, ProjectFiscal.new(user: new_user))
+    end
+
+    it 'permits access if user is admin' do
+      admin = User.new
+      admin.admin = true
+      expect(subject).to permit(admin, ProjectFiscal.new(user: User.new))
+    end
+  end
+
+  permissions(:debit_note?) { it_behaves_like 'access permissions' }
+
+  permissions(:inform?) { it_behaves_like 'access permissions' }
+
+  permissions(:inform_years?) { it_behaves_like 'access permissions' }
+
+  permissions(:debit_note_end_dates?) { it_behaves_like 'access permissions' }
+end


### PR DESCRIPTION
### Descrição
Criar estrutura para mostrar a tabela ProjectFiscal como nota de débito e também como Informe Anual, listando todos os ProjectFiscals gerando durante aquele ano. 

### Referência
https://www.notion.so/catarse/Utilizar-os-dados-da-nova-estrutura-de-dados-fiscais-no-frontend-do-projeto-2431c6f98bc74a028717607f3a5a01d4

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
