### PR TITLE
🐞 Ajusta título da página de edição do usuário

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/users/edit.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/users/edit.html.slim
@@ -2,9 +2,10 @@
   = javascript_include_tag 'redactor'
 javascript:
   const userName = "#{resource.decorator.display_name}";
-  
+
   function updatePageTitle() {
-    var path = `users.edit.menu.${window.location.href.split("#")[1]}`;
+    const pageTitleKey = window.location.href.split("#")[1] || 'contributions'
+    const path = `users.edit.menu.${pageTitleKey}`;
     document.title = `${I18n.t(path)} - ${userName}`;
   };
 


### PR DESCRIPTION
### Descrição
Quando não houver uma rota após o # na página de edição de usuário, o código irá assumir que a página é a de projetos apoiados.

### Referência
https://www.notion.so/catarse/Ajustar-t-tulo-da-p-gina-de-edi-o-de-usu-rio-ca7e7e1b0a0e4e72909931e2dbe17c18

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
