### PR TITLE
🐞 Mostra dados da aba 'Sobre' somente de realizadores

### DIFF
--- a/services/catarse/app/controllers/users_controller.rb
+++ b/services/catarse/app/controllers/users_controller.rb
@@ -2,12 +2,12 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  after_action :verify_authorized, except: %i[reactivate verify_can_receive_message]
+  after_action :verify_authorized, except: %i[reactivate verify_has_ongoing_or_successful_projects]
   after_action :redirect_user_back_after_login, only: %i[show]
   inherit_resources
   defaults finder: :find_active!
   actions :show, :update, :unsubscribe_notifications, :destroy, :edit
-  respond_to :json, only: %i[contributions projects verify_can_receive_message]
+  respond_to :json, only: %i[contributions projects verify_has_ongoing_or_successful_projects]
   before_action :referral_it!, only: [:show]
   before_action :authenticate_user!, only: [:follow_fb_friends]
 
@@ -147,10 +147,10 @@ class UsersController < ApplicationController
     end
   end
 
-  def verify_can_receive_message
-    can_receive_message = resource.has_ongoing_or_successful_projects?
+  def verify_has_ongoing_or_successful_projects
+    has_ongoing_or_successful_projects = resource.has_ongoing_or_successful_projects?
 
-    render json: { can_receive_message: can_receive_message }
+    render json: { has_ongoing_or_successful_projects: has_ongoing_or_successful_projects }
   rescue StandardError => error_message
     Sentry.capture_exception(error_message)
 

--- a/services/catarse/catarse.js/legacy/src/c/project-user-card.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/project-user-card.tsx
@@ -30,12 +30,12 @@ const projectUserCard = {
         }
 
         let builder = { requestOptions: {
-                        url: (`/users/${userId}/verify_can_receive_message`),
+                        url: (`/users/${userId}/verify_has_ongoing_or_successful_projects`),
                         method: 'GET'}
                     };
 
         const load = () => m.request(_.extend({}, {}, builder.requestOptions)),
-              resp = h.RedrawStream('');
+              canReceiveMessage = h.RedrawStream('');
 
         builder.requestOptions.config = (xhr) => {
             if (h.authenticityToken()) {
@@ -44,11 +44,11 @@ const projectUserCard = {
         };
 
         const requestSuccess = (res) => {
-            resp(res.can_receive_message);
+            canReceiveMessage(res.has_ongoing_or_successful_projects);
         };
 
         const requestError = (e) => {
-            resp(false);
+            canReceiveMessage(false);
         };
 
         load().then(requestSuccess, requestError);
@@ -56,7 +56,7 @@ const projectUserCard = {
         vnode.state = {
             displayModal,
             sendMessage,
-            resp,
+            canReceiveMessage,
         };
     },
     view: function ({ state, attrs }) {
@@ -184,7 +184,7 @@ const projectUserCard = {
                                             follow_id: userDetail.id,
                                             following: userDetail.following_this_user,
                                         }),
-                                    state.resp() ?
+                                    state.canReceiveMessage() ?
                                         m(
                                             `button.w-button.btn.btn-terciary${attrs.isDark ? '.btn-terciary-negative' : ''}.btn-small`,
                                             {

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -173,7 +173,7 @@ Catarse::Application.routes.draw do
           get :reactivate
           post :new_password
           post :ban
-          get :verify_can_receive_message
+          get :verify_has_ongoing_or_successful_projects
         end
 
         resources :unsubscribes, only: [:create]

--- a/services/catarse/spec/controllers/users_controller_spec.rb
+++ b/services/catarse/spec/controllers/users_controller_spec.rb
@@ -347,42 +347,42 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
-  describe 'GET verify_can_receive_message' do
+  describe 'GET verify_has_ongoing_or_successful_projects' do
     context 'when the user has ongoing or successful projects' do
       let(:user) { create(:user) }
 
       before do
         allow_any_instance_of(User).to receive(:has_ongoing_or_successful_projects?).and_return(true)
-        get :verify_can_receive_message, params: { id: user.id }
+        get :verify_has_ongoing_or_successful_projects, params: { id: user.id }
       end
 
       it 'returns `ok` http response' do
         expect(response).to have_http_status(:ok)
       end
 
-      it 'returns `can_receive_message` flag as true' do
-        expect(response.body).to eq({ can_receive_message: true }.to_json)
+      it 'returns `has_ongoing_or_successful_projects` flag as true' do
+        expect(response.body).to eq({ has_ongoing_or_successful_projects: true }.to_json)
       end
     end
 
     context 'when the user hasn`t ongoing or successful projects' do
       before do
         allow_any_instance_of(User).to receive(:has_ongoing_or_successful_projects?).and_return(false)
-        get :verify_can_receive_message, params: { id: user.id }
+        get :verify_has_ongoing_or_successful_projects, params: { id: user.id }
       end
 
       it 'returns `ok` http response' do
         expect(response).to have_http_status(:ok)
       end
 
-      it 'returns `can_receive_message` flag as false' do
-        expect(response.body).to eq({ can_receive_message: false }.to_json)
+      it 'returns `has_ongoing_or_successful_projects` flag as false' do
+        expect(response.body).to eq({ has_ongoing_or_successful_projects: false }.to_json)
       end
     end
 
     context 'when an error occurs' do
       before do
-        get :verify_can_receive_message, params: { id: [] }
+        get :verify_has_ongoing_or_successful_projects, params: { id: [] }
       end
 
       it 'returns `internal_server_error` http response' do


### PR DESCRIPTION
### Descrição
Somente o perfil de realizadores terão seus dados da aba 'Sobre' visíveis, para resguardar os dados dos usuários de acordo com a LGPD.

### Referência
https://www.notion.so/catarse/Aba-Sobre-exibida-somente-para-usu-rios-que-tenha-a-flag-de-PROJETO-online-waiting_funds-ou-succ-bf27fd1600ca4d1fa8b230b2b63503a7

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
