### PR TITLE
🐞 Corrige titulo das paginas de ediçao do perfil

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/users/edit.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/users/edit.html.slim
@@ -1,5 +1,16 @@
 - content_for :js do
   = javascript_include_tag 'redactor'
+javascript:
+  const userName = "#{resource.decorator.display_name}";
+  
+  function updatePageTitle() {
+    var path = `users.edit.menu.${window.location.href.split("#")[1]}`;
+    document.title = `${I18n.t(path)} - ${userName}`;
+  };
+
+  window.addEventListener('hashchange', updatePageTitle);
+  document.addEventListener('DOMContentLoaded', updatePageTitle);
+
 - content_for :stylesheets do
   = stylesheet_link_tag 'redactor'
 

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/edit.pt.yml
@@ -1,6 +1,14 @@
 pt:
   users:
     edit:
+      menu: 
+        contributions: 'Apoiados'
+        projects: 'Criados'
+        about_me: 'Perfil público'
+        settings: 'Dados cadastrais'
+        contributions: 'Apoiados'
+        notifications: 'Notificações'
+        balance: 'Saldo'
       settings_tab:
         credit_cards:
           title: 'Cartões de crédito'


### PR DESCRIPTION
### Descrição
As páginas de edição do perfil do usuário não estavam exibindo o título da aba corretamente, mostrando apenas a url da página. Foi corrigido para mostrar o titulo da tela de edição selecionada e o nome do usuário.

### Referência
https://www.notion.so/catarse/Modificar-o-Title-das-p-ginas-de-edi-o-de-perfil-que-est-o-com-o-link-para-a-descri-o-apropriad-610897e1dea5440185102caa26bba0d0

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
