### PR TITLE
✨ Adiciona projetos em pré-lançamento nos cards de explore.

### DIFF
--- a/services/catarse/catarse.js/legacy/spec/lib/mocks/project.mock.js
+++ b/services/catarse/catarse.js/legacy/spec/lib/mocks/project.mock.js
@@ -61,22 +61,22 @@ beforeAll(function(){
       "open_for_contributions":false,
       "online_days":60,
       "remaining_time":{
-        "total" : 0, 
+        "total" : 0,
         "unit" : "seconds"
       },
       "elapsed_time":{
-        "total" : 0, 
+        "total" : 0,
         "unit" : "seconds"
       },
       "posts_count":0,
       "address":{
-        "city" : "fda", 
-        "state_acronym" : "RS", 
+        "city" : "fda",
+        "state_acronym" : "RS",
         "state" : "Rio Grande do Sul"
       },
       "user":{
-        "id" : 3, 
-        "name" : "test test", 
+        "id" : 3,
+        "name" : "test test",
         "public_name" : "Test1"
       },
       "reminder_count":0,
@@ -133,7 +133,7 @@ beforeAll(function(){
 
 
   ProjectsGenerator = function(numberOfProjects, overrides, url) {
-    
+
     const projectBase = {
       project_id: 5,
       category_id: 1,
@@ -172,7 +172,7 @@ beforeAll(function(){
       common_id: "a60eec2e-dbe0-4efb-876c-e8c5ec0c8adc",
       is_adult_content: false,
       content_rating: 1,
-      saved_projects: true
+      active_saved_projects: true
     };
 
     const projects = [];
@@ -190,6 +190,3 @@ beforeAll(function(){
   });
 
 });
-
-
-

--- a/services/catarse/catarse.js/legacy/src/c/explore/explore-projects-list.js
+++ b/services/catarse/catarse.js/legacy/src/c/explore/explore-projects-list.js
@@ -2,21 +2,90 @@ import m from 'mithril';
 import _ from 'underscore';
 import h from '../../h';
 import projectCard from '../project-card';
+import { catarse } from '../../api'
+import models from '../../models';
+import prop from 'mithril/stream';
 
 export const ExploreProjectsList = {
-    view({attrs}) {
+    oninit: function(vnode) {
+        const projectsDetails = prop([{}]);
+        const loading = prop(true);
+        const filterWithProjectsDetails = ['active_saved_projects', 'coming_soon_landing_page'];
 
+        const reloadProjectsDetails = () => {
+            if (filterWithProjectsDetails.includes(vnode.attrs.filterKeyName)) {
+                let projects_ids = [], group_projects_ids = [], dataProjectsDetails = []
+                const projects = vnode.attrs.projects.collection().filter(function (project) {
+                    return !!project.integrations && project.integrations.includes("COMING_SOON_LANDING_PAGE")
+                })
+                projects.map(function (project) { projects_ids.push(`${project.project_id}`) })
+                for (var i = 0; i < projects_ids.length; i = i + 9) {
+                    group_projects_ids.push(projects_ids.slice(i, i + 9));
+                }
+
+                for (var i = 0; i < group_projects_ids.length; i++) {
+                    const filtersVM = catarse.filtersVM({ project_id: 'in' }).project_id(group_projects_ids[i])
+
+                    const lProjectsDetails = catarse.loaderWithToken(
+                        models.projectDetail.getPageOptions(filtersVM.parameters())
+                    );
+
+                    lProjectsDetails.load().then((data) => {
+                        data.map(function(detail) { dataProjectsDetails.push(detail) });
+                    });
+                }
+                projectsDetails(dataProjectsDetails)
+                loading(false);
+                h.redraw();
+            } else {
+                loading(false);
+            }
+        };
+
+        reloadProjectsDetails();
+
+        vnode.state = {
+            loading,
+            projectsDetails,
+            reloadProjectsDetails
+        };
+
+    },
+    view: function({state, attrs}) {
         const projects = attrs.projects;
         const isSearch = attrs.isSearch;
         const filterKeyName = attrs.filterKeyName;
         const isContributedByFriendsFilter = (filterKeyName === 'contributed_by_friends');
+        const isActiveSavedProjectsFilter = (filterKeyName === 'active_saved_projects');
+        const isComingSoonLandingPageFilter = (filterKeyName === 'coming_soon_landing_page');
+        const projectsDetails = state.projectsDetails();
+        const loading = state.loading();
+        const projectsLenght = projects.collection().filter(function (project) {
+            return !!project.integrations && project.integrations.includes("COMING_SOON_LANDING_PAGE")
+        }).length
 
-        return m('.w-section.section', [
+        if (!loading && projectsDetails.length > 0 && projectsLenght > 0
+          && projectsLenght != projectsDetails.length) {
+            state.reloadProjectsDetails();
+        }
+
+        if (!loading && (isActiveSavedProjectsFilter || isComingSoonLandingPageFilter)
+            && projectsDetails.length == 0 && projectsLenght > 0) {
+            h.redraw();
+        }
+
+        return !loading && m('.w-section.section', [
             m('.w-container', [
+                (!isActiveSavedProjectsFilter || projectsLenght == projectsDetails.length) ?
                 m('.w-row', [
                     m('.w-row', _.map(projects.collection(), project => {
                         let cardType = 'small';
                         let ref = 'ctrse_explore';
+                        let projectDetails;
+                        projectDetails = projectsDetails.find(
+                            project_details => project_details.project_id === project.project_id
+                        );
+                        if (projectDetails == undefined) projectDetails = {}
 
                         if (isSearch) {
                             ref = 'ctrse_explore_pgsearch';
@@ -26,7 +95,7 @@ export const ExploreProjectsList = {
                             if (project.score >= 1) {
                                 ref = 'ctrse_explore_featured';
                             }
-                        } else if (filterKeyName === 'saved_projects') {
+                        } else if (filterKeyName === 'active_saved_projects') {
                             ref = 'ctrse_explore_saved_project';
                         } else if (filterKeyName === 'projects_we_love') {
                             ref = 'ctrse_explore_projects_we_love';
@@ -34,14 +103,15 @@ export const ExploreProjectsList = {
 
                         return m(projectCard, {
                             project,
+                            projectDetails,
                             ref,
                             type: cardType,
                             showFriends: isContributedByFriendsFilter,
                         });
                     })),
                     projects.isLoading() ? h.loader() : ''
-                ])
+                ]) : h.loader()
             ])
-        ]);
+        ])
     }
 };

--- a/services/catarse/catarse.js/legacy/src/c/projects-display.js
+++ b/services/catarse/catarse.js/legacy/src/c/projects-display.js
@@ -24,7 +24,7 @@ const projectsDisplay = {
             sample3 = _.partial(_.sample, _, 3),
             loader = catarse.loaderWithToken,
             project = models.project,
-            subHomeWith6CollectionsFilters = ['projects_we_love_not_sub', 'sub', 'covid_19', 'contributed_by_friends'],
+            subHomeWith6CollectionsFilters = ['projects_we_love_not_sub', 'sub', 'covid_19', 'contributed_by_friends', 'coming_soon_landing_page'],
             windowEventNOTDispatched = true;
 
         project.pageSize(20);
@@ -52,7 +52,7 @@ const projectsDisplay = {
                 .then(() => m.redraw());
 
             const query = f.query || {};
-            
+
             if (!f.query) {
                 if (f.mode) {
                     query.mode = f.mode;

--- a/services/catarse/catarse.js/legacy/src/entities/project.d.ts
+++ b/services/catarse/catarse.js/legacy/src/entities/project.d.ts
@@ -33,7 +33,7 @@ export type Project = {
     common_id: string;
     is_adult_content: boolean;
     content_rating:	number;
-    saved_projects: boolean;
     integrations: ProjectIntegration[];
     category_name: string;
+    active_saved_projects: boolean;
 };

--- a/services/catarse/catarse.js/legacy/src/experiments/c/explore-light-box.js
+++ b/services/catarse/catarse.js/legacy/src/experiments/c/explore-light-box.js
@@ -46,10 +46,16 @@ export class ExploreLightBox {
                     mode: 'covid_19',
                 }
             },
+            {
+                name: 'Em breve no Catarse',
+                query: {
+                    filter: 'coming_soon_landing_page',
+                }
+            },
             userVM.isLoggedIn ? {
                 name: 'Projetos Salvos',
                 query: {
-                    filter: 'saved_projects',
+                    filter: 'active_saved_projects',
                 }
             } : null,
             userVM.isLoggedIn ? {
@@ -80,7 +86,7 @@ export class ExploreLightBox {
         };
 
         /**
-         * @param {{name: string, keyName: string}} filter 
+         * @param {{name: string, keyName: string}} filter
          * @returns {ListItem}
          */
         const mapFiltersToItems = (filter) => {
@@ -103,7 +109,7 @@ export class ExploreLightBox {
             };
         };
 
-        return m('div.explore-lightbox', 
+        return m('div.explore-lightbox',
             m('div.explore-lightbox-container.w-clearfix', [
                 m('a.modal-close-container.fa.fa-2x.fa-close.w-inline-block[href="#"]', { onclick: closePreventRedirect }),
 
@@ -137,7 +143,7 @@ class ExploreLightBoxList {
      */
 
     /**
-     * @param {{ attrs: Attrs }} vnode 
+     * @param {{ attrs: Attrs }} vnode
      */
     view({attrs}) {
 
@@ -147,7 +153,7 @@ class ExploreLightBoxList {
         const onSelect = attrs.onSelect;
 
         return m('div.u-marginbottom-30', [
-            m('div.u-margintop-30', 
+            m('div.u-margintop-30',
                 m('div.fontsize-base.fontcolor-terciary', title)
             ),
             items.map(item => {
@@ -165,16 +171,16 @@ class ExploreLightBoxList {
 }
 
 class ExploreLightBoxListItem {
-    
+
     /**
      * @typedef Attrs
-     * @property {() => void} onSelect 
+     * @property {() => void} onSelect
      * @property {string} url
      * @property {string} label
      */
 
     /**
-     * @param {{ attrs: Attrs }} vnode 
+     * @param {{ attrs: Attrs }} vnode
      */
     view({attrs}) {
         const label = attrs.label;

--- a/services/catarse/catarse.js/legacy/src/root/projects-explore.ts
+++ b/services/catarse/catarse.js/legacy/src/root/projects-explore.ts
@@ -249,6 +249,7 @@ const projectsExplore : m.Component<ProjectExploreAttrs, ProjectExploreState> = 
                 showConnectToFacebookButton &&
                 m(UnsignedFriendFacebookConnect)
             ],
+            projectsExploreVM.projectsView.collection()[0] &&
             m(ExploreProjectsList, {
                 projects: projectsExploreVM.projectsView,
                 isSearch: projectsExploreVM.isTextSearch,

--- a/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.scss
+++ b/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.scss
@@ -1,0 +1,18 @@
+.save-project-card-wrapper {
+	-webkit-box-align: stretch;
+	-webkit-box-direction: normal;
+	-webkit-box-orient: vertical;
+	-webkit-box-pack: center;
+	align-items: stretch;
+	box-sizing: border-box;
+	color: #3f4752;
+	display: flex;
+	flex-direction: column;
+	font-family: proxima-nova, sans-serif;
+	font-size: 14px;
+	height: 82px;
+	justify-content: center;
+	line-height: 20px;
+	padding-left: 13px;
+	padding-right: 13px;
+}

--- a/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useCallback, useRef, useState, withHooks } from 'mithril-hooks'
+import { ProjectDetails } from '../../entities'
+import { Loader } from '../../shared/components/loader'
+import PopNotification from '../../c/pop-notification'
+import h from '../../h'
+import { getCurrentUserCached } from '../../shared/services/user/get-current-user-cached'
+import { isLoggedIn } from '../../shared/services/user/is-logged-in'
+import m from 'mithril'
+import { removeRemind } from './controllers/removeRemind'
+import { remind } from './controllers/remind'
+import './coming-soon-landing-page-bookmark-card.scss'
+import './coming-soon-landing-page-explore-remind-button.scss'
+
+export type ComingSoonLandingPageExploreRemindButtonProps = {
+    project: ProjectDetails
+    isFollowing: boolean
+}
+
+export const ComingSoonLandingPageExploreRemindButton = withHooks<ComingSoonLandingPageExploreRemindButtonProps>(_ComingSoonLandingPageExploreRemindButton)
+
+function _ComingSoonLandingPageExploreRemindButton(props: ComingSoonLandingPageExploreRemindButtonProps) {
+
+    const { project, isFollowing } = props
+    const popupTimeout = useRef<NodeJS.Timeout>()
+    const [isLoading, setIsLoading] = useState(false)
+    const [currentUserBookmarked, setCurrentUserBookmarked] = useState(isFollowing)
+
+    // Pop notification properties
+    const timeDisplayingPopup = 5000
+    const [displayPopNotification, setDisplayPopNotification] = useState(false)
+    const [popNotificationMessage, setPopNotificationMessage] = useState('')
+    const [isPopNotificationError, setIsPopNotificationError] = useState(false)
+
+    useEffect(() => {
+        setCurrentUserBookmarked(project.in_reminder)
+    }, [project.in_reminder])
+
+    function redirectToLogin() {
+        if (!isLoggedIn(getCurrentUserCached())) {
+            h.storeAction('reminder', project.project_id)
+            h.navigateToDevise(`?redirect_to=/explore?filter=coming_soon_landing_page`)
+            return true
+        }
+
+        return false
+    }
+
+    const handleRemindMe = useCallback(() => {
+        if (redirectToLogin()) return
+        toggleRemindMeProject(true);
+    }, [])
+
+    const handleRemoveRemindMe = useCallback(() => {
+        toggleRemindMeProject(false)
+    }, [])
+
+    async function toggleRemindMeProject(isRemind: boolean) {
+        try {
+            setIsLoading(true)
+            await isRemind ? remind(project) : removeRemind(project)
+            setCurrentUserBookmarked(isRemind)
+            await displayPopNotificationMessage({ message: successMessage(project) })
+        } catch (error) {
+            await displayPopNotificationMessage({ message: errorMessage(project), isError: true })
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    const successMessage = (project) => {
+        return project.in_reminder ?
+            'Ok, Removemos o lembrete por e-mail de quando a campanha for ao ar!' :
+            'Você irá receber um email quando este projeto for publicado!'
+
+    };
+    const errorMessage = (project) => {
+        return project.in_reminder ?
+            'Error ao remover lembrete.' :
+            'Error ao salvar lembrete.'
+    };
+
+    async function displayPopNotificationMessage({message, isError = false} : {message: string, isError?: boolean}) {
+        setPopNotificationMessage(message)
+        setIsPopNotificationError(isError)
+        setDisplayPopNotification(!displayPopNotification)
+        if (popupTimeout.current) clearTimeout(popupTimeout.current)
+        setTimeout(() => setDisplayPopNotification(true))
+        popupTimeout.current = setTimeout(() => setDisplayPopNotification(false), timeDisplayingPopup)
+    }
+
+    return (
+        <div class='save-project-card-wrapper'>
+            {
+                displayPopNotification &&
+                <PopNotification
+                    message={popNotificationMessage}
+                    error={isPopNotificationError} />
+            }
+            <div class="back-project--btn-row">
+                {
+                    isLoading ?
+                        <Loader />
+                        :
+                        currentUserBookmarked ?
+                            <button onclick={handleRemoveRemindMe} class='btn btn-medium btn-terciary w-button'>
+                                <span class="fa fa-bookmark text-success"></span>&nbsp;
+                                Projeto Salvo
+                            </button>
+                            :
+                            <button onclick={handleRemindMe} class='btn btn-medium btn-dark w-button'>
+                                <span class="fa fa-bookmark-o"></span>&nbsp;
+                                Avise-me do lançamento!
+                            </button>
+                }
+            </div>
+        </div>
+    )
+}

--- a/services/catarse/catarse.js/legacy/src/vms/project-filters-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/project-filters-vm.js
@@ -44,10 +44,9 @@ const projectFiltersVM = () => {
             open_for_contributions: 'eq'
         }).open_for_contributions('true'),
 
-        saved_projects = filtersVM({
-            open_for_contributions: 'eq',
-            saved_projects: 'eq'
-        }).open_for_contributions('true').saved_projects(true),
+        active_saved_projects = filtersVM({
+          active_saved_projects: 'eq'
+        }).active_saved_projects(true),
 
         contributed_by_friends = filtersVM({
             open_for_contributions: 'eq',
@@ -57,6 +56,11 @@ const projectFiltersVM = () => {
         successful = filtersVM({
             state: 'eq'
         }).state('successful'),
+
+        coming_soon_landing_page = filtersVM({
+            state: 'eq',
+            integrations: 'like',
+        }).state('draft').integrations('COMING_SOON_LANDING_PAGE'),
 
         finished = filtersVM({}),
 
@@ -68,7 +72,7 @@ const projectFiltersVM = () => {
             recommended: 'eq',
             mode: 'not.eq'
         }).recommended(true).mode('sub'),
-        
+
         filters = {
             projects_we_love_not_sub: {
                 title: 'Projetos que amamos',
@@ -106,12 +110,12 @@ const projectFiltersVM = () => {
                     filter: 'all'
                 }
             },
-            saved_projects: {
+            active_saved_projects: {
                 title: 'Projetos Salvos',
-                filter: saved_projects,
+                filter: active_saved_projects,
                 nicename: 'Projetos Salvos',
                 isContextual: false,
-                keyName: 'saved_projects'
+                keyName: 'active_saved_projects'
             },
             contributed_by_friends: {
                 title: 'Amigos',
@@ -160,6 +164,13 @@ const projectFiltersVM = () => {
                 nicename: 'Financiados',
                 isContextual: false,
                 keyName: 'successful'
+            },
+            coming_soon_landing_page: {
+                title: 'Em breve no Catarse',
+                filter: coming_soon_landing_page,
+                nicename: 'Em breve no Catarse',
+                isContextual: false,
+                keyName: 'coming_soon_landing_page'
             },
             not_sub: {
                 title: 'Projetos pontuais',

--- a/services/catarse/db/migrate/20211101175657_change_saved_projects_view.rb
+++ b/services/catarse/db/migrate/20211101175657_change_saved_projects_view.rb
@@ -1,0 +1,124 @@
+class ChangeSavedProjectsView < ActiveRecord::Migration[6.1]
+  def change
+    execute <<-SQL
+      DROP VIEW "1".projects CASCADE;
+
+      CREATE OR REPLACE VIEW "1".projects
+        AS SELECT p.id AS project_id,
+        p.category_id,
+        p.name AS project_name,
+        p.headline,
+        p.permalink,
+        p.mode,
+        p.state::text AS state,
+        so.so AS state_order,
+        od.od AS online_date,
+        p.recommended,
+        thumbnail_image(p.*, 'large'::text) AS project_img,
+        remaining_time_json(p.*) AS remaining_time,
+        p.expires_at,
+        COALESCE((pms.data ->> 'pledged'::text)::numeric, 0::numeric) AS pledged,
+        COALESCE((pms.data ->> 'progress'::text)::numeric, 0::numeric) AS progress,
+        s.acronym AS state_acronym,
+        u.name AS owner_name,
+        c.name AS city_name,
+        p.full_text_index,
+        is_current_and_online(p.expires_at, p.state::text) AS open_for_contributions,
+        elapsed_time_json(p.*) AS elapsed_time,
+        COALESCE(pss.score::numeric, 0::numeric) AS score,
+        (EXISTS ( SELECT true AS bool
+              FROM contributions c_1
+                JOIN user_follows uf ON uf.follow_id = c_1.user_id
+              WHERE is_confirmed(c_1.*) AND uf.user_id = current_user_id() AND c_1.project_id = p.id)) AS contributed_by_friends,
+        p.user_id AS project_user_id,
+        p.video_embed_url,
+        p.updated_at,
+        u.public_name AS owner_public_name,
+        zone_timestamp(p.expires_at) AS zone_expires_at,
+        p.common_id,
+        p.content_rating >= 18 AS is_adult_content,
+        p.content_rating,
+        ( SELECT array_to_string(array_agg(COALESCE(integration.data ->> 'name'::text, integration.name::text)), ','::text) AS integration_name
+              FROM project_integrations integration
+              WHERE integration.project_id = p.id) AS integrations,
+        COALESCE(category.name_pt, category.name_en::text) AS category_name,
+        (EXISTS (SELECT true AS bool FROM project_reminders pr
+          WHERE ((is_current_and_online(p.expires_at, (p.state)::text) OR
+          ((SELECT true AS bool FROM project_integrations integration WHERE (integration.project_id = p.id
+              and integration.name = 'COMING_SOON_LANDING_PAGE') and p.state = 'draft' group by p.id)))
+          and ((p.id = pr.project_id) AND (pr.user_id = current_user_id()))))) AS active_saved_projects,
+        (SELECT count(*) AS count FROM project_reminders pr WHERE p.id = pr.project_id) AS count_project_reminders
+      FROM projects p
+        JOIN users u ON p.user_id = u.id
+        LEFT JOIN project_score_storages pss ON pss.project_id = p.id
+        LEFT JOIN project_metric_storages pms ON pms.project_id = p.id
+        LEFT JOIN cities c ON c.id = p.city_id
+        LEFT JOIN states s ON s.id = c.state_id
+        JOIN LATERAL zone_timestamp(online_at(p.*)) od(od) ON true
+        JOIN LATERAL state_order(p.*) so(so) ON true
+        LEFT JOIN categories category ON category.id = p.category_id
+      WHERE p.state::text <> 'deleted'::text;
+
+      grant select on "1"."projects" to admin, anonymous, web_user;
+
+      CREATE OR REPLACE FUNCTION public.near_me("1".projects)
+      RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+          COALESCE($1.state_acronym, (SELECT u.address_state FROM users u WHERE u.id = $1.project_user_id)) = (SELECT u.address_state FROM users u WHERE u.id = current_user_id());
+      $function$;
+
+      CREATE OR REPLACE FUNCTION public.is_expired(project projects)
+      RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        select
+        case when $1.mode = 'sub' then
+          false
+        else
+          public.is_past($1.expires_at)
+        end;
+      $function$;
+
+      CREATE OR REPLACE FUNCTION public.is_expired(project "1".projects)
+      RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        select
+        case when $1.mode = 'sub' then
+            false
+        else
+          public.is_past($1.expires_at)
+        end;
+      $function$;
+
+      CREATE OR REPLACE FUNCTION "1".project_search(query text)
+      RETURNS SETOF "1".projects
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+          p.*
+        FROM
+            "1".projects p
+        WHERE
+            (
+                p.full_text_index @@ plainto_tsquery('portuguese', unaccent(query))
+                OR
+                p.project_name % query
+            )
+            AND p.state_order >= 'published'
+        ORDER BY
+            p.open_for_contributions DESC,
+            p.score DESC NULLS LAST,
+            p.state DESC,
+            ts_rank(p.full_text_index, plainto_tsquery('portuguese', unaccent(query))) DESC,
+            p.project_id DESC;
+      $function$;
+    SQL
+  end
+end


### PR DESCRIPTION
### Descrição
Adiciona no explore projetos em pré-lançamento tanto em um filtro personalizado: "Em breve no Catarse" e também listado nos "Projetos Salvos". 

Ajuste de pontos no QA da atividade.

### Referência
https://www.notion.so/catarse/Implementar-card-de-projeto-em-Pr-Lan-amento-no-Catarse-cc3d9c4fc67d46deb38474bfe9e9cf78

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
