### PR TITLE
🐞 Exibe recompensa esgotada na edição de assinaturas com essa recompensa.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/reward-select-card.js
@@ -81,6 +81,7 @@ const rewardSelectCard = {
 
         vnode.state = {
             normalReward,
+            isEdit,
             isSelected,
             setInput,
             submitContribution,
@@ -97,7 +98,7 @@ const rewardSelectCard = {
     view: function({state, attrs}) {
         const reward = state.normalReward(attrs.reward);
 
-        if (!h.rewardSouldOut(reward)) {
+        if ((state.isEdit() && h.rewardSouldOut(reward) && state.isSelected(reward)) || !h.rewardSouldOut(reward)) {
             return(
                 m('span.radio.w-radio.w-clearfix.back-reward-radio-reward', {
                     class: state.isSelected(reward) ? 'selected' : '',


### PR DESCRIPTION
### Descrição
Ajustar quando o usuário tenta atualizar uma assinatura em que a recompensa selecionada ja foi esgotada a recompensa não é exibida na listagem na hora da edição

### Referência
[Link para a atividade
](https://www.notion.so/catarse/Verificar-se-a-assinatura-tem-a-recompensa-esgotada-selecionada-antes-de-esconder-a-recompensa-72a9b0dfef0449b29ba362fb76f5dc03)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
