### PR TITLE
Faz com que a header da table seja sticky no scroll

### DIFF
--- a/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
+++ b/services/catarse/app/assets/stylesheets/catarse_bootstrap/_main.scss
@@ -3219,7 +3219,10 @@ a:hover {
 }
 
 .table-row.header {
-  background-color: rgba(241, 244, 244, 0.49);
+  background-color: #f8fafa;
+  position: sticky;
+  top: 0;
+  z-index: 99;
 }
 
 .toggle {


### PR DESCRIPTION
## Descrição
Coloca o header da table como sticky no scroll.

## Referência
https://www.notion.so/catarse/Table-row-header-sicky-on-scroll-4dcbe469321748a5b903415d83ee1d5a

