### PR TITLE
✨ Adiciona validação no nível de apoio que pertence a um projeto de assinatura.

### DIFF
--- a/services/catarse/app/models/membership/tier.rb
+++ b/services/catarse/app/models/membership/tier.rb
@@ -15,5 +15,14 @@ module Membership
 
     validates :subscribers_limit, numericality: { greater_than: 0, only_integer: true }, allow_nil: true
     validates :order, numericality: { only_integer: true }
+    validate :project_mode_is_membership
+
+    private
+
+    def project_mode_is_membership
+      return if project.try(:is_sub?)
+
+      errors.add(:project_id, I18n.t('models.membership.tier.errors.invalid_project'))
+    end
   end
 end

--- a/services/catarse/config/locales/membership.en.yml
+++ b/services/catarse/config/locales/membership.en.yml
@@ -1,0 +1,6 @@
+en:
+  models:
+    membership:
+      tier:
+        errors:
+          invalid_project: "project mode must be membership."

--- a/services/catarse/config/locales/membership.pt.yml
+++ b/services/catarse/config/locales/membership.pt.yml
@@ -1,0 +1,6 @@
+pt:
+  models:
+    membership:
+      tier:
+        errors:
+          invalid_project: "o projeto deve ser da modalidade de assinatura."

--- a/services/catarse/spec/actions/membership/tiers/create_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/create_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Membership::Tiers::Create, type: :action do
   describe '#call' do
     subject(:result) { described_class.result(project_id: project.id, attributes: attributes) }
 
-    let(:project) { create(:project) }
+    let(:project) { create(:subscription_project) }
 
     context 'when attributes are valid' do
       let(:attributes) { attributes_for(:membership_tier).merge(project_id: project.id) }

--- a/services/catarse/spec/actions/membership/tiers/list_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/list_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Membership::Tiers::List, type: :action do
     subject(:result) { described_class.result(project_id: project_id) }
 
     context 'when project exists' do
-      let(:project) { create(:project) }
+      let(:project) { create(:subscription_project) }
       let!(:tiers) { create_list(:membership_tier, 3, project: project) }
       let(:project_id) { project.id }
 

--- a/services/catarse/spec/factories/membership/subscriptions_factories.rb
+++ b/services/catarse/spec/factories/membership/subscriptions_factories.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :membership_subscription, class: 'Membership::Subscription' do
     traits_for_enum :state, Membership::SubscriptionStateMachine.states
 
-    association :project
+    association :project, factory: :subscription_project
     association :user
 
     tier { association :membership_tier, project: project }

--- a/services/catarse/spec/factories/membership/tiers_factories.rb
+++ b/services/catarse/spec/factories/membership/tiers_factories.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :membership_tier, class: 'Membership::Tier' do
-    association :project, factory: :project
+    association :project, factory: :subscription_project
 
     name { Faker::Lorem.sentence }
     description { Faker::Lorem.sentence(word_count: 20) }

--- a/services/catarse/spec/models/membership/tier_spec.rb
+++ b/services/catarse/spec/models/membership/tier_spec.rb
@@ -19,5 +19,31 @@ RSpec.describe Membership::Tier, type: :model do
 
     it { is_expected.to validate_numericality_of(:subscribers_limit).is_greater_than(0).only_integer.allow_nil }
     it { is_expected.to validate_numericality_of(:order).only_integer }
+
+    context 'when the project does have subscription mode' do
+      let(:tier) { build(:membership_tier, project: project) }
+      let(:project) { create(:subscription_project) }
+
+      it 'doesn`t add invalid project error' do
+        tier.valid?
+
+        expect(tier.errors[:project_id]).to be_empty
+      end
+    end
+
+    context 'when the project does not have subscription mode' do
+      let(:tier) { build(:membership_tier, project: project) }
+
+      %i[aon flex].each do |mode|
+        let(:project) { create(:project, mode: mode.to_s) }
+
+        it 'adds invalid project error message' do
+          tier.valid?
+
+          error_message = I18n.t('models.membership.tier.errors.invalid_project')
+          expect(tier.errors[:project_id]).to include error_message
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Descrição
Ao salvar nível de apoio (Tier), validar que o seu projeto é da modalidade Assinatura.

### Referência
[Link para a atividade
](https://www.notion.so/catarse/Validar-que-n-vel-de-apoio-pertence-a-um-projeto-de-assinatura-ad0131e36827452496155d77542240f9)

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
