### PR TITLE
🐞 Adiciona condição em projetos apoiados por amigos para listar somente os financiamento.

### DIFF
--- a/services/catarse/app/models/user.rb
+++ b/services/catarse/app/models/user.rb
@@ -312,7 +312,8 @@ class User < ApplicationRecord
   end
 
   def projects_backed_by_friends_in_last_day
-    Project.joins(:contributions)
+    Project.in_funding
+           .joins(:contributions)
            .joins('join user_follows on user_follows.follow_id = contributions.user_id
             join payments on payments.contribution_id = contributions.id')
            .where('contributions.is_confirmed and not contributions.anonymous')


### PR DESCRIPTION
### Descrição
Filtrar somente projetos que estão disponíveis para contribuição para enviarem notificações de apoiados por amigos.

### Referência
[Link para a atividade
](https://www.notion.so/catarse/N-o-enviar-notifica-o-de-apoio-de-amigos-para-projetos-finalizados-d75714df8edc4e42b55aafad85f8ea30)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
