### PR TITLE
✨ Adiciona valor padrão no atributo de ordenação na criação do Tier.

### DIFF
--- a/services/catarse/app/actions/membership/tiers/create.rb
+++ b/services/catarse/app/actions/membership/tiers/create.rb
@@ -10,7 +10,7 @@ module Membership
 
       def call
         project = Project.find(project_id)
-        self.tier = project.tiers.create!(attributes)
+        self.tier = project.tiers.create!(attributes.merge(order: 5))
       end
     end
   end

--- a/services/catarse/spec/actions/membership/tiers/create_spec.rb
+++ b/services/catarse/spec/actions/membership/tiers/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Membership::Tiers::Create, type: :action do
     let(:project) { create(:project) }
 
     context 'when attributes are valid' do
-      let(:attributes) { attributes_for(:membership_tier).merge(project_id: project.id) }
+      let(:attributes) { attributes_for(:membership_tier).merge(project_id: project.id, order: 5) }
 
       it { is_expected.to be_success }
 
@@ -32,6 +32,10 @@ RSpec.describe Membership::Tiers::Create, type: :action do
 
       it 'creates tier with given attribute' do
         expect(result.tier.attributes).to include(attributes.stringify_keys)
+      end
+
+      it 'creates tier with order equal 5' do
+        expect(result.tier[:order]).to eq(5)
       end
     end
 


### PR DESCRIPTION
### Descrição
Adicionar atributo ordem com valor padrão igual a 5 na Action de criação do Tier.

### Referência
[Link para a atividade
](https://www.notion.so/catarse/Preencher-atributo-de-ordena-o-no-n-vel-de-apoio-quando-ele-for-criado-86b887e6996a40d8aadc4da4570d6cec)

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
