### PR TITLE
✨ Adiciona transação de status successful para deleted.

### DIFF
--- a/services/catarse/app/state_machines/aon_project_machine.rb
+++ b/services/catarse/app/state_machines/aon_project_machine.rb
@@ -8,7 +8,7 @@ class AonProjectMachine < FlexProjectMachine
     transition from: :online, to: %i[draft rejected deleted waiting_funds successful failed]
     transition from: :waiting_funds, to: %i[successful failed rejected]
     transition from: :failed, to: %i[deleted rejected]
-    transition from: :successful, to: :rejected
+    transition from: :successful, to: %i[deleted rejected]
 
     guard_transition(from: :successful, to: :rejected) do |project, transition|
       project.can_cancel?

--- a/services/catarse/app/state_machines/flex_project_machine.rb
+++ b/services/catarse/app/state_machines/flex_project_machine.rb
@@ -105,7 +105,7 @@ class FlexProjectMachine
     transition from: :online, to: %i[draft rejected deleted waiting_funds successful failed]
     transition from: :waiting_funds, to: %i[successful failed rejected]
     transition from: :failed, to: %i[deleted rejected]
-    transition from: :successful, to: :rejected
+    transition from: :successful, to: %i[deleted rejected]
 
     guard_transition(from: :successful, to: :rejected) do |project, transition|
       project.can_cancel?

--- a/services/catarse/spec/state_machines/aon_project_machine_spec.rb
+++ b/services/catarse/spec/state_machines/aon_project_machine_spec.rb
@@ -315,6 +315,84 @@ RSpec.describe AonProjectMachine, type: :model do
           end
         end
       end
+
+      context 'successful project can go to deleted or rejected' do
+        let(:project_state) { 'successful' }
+
+        context 'deleted transition' do
+          context 'when can go to deleted' do
+            context 'project not have waiting payments and not reached the goal' do
+              before do
+                allow(project).to receive(:in_time_to_wait?).and_return(false)
+                allow(project).to receive(:reached_goal?).and_return(false)
+              end
+
+              it_should_behave_like 'valid deleted project transaction'
+            end
+
+            context 'project not have waiting payments and reached the goal' do
+              before do
+                allow(project).to receive(:in_time_to_wait?).and_return(false)
+                allow(project).to receive(:reached_goal?).and_return(true)
+              end
+
+              it_should_behave_like 'valid deleted project transaction'
+            end
+
+            context 'project does not expired' do
+              before { allow(project).to receive(:expired?).and_return(false) }
+
+              it_should_behave_like 'valid deleted project transaction'
+            end
+
+            context 'project have pending payments and already reached the goal' do
+              before do
+                allow(project).to receive(:in_time_to_wait?).and_return(true)
+                allow(project).to receive(:reached_goal?).and_return(true)
+              end
+
+              it_should_behave_like 'valid deleted project transaction'
+            end
+          end
+        end
+
+        context 'rejected transition' do
+          context 'when can go to rejected' do
+            context 'project not have waiting payments and reached the goal' do
+              before do
+                allow(project).to receive(:in_time_to_wait?).and_return(false)
+                allow(project).to receive(:reached_goal?).and_return(true)
+              end
+
+              it_should_behave_like 'valid rejected project transaction'
+            end
+
+            context 'project have pending payments and already reached the goal' do
+              before do
+                allow(project).to receive(:in_time_to_wait?).and_return(true)
+                allow(project).to receive(:reached_goal?).and_return(true)
+              end
+
+              it_should_behave_like 'valid rejected project transaction'
+            end
+
+            context 'project not have pending payments and reached the goal' do
+              before do
+                allow(project).to receive(:in_time_to_wait?).and_return(false)
+                allow(project).to receive(:reached_goal?).and_return(true)
+              end
+
+              it_should_behave_like 'valid rejected project transaction'
+            end
+
+            context 'project does not expired' do
+              before { allow(project).to receive(:expired?).and_return(false) }
+
+              it_should_behave_like 'valid rejected project transaction'
+            end
+          end
+        end
+      end
     end
 
     context 'instance methods' do

--- a/services/catarse/spec/state_machines/flex_project_machine_spec.rb
+++ b/services/catarse/spec/state_machines/flex_project_machine_spec.rb
@@ -157,6 +157,85 @@ RSpec.describe FlexProjectMachine, type: :model do
     end
   end
 
+  context 'successful project can go to deleted or rejected' do
+    let(:project) { create(:project, state: project_state) }
+    let(:project_state) { 'successful' }
+
+    context 'deleted transition' do
+      context 'when can go to deleted' do
+        context 'project not have waiting payments and not reached the goal' do
+          before do
+            allow(project).to receive(:in_time_to_wait?).and_return(false)
+            allow(project).to receive(:reached_goal?).and_return(false)
+          end
+
+          it { should_be_valid_transition 'deleted' }
+        end
+
+        context 'project not have pending payments and reached the goal' do
+          before do
+            allow(project).to receive(:in_time_to_wait?).and_return(false)
+            allow(project).to receive(:reached_goal?).and_return(true)
+          end
+
+          it { should_be_valid_transition 'deleted' }
+        end
+
+        context 'project have pending payments and already reached the goal' do
+          before do
+            allow(project).to receive(:in_time_to_wait?).and_return(true)
+            allow(project).to receive(:reached_goal?).and_return(true)
+          end
+
+          it { should_be_valid_transition 'deleted' }
+        end
+
+        context 'project does not expired' do
+          before { allow(project).to receive(:expired?).and_return(false) }
+
+          it { should_be_valid_transition 'deleted' }
+        end
+      end
+    end
+
+    context 'rejected transition' do
+      context 'when can go to rejected' do
+        context 'project not have waiting payments and reached the goal' do
+          before do
+            allow(project).to receive(:in_time_to_wait?).and_return(false)
+            allow(project).to receive(:reached_goal?).and_return(true)
+          end
+
+          it { should_be_valid_transition 'rejected' }
+        end
+
+        context 'project have pending payments and already reached the goal' do
+          before do
+            allow(project).to receive(:in_time_to_wait?).and_return(true)
+            allow(project).to receive(:reached_goal?).and_return(true)
+          end
+
+          it { should_be_valid_transition 'rejected' }
+        end
+
+        context 'project not have pending payments and reached the goal' do
+          before do
+            allow(project).to receive(:in_time_to_wait?).and_return(false)
+            allow(project).to receive(:reached_goal?).and_return(true)
+          end
+
+          it { should_be_valid_transition 'rejected' }
+        end
+
+        context 'project does not expired' do
+          before { allow(project).to receive(:expired?).and_return(false) }
+
+          it { should_be_valid_transition 'rejected' }
+        end
+      end
+    end
+  end
+
   context '#push_to_draft' do
     before do
       expect(subject).to receive(:transition_to)


### PR DESCRIPTION
### Descrição
Projetos que são finalizados com sucesso, não podem ser deletados devido a máquina de estado. A solução é adicionar uma nova transação de successful pra deleted.

### Referência
https://www.notion.so/catarse/Ajustar-statemachine-de-projetos-para-permitir-que-projetos-bem-sucedidos-sejam-deletados-46bc1866e7e449f49607611ddc91a2ee

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
