### PR TITLE
✨ Preenche atributo de ordenação na criação do Tier.

### DIFF
--- a/services/catarse/app/models/membership/tier.rb
+++ b/services/catarse/app/models/membership/tier.rb
@@ -15,5 +15,15 @@ module Membership
 
     validates :subscribers_limit, numericality: { greater_than: 0, only_integer: true }, allow_nil: true
     validates :order, numericality: { only_integer: true }
+
+    before_validation :fill_order, on: :create
+
+    private
+
+    def fill_order
+      return if order.present?
+
+      self.order = self.class.where(project_id: project_id).maximum(:order).to_i + 1
+    end
   end
 end

--- a/services/catarse/db/refactoring_migrations/20211220182104_change_order_to_membership_tiers.rb
+++ b/services/catarse/db/refactoring_migrations/20211220182104_change_order_to_membership_tiers.rb
@@ -1,0 +1,5 @@
+class ChangeOrderToMembershipTiers < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default(:membership_tiers, :order, nil)
+  end
+end

--- a/services/catarse/spec/models/membership/tier_spec.rb
+++ b/services/catarse/spec/models/membership/tier_spec.rb
@@ -10,6 +10,54 @@ RSpec.describe Membership::Tier, type: :model do
     it { is_expected.to have_many(:subscriptions).class_name('Membership::Subscription').dependent(:destroy) }
   end
 
+  describe 'Before Validation' do
+    subject(:tier) { create(:membership_tier, project_id: project.id, order: nil) }
+
+    let(:project) { create(:project) }
+
+    context 'when the order attribute is not populated and there are one or more tiers' do
+      before do
+        create(:membership_tier, order: 1, project: project)
+        create(:membership_tier, order: 3, project: project)
+      end
+
+      it 'the order attribute is the highest value plus a unit' do
+        expect(tier.order).to eq(4)
+      end
+    end
+
+    context 'when the order attribute is not populated and there are no more tier' do
+      it 'the order attribute is equal to one' do
+        expect(tier.order).to eq(1)
+      end
+    end
+
+    context 'when order attribute is populated on creation' do
+      subject(:tier) { create(:membership_tier, project_id: project.id, order: 10) }
+
+      before do
+        create(:membership_tier, project: project, order: 1)
+      end
+
+      it 'there is no change in the attribute order' do
+        expect(tier.order).to eq(10)
+      end
+    end
+
+    context 'when an attribute is updated' do
+      subject(:tier) { create(:membership_tier, project_id: project.id, order: 1) }
+
+      before do
+        create(:membership_tier, project: project, order: 5)
+        tier.update(name: Faker::Lorem.sentence)
+      end
+
+      it 'there is no change in the attribute order' do
+        expect(tier.order).to eq(1)
+      end
+    end
+  end
+
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:description) }


### PR DESCRIPTION
### Descrição
Ao criar um nível de apoio, na action, devesse preencher automaticamente o atributo order para que ele seja o último nível de apoio na ordenação.

### Referência
[Link para a atividade
](https://www.notion.so/catarse/Preencher-atributo-de-ordena-o-no-n-vel-de-apoio-quando-ele-for-criado-86b887e6996a40d8aadc4da4570d6cec)

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
