### PR TITLE
✨ Adiciona validação de endereço de pagamento no cadastro do cartão de crédito.

### DIFF
--- a/services/catarse/app/models/billing/credit_card.rb
+++ b/services/catarse/app/models/billing/credit_card.rb
@@ -20,6 +20,16 @@ module Billing
     validates :brand, presence: true
     validates :expires_on, presence: true
 
+    validate :billing_address_owner_matches_user, if: %i[user_id? billing_address_id?]
+
     scope :safelist, Billing::CreditCards::SafelistQuery
+
+    private
+
+    def billing_address_owner_matches_user
+      return if user_id == billing_address.user_id
+
+      errors.add(:billing_address_id, I18n.t('models.billing.credit_card.errors.invalid_billing_address'))
+    end
   end
 end

--- a/services/catarse/config/locales/billing.en.yml
+++ b/services/catarse/config/locales/billing.en.yml
@@ -1,6 +1,9 @@
 en:
   models:
     billing:
+      credit_card:
+        errors:
+          invalid_billing_address: "billing address owner doesn't match user"
       payment:
         errors:
           invalid_total_amount: "doesn't match other values"

--- a/services/catarse/config/locales/billing.pt.yml
+++ b/services/catarse/config/locales/billing.pt.yml
@@ -1,6 +1,9 @@
 pt:
   models:
     billing:
+      credit_card:
+        errors:
+          invalid_billing_address: "não pertence ao usuário do cartão de crédito"
       payment:
         errors:
           invalid_total_amount: "incompatível com os outros valores"

--- a/services/catarse/spec/factories/billing/credit_cards_factories.rb
+++ b/services/catarse/spec/factories/billing/credit_cards_factories.rb
@@ -3,7 +3,10 @@
 FactoryBot.define do
   factory :billing_credit_card, class: 'Billing::CreditCard' do
     association :user, factory: :user, strategy: :create
-    association :billing_address, factory: :common_address, strategy: :create
+
+    billing_address do
+      create(:common_address, user: user)
+    end
 
     gateway { Billing::Gateways.list.sample }
     gateway_id { Faker::Internet.uuid }

--- a/services/catarse/spec/models/billing/credit_card_spec.rb
+++ b/services/catarse/spec/models/billing/credit_card_spec.rb
@@ -27,6 +27,38 @@ RSpec.describe Billing::CreditCard, type: :model do
     it { is_expected.to validate_presence_of(:country) }
     it { is_expected.to validate_presence_of(:brand) }
     it { is_expected.to validate_presence_of(:expires_on) }
+
+    context 'when billing address owner matches user' do
+      subject(:credit_card) do
+        described_class.new(user: user, billing_address: address)
+      end
+
+      let(:address) { create(:common_address) }
+      let(:user) { address.user }
+
+      it 'doesn`t add invalid_billing_address error' do
+        credit_card.valid?
+
+        expect(credit_card.errors[:billing_address_id]).to be_empty
+      end
+    end
+
+    context 'when billing address owner doesn`t match user' do
+      subject(:credit_card) do
+        described_class.new(user: user, user_id: user.id, billing_address: billing_address)
+      end
+
+      let(:address) { create(:common_address) }
+      let(:user) { address.user }
+      let(:billing_address) { create(:common_address) }
+
+      it 'adds invalid billing address error message' do
+        credit_card.valid?
+
+        error_message = I18n.t('models.billing.credit_card.errors.invalid_billing_address')
+        expect(credit_card.errors[:billing_address_id]).to include error_message
+      end
+    end
   end
 
   describe 'Scopes' do


### PR DESCRIPTION
### Descrição
Ao cadastrar um cartão de crédito é enviado um id do endereço de cobrança. É importante criar uma validação para verificar se o endereço do cartão pertence ao usuário do cartão.

### Referência
https://www.notion.so/catarse/Validar-que-endere-o-enviado-no-cadastro-do-cart-o-cr-dito-do-pr-prio-usu-rio-02dde4715a8847a49e01f032d75e77c4

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
