### PR TITLE
✨ Adiciona projetos em pré-lançamento nos cards de explore.

### DIFF
--- a/services/catarse/app/controllers/users_controller.rb
+++ b/services/catarse/app/controllers/users_controller.rb
@@ -215,6 +215,8 @@ class UsersController < ApplicationController
         if params[:user][:reminders][:"#{project_id}"] == 'false'
           Project.find(project_id).delete_from_reminder_queue(@user.id)
           @user.reminders.where(project_id: project_id).destroy_all
+        else
+          ProjectMetricStorageRefreshWorker.perform_async(project_id)
         end
       end
     end

--- a/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
+++ b/services/catarse/app/workers/project_metric_storage_refresh_worker.rb
@@ -6,8 +6,22 @@ class ProjectMetricStorageRefreshWorker < ProjectBaseWorker
 
   def perform(id)
     _resource = resource(id)
-    can_refresh = !%w[draft deleted].include?(_resource.state)
 
-    _resource.refresh_project_metric_storage if can_refresh
+    _resource.refresh_project_metric_storage if can_refresh?(_resource)
+  end
+
+  private
+
+  def not_comming_soon_landing_page?(project)
+    project.state != 'draft' ||
+      (project.state == 'draft' && project.has_comming_soon_landing_page_integration?)
+  end
+
+  def not_in_deleted?(project)
+    project.state != 'deleted'
+  end
+
+  def can_refresh?(project)
+    not_in_deleted?(project) && not_comming_soon_landing_page?(project)
   end
 end

--- a/services/catarse/catarse.js/legacy/spec/lib/mocks/project.mock.js
+++ b/services/catarse/catarse.js/legacy/spec/lib/mocks/project.mock.js
@@ -61,22 +61,22 @@ beforeAll(function(){
       "open_for_contributions":false,
       "online_days":60,
       "remaining_time":{
-        "total" : 0, 
+        "total" : 0,
         "unit" : "seconds"
       },
       "elapsed_time":{
-        "total" : 0, 
+        "total" : 0,
         "unit" : "seconds"
       },
       "posts_count":0,
       "address":{
-        "city" : "fda", 
-        "state_acronym" : "RS", 
+        "city" : "fda",
+        "state_acronym" : "RS",
         "state" : "Rio Grande do Sul"
       },
       "user":{
-        "id" : 3, 
-        "name" : "test test", 
+        "id" : 3,
+        "name" : "test test",
         "public_name" : "Test1"
       },
       "reminder_count":0,
@@ -133,7 +133,7 @@ beforeAll(function(){
 
 
   ProjectsGenerator = function(numberOfProjects, overrides, url) {
-    
+
     const projectBase = {
       project_id: 5,
       category_id: 1,
@@ -172,7 +172,7 @@ beforeAll(function(){
       common_id: "a60eec2e-dbe0-4efb-876c-e8c5ec0c8adc",
       is_adult_content: false,
       content_rating: 1,
-      saved_projects: true
+      active_saved_projects: true
     };
 
     const projects = [];
@@ -190,6 +190,3 @@ beforeAll(function(){
   });
 
 });
-
-
-

--- a/services/catarse/catarse.js/legacy/src/c/explore/explore-projects-list.js
+++ b/services/catarse/catarse.js/legacy/src/c/explore/explore-projects-list.js
@@ -26,7 +26,7 @@ export const ExploreProjectsList = {
                             if (project.score >= 1) {
                                 ref = 'ctrse_explore_featured';
                             }
-                        } else if (filterKeyName === 'saved_projects') {
+                        } else if (filterKeyName === 'active_saved_projects') {
                             ref = 'ctrse_explore_saved_project';
                         } else if (filterKeyName === 'projects_we_love') {
                             ref = 'ctrse_explore_projects_we_love';

--- a/services/catarse/catarse.js/legacy/src/c/project-card.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-card.js
@@ -4,6 +4,7 @@ import h from '../h';
 import projectVM from '../vms/project-vm';
 import projectFriends from './project-friends';
 import progressMeter from './progress-meter';
+import { ComingSoonLandingPageExploreRemindButton } from '../root/projects/coming-soon-landing-page-explore-remind-button';
 
 const I18nScope = _.partial(h.i18nScope, 'projects.card');
 const projectCard = {
@@ -88,12 +89,12 @@ const projectCard = {
     view: function({state, attrs}) {
         const project = attrs.project;
         const projectOwnerName = project.user ? (project.user.public_name || project.user.name) : (project.owner_public_name || project.owner_name);
-        
+
         const projectLocalizationObject = {
             filter: 'all',
             city_name: project.address ? project.address.city : project.city_name,
             state_acronym: project.address ? project.address.state_acronym : project.state_acronym,
-        };        
+        };
         const projectLocalizationSearchUrl = `/explore?${m.buildQueryString(projectLocalizationObject)}`
         const projectLocalizationName = project.address ? `${project.address.city}, ${project.address.state_acronym}` : `${project.city_name}, ${project.state_acronym}`;
 
@@ -115,7 +116,7 @@ const projectCard = {
                 }),
                 (
                     project.recommended &&
-                    m('div.loved-projects-container', 
+                    m('div.loved-projects-container',
                         m(`a.loved-projects-badge[href="/${window.I18n.locale}/explore?filter=projects_we_love"]`, 'Projeto que amamos')
                     )
                 ),
@@ -135,21 +136,31 @@ const projectCard = {
                             }, project.headline)
                         ])
                     ]),
-                    m(progressMeter, { progress: state.progress, project }),
-                    m('.card-project-stats', [
-                        m('.w-row', [
-                            m('.w-col.w-col-4.w-col-small-4.w-col-tiny-4', [
-                                m('.fontsize-base.fontweight-semibold', `${Math.floor(project.progress)}%`)
+                        project.state === 'draft' ?
+                        [
+                            m(ComingSoonLandingPageExploreRemindButton, {
+                                project: project,
+                                isFollowing: project.in_reminder
+                            })
+                        ]  :
+                        [
+                            m(progressMeter, { progress: state.progress, project }),
+                            m('.card-project-stats', [
+                                m('.w-row', [
+                                    m('.w-col.w-col-4.w-col-small-4.w-col-tiny-4', [
+                                        m('.fontsize-base.fontweight-semibold', `${Math.floor(project.progress)}%`)
+                                    ]),
+                                    m('.w-col.w-col-4.w-col-small-4.w-col-tiny-4.u-text-center-small-only', [
+                                        m('.fontsize-smaller.fontweight-semibold', `R$ ${h.formatNumber(project.pledged)}`),
+                                        m('.fontsize-smallest.lineheight-tightest', window.I18n.t(`pledged.${project.mode}`, I18nScope()))
+                                    ]),
+                                    m('.w-col.w-col-4.w-col-small-4.w-col-tiny-4.u-text-right', state.cardCopy(project)),
+                                ])
                             ]),
-                            m('.w-col.w-col-4.w-col-small-4.w-col-tiny-4.u-text-center-small-only', [
-                                m('.fontsize-smaller.fontweight-semibold', `R$ ${h.formatNumber(project.pledged)}`),
-                                m('.fontsize-smallest.lineheight-tightest', window.I18n.t(`pledged.${project.mode}`, I18nScope()))
-                            ]),
-                            m('.w-col.w-col-4.w-col-small-4.w-col-tiny-4.u-text-right', state.cardCopy(project)),
-                        ])
-                    ]),
-                    m(state.css().city, 
+                        ],
+                        m(state.css().city,
                         m('div', [
+                            project.state != 'draft' ?
                             m('div',
                                 m(`a.link-hidden-dark.fontsize-smallest.fontcolor-secondary[href="${projectLocalizationSearchUrl}"]`, {
                                     onclick: (/** @type {Event} */ event) => {
@@ -160,7 +171,7 @@ const projectCard = {
                                     m('span.fa.fa-map-marker.fa-sm', ' '),
                                     ` ${projectLocalizationName}`
                                 ])
-                            ),
+                            ) :  m('br'),
                             m('div',
                                 m(`a.link-hidden-dark.fontsize-smallest.fontcolor-secondary[href="${projectCategorySearchUrl}"]`, {
                                     onclick: (/** @type {Event} */ event) => {

--- a/services/catarse/catarse.js/legacy/src/c/projects-display.js
+++ b/services/catarse/catarse.js/legacy/src/c/projects-display.js
@@ -24,7 +24,7 @@ const projectsDisplay = {
             sample3 = _.partial(_.sample, _, 3),
             loader = catarse.loaderWithToken,
             project = models.project,
-            subHomeWith6CollectionsFilters = ['projects_we_love_not_sub', 'sub', 'covid_19', 'contributed_by_friends'],
+            subHomeWith6CollectionsFilters = ['projects_we_love_not_sub', 'sub', 'covid_19', 'contributed_by_friends', 'coming_soon_landing_page'],
             windowEventNOTDispatched = true;
 
         project.pageSize(20);
@@ -52,7 +52,7 @@ const projectsDisplay = {
                 .then(() => m.redraw());
 
             const query = f.query || {};
-            
+
             if (!f.query) {
                 if (f.mode) {
                     query.mode = f.mode;

--- a/services/catarse/catarse.js/legacy/src/entities/notification-data.d.ts
+++ b/services/catarse/catarse.js/legacy/src/entities/notification-data.d.ts
@@ -73,6 +73,8 @@ interface Platform {
 }
 
 interface Project {
+    project_id:                         number;
+    in_reminder:                        boolean;
     id:                                 string;
     mode:                               string;
     name:                               string;

--- a/services/catarse/catarse.js/legacy/src/entities/project.d.ts
+++ b/services/catarse/catarse.js/legacy/src/entities/project.d.ts
@@ -33,7 +33,8 @@ export type Project = {
     common_id: string;
     is_adult_content: boolean;
     content_rating:	number;
-    saved_projects: boolean;
     integrations: ProjectIntegration[];
     category_name: string;
+    active_saved_projects: boolean;
+    in_reminder: boolean;
 };

--- a/services/catarse/catarse.js/legacy/src/experiments/c/explore-light-box.js
+++ b/services/catarse/catarse.js/legacy/src/experiments/c/explore-light-box.js
@@ -46,10 +46,16 @@ export class ExploreLightBox {
                     mode: 'covid_19',
                 }
             },
+            {
+                name: 'Em breve no Catarse',
+                query: {
+                    filter: 'coming_soon_landing_page',
+                }
+            },
             userVM.isLoggedIn ? {
                 name: 'Projetos Salvos',
                 query: {
-                    filter: 'saved_projects',
+                    filter: 'active_saved_projects',
                 }
             } : null,
             userVM.isLoggedIn ? {
@@ -80,7 +86,7 @@ export class ExploreLightBox {
         };
 
         /**
-         * @param {{name: string, keyName: string}} filter 
+         * @param {{name: string, keyName: string}} filter
          * @returns {ListItem}
          */
         const mapFiltersToItems = (filter) => {
@@ -103,7 +109,7 @@ export class ExploreLightBox {
             };
         };
 
-        return m('div.explore-lightbox', 
+        return m('div.explore-lightbox',
             m('div.explore-lightbox-container.w-clearfix', [
                 m('a.modal-close-container.fa.fa-2x.fa-close.w-inline-block[href="#"]', { onclick: closePreventRedirect }),
 
@@ -137,7 +143,7 @@ class ExploreLightBoxList {
      */
 
     /**
-     * @param {{ attrs: Attrs }} vnode 
+     * @param {{ attrs: Attrs }} vnode
      */
     view({attrs}) {
 
@@ -147,7 +153,7 @@ class ExploreLightBoxList {
         const onSelect = attrs.onSelect;
 
         return m('div.u-marginbottom-30', [
-            m('div.u-margintop-30', 
+            m('div.u-margintop-30',
                 m('div.fontsize-base.fontcolor-terciary', title)
             ),
             items.map(item => {
@@ -165,16 +171,16 @@ class ExploreLightBoxList {
 }
 
 class ExploreLightBoxListItem {
-    
+
     /**
      * @typedef Attrs
-     * @property {() => void} onSelect 
+     * @property {() => void} onSelect
      * @property {string} url
      * @property {string} label
      */
 
     /**
-     * @param {{ attrs: Attrs }} vnode 
+     * @param {{ attrs: Attrs }} vnode
      */
     view({attrs}) {
         const label = attrs.label;

--- a/services/catarse/catarse.js/legacy/src/root/projects-explore.ts
+++ b/services/catarse/catarse.js/legacy/src/root/projects-explore.ts
@@ -16,6 +16,10 @@ import { I18ScopeType, ThisWindow } from '../entities/window';
 import ExploreMobileSearch from '../c/explore/explore-mobile-search';
 import { getCurrentUserCached } from '../shared/services/user/get-current-user-cached';
 import { isLoggedIn } from '../shared/services/user/is-logged-in';
+import { removeRemindProject } from './projects/controllers/removeRemindProject'
+import { remindProject } from './projects/controllers/remindProject'
+import { catarse } from '../api'
+import models from '../models';
 
 declare var window : ThisWindow
 
@@ -108,6 +112,32 @@ const projectsExplore : m.Component<ProjectExploreAttrs, ProjectExploreState> = 
             defineDeepObject('state.state_name', state_name, cityState);
             return cityState as CityState;
         };
+
+        function findRemindProjectInLocalStorage() {
+            const reminder = parseInt(localStorage.getItem('reminder'));
+
+            if (isLoggedIn(getCurrentUserCached()) && reminder) {
+                const lProjectsDetails = catarse.loaderWithToken(models.projectDetail.getPageOptions(
+                    catarse.filtersVM({ project_id: 'eq' }).project_id(reminder).parameters())
+                );
+                lProjectsDetails.load().then((data) => { remindProjectInLocalStorage(_.first(data)) });
+            }
+
+            localStorage.removeItem('reminder');
+        }
+
+        function remindProjectInLocalStorage(projectsDetails) {
+            try {
+                remindProject(projectsDetails)
+                h.redraw()
+                h.storeAction('display_pop', 'success')
+            } catch (error) {
+                h.redraw()
+                h.storeAction('display_pop', 'error')
+            }
+        }
+
+        findRemindProjectInLocalStorage()
 
         vnode.state = {
             projectsExploreVM,

--- a/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.scss
+++ b/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.scss
@@ -1,0 +1,18 @@
+.save-project-card-wrapper {
+	-webkit-box-align: stretch;
+	-webkit-box-direction: normal;
+	-webkit-box-orient: vertical;
+	-webkit-box-pack: center;
+	align-items: stretch;
+	box-sizing: border-box;
+	color: #3f4752;
+	display: flex;
+	flex-direction: column;
+	font-family: proxima-nova, sans-serif;
+	font-size: 14px;
+	height: 82px;
+	justify-content: center;
+	line-height: 20px;
+	padding-left: 13px;
+	padding-right: 13px;
+}

--- a/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/projects/coming-soon-landing-page-explore-remind-button.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useCallback, useRef, useState, withHooks } from 'mithril-hooks'
+import { Project } from '../../entities'
+import { Loader } from '../../shared/components/loader'
+import PopNotification from '../../c/pop-notification'
+import h from '../../h'
+import { getCurrentUserCached } from '../../shared/services/user/get-current-user-cached'
+import { isLoggedIn } from '../../shared/services/user/is-logged-in'
+import m from 'mithril'
+import _ from 'underscore';
+import { removeRemindProject } from './controllers/removeRemindProject'
+import { remindProject } from './controllers/remindProject'
+import './coming-soon-landing-page-bookmark-card.scss'
+import './coming-soon-landing-page-explore-remind-button.scss'
+import { catarse } from '../../api'
+import models from '../../models';
+
+export type ComingSoonLandingPageExploreRemindButtonProps = {
+    project: Project
+    isFollowing: boolean
+}
+
+export const ComingSoonLandingPageExploreRemindButton = withHooks<ComingSoonLandingPageExploreRemindButtonProps>(_ComingSoonLandingPageExploreRemindButton)
+
+function _ComingSoonLandingPageExploreRemindButton(props: ComingSoonLandingPageExploreRemindButtonProps) {
+
+    const { project, isFollowing } = props
+    const popupTimeout = useRef<NodeJS.Timeout>()
+    const [isLoading, setIsLoading] = useState(false)
+    const [currentUserBookmarked, setCurrentUserBookmarked] = useState(isFollowing)
+
+    // Pop notification properties
+    const timeDisplayingPopup = 5000
+    const [displayPopNotification, setDisplayPopNotification] = useState(false)
+    const [popNotificationMessage, setPopNotificationMessage] = useState('')
+    const [isPopNotificationError, setIsPopNotificationError] = useState(false)
+
+    useEffect(() => {
+        setCurrentUserBookmarked(project.in_reminder)
+    }, [project.in_reminder])
+
+    useEffect(() => {
+        displayPop()
+    }, [])
+
+    function displayPop() {
+        const displayPop = localStorage.getItem('display_pop');
+
+        if (displayPop) {
+            if (displayPop == 'success') {
+                displayPopNotificationMessage({ message: 'Você irá receber um email quando este projeto for publicado!' })
+            } else if (displayPop == 'error') {
+                displayPopNotificationMessage({ message: 'Error ao salvar lembrete.', isError: true })
+            }
+
+            localStorage.removeItem('display_pop');
+        }
+        h.redraw();
+    }
+
+    function redirectToLogin() {
+        if (!isLoggedIn(getCurrentUserCached())) {
+            h.storeAction('reminder', project.project_id)
+            h.navigateToDevise(`?redirect_to=/explore?filter=coming_soon_landing_page`)
+            return true
+        }
+
+        return false
+    }
+
+    const handleRemindMe = useCallback(() => {
+        if (redirectToLogin()) return
+        toggleRemindMeProject(true);
+    }, [])
+
+    const handleRemoveRemindMe = useCallback(() => {
+        toggleRemindMeProject(false)
+    }, [])
+
+    async function toggleRemindMeProject(isRemind: boolean) {
+        try {
+            setIsLoading(true)
+            await isRemind ? remindProject(project) : removeRemindProject(project)
+            setCurrentUserBookmarked(isRemind)
+            await displayPopNotificationMessage({ message: successMessage(project) })
+        } catch (error) {
+            await displayPopNotificationMessage({ message: errorMessage(project), isError: true })
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    const successMessage = (project) => {
+        return project.in_reminder ?
+            'Ok, Removemos o lembrete por e-mail de quando a campanha for ao ar!' :
+            'Você irá receber um email quando este projeto for publicado!'
+
+    };
+    const errorMessage = (project) => {
+        return project.in_reminder ?
+            'Error ao remover lembrete.' :
+            'Error ao salvar lembrete.'
+    };
+
+    async function displayPopNotificationMessage({message, isError = false} : {message: string, isError?: boolean}) {
+        setPopNotificationMessage(message)
+        setIsPopNotificationError(isError)
+        setDisplayPopNotification(!displayPopNotification)
+        if (popupTimeout.current) clearTimeout(popupTimeout.current)
+        setTimeout(() => setDisplayPopNotification(true))
+        popupTimeout.current = setTimeout(() => setDisplayPopNotification(false), timeDisplayingPopup)
+    }
+
+    return (
+        <div class='save-project-card-wrapper'>
+            {
+                displayPopNotification &&
+                <PopNotification
+                    message={popNotificationMessage}
+                    error={isPopNotificationError} />
+            }
+            <div class="back-project--btn-row">
+                {
+                    isLoading ?
+                        <Loader />
+                        :
+                        currentUserBookmarked ?
+                            <button onclick={handleRemoveRemindMe} class='btn btn-medium btn-terciary w-button'>
+                                <span class="fa fa-bookmark text-success"></span>&nbsp;
+                                Projeto Salvo
+                            </button>
+                            :
+                            <button onclick={handleRemindMe} class='btn btn-medium btn-dark w-button'>
+                                <span class="fa fa-bookmark-o"></span>&nbsp;
+                                Avise-me do lançamento!
+                            </button>
+                }
+            </div>
+        </div>
+    )
+}

--- a/services/catarse/catarse.js/legacy/src/root/projects/controllers/remindProject.ts
+++ b/services/catarse/catarse.js/legacy/src/root/projects/controllers/remindProject.ts
@@ -1,0 +1,11 @@
+import { catarse } from '../../../api';
+import { Project } from '../../../entities'
+import models from '../../../models';
+import projectVM from '../../../vms/project-vm';
+
+export async function remindProject(project: Project) {
+    const loaderOpts = models.projectReminder.postOptions({ project_id: project.project_id })
+    await catarse.loaderWithToken(loaderOpts).load()
+    projectVM.getCurrentProject()
+}
+

--- a/services/catarse/catarse.js/legacy/src/root/projects/controllers/removeRemindProject.ts
+++ b/services/catarse/catarse.js/legacy/src/root/projects/controllers/removeRemindProject.ts
@@ -1,0 +1,10 @@
+import { catarse } from '../../../api'
+import { Project } from '../../../entities'
+import models from '../../../models'
+import projectVM from '../../../vms/project-vm'
+
+export async function removeRemindProject(project: Project) {
+    const loaderOpts = models.projectReminder.deleteOptions({ project_id: `eq.${project.project_id}` })
+    await catarse.loaderWithToken(loaderOpts).load()
+    projectVM.getCurrentProject()
+}

--- a/services/catarse/catarse.js/legacy/src/vms/project-filters-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/project-filters-vm.js
@@ -44,10 +44,9 @@ const projectFiltersVM = () => {
             open_for_contributions: 'eq'
         }).open_for_contributions('true'),
 
-        saved_projects = filtersVM({
-            open_for_contributions: 'eq',
-            saved_projects: 'eq'
-        }).open_for_contributions('true').saved_projects(true),
+        active_saved_projects = filtersVM({
+          active_saved_projects: 'eq'
+        }).active_saved_projects(true),
 
         contributed_by_friends = filtersVM({
             open_for_contributions: 'eq',
@@ -57,6 +56,11 @@ const projectFiltersVM = () => {
         successful = filtersVM({
             state: 'eq'
         }).state('successful'),
+
+        coming_soon_landing_page = filtersVM({
+            state: 'eq',
+            integrations: 'like',
+        }).state('draft').integrations('COMING_SOON_LANDING_PAGE'),
 
         finished = filtersVM({}),
 
@@ -68,7 +72,7 @@ const projectFiltersVM = () => {
             recommended: 'eq',
             mode: 'not.eq'
         }).recommended(true).mode('sub'),
-        
+
         filters = {
             projects_we_love_not_sub: {
                 title: 'Projetos que amamos',
@@ -106,12 +110,12 @@ const projectFiltersVM = () => {
                     filter: 'all'
                 }
             },
-            saved_projects: {
+            active_saved_projects: {
                 title: 'Projetos Salvos',
-                filter: saved_projects,
+                filter: active_saved_projects,
                 nicename: 'Projetos Salvos',
                 isContextual: false,
-                keyName: 'saved_projects'
+                keyName: 'active_saved_projects'
             },
             contributed_by_friends: {
                 title: 'Amigos',
@@ -160,6 +164,13 @@ const projectFiltersVM = () => {
                 nicename: 'Financiados',
                 isContextual: false,
                 keyName: 'successful'
+            },
+            coming_soon_landing_page: {
+                title: 'Em breve no Catarse',
+                filter: coming_soon_landing_page,
+                nicename: 'Em breve no Catarse',
+                isContextual: false,
+                keyName: 'coming_soon_landing_page'
             },
             not_sub: {
                 title: 'Projetos pontuais',

--- a/services/catarse/db/migrate/20211101186779_add_count_reminder_in_projects_metric_storage.rb
+++ b/services/catarse/db/migrate/20211101186779_add_count_reminder_in_projects_metric_storage.rb
@@ -1,0 +1,185 @@
+class AddCountReminderInProjectsMetricStorage < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.refresh_project_metric_storage(projects)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+declare
+    v_data jsonb;
+    begin
+        if $1.mode = 'sub' then
+            -- build jsonb object for subscription project
+            select
+                json_build_object(
+                    'pledged', coalesce(subs_agg.sum_active_payments, 0),
+                    'total_contributions', coalesce(subs_agg.count_active, 0),
+                    'total_contributors', coalesce(subs_agg.count_per_user, 0),
+                    'progress', coalesce((
+                        (coalesce(subs_agg.sum_active, 0) / coalesce(goals_agg.min_value, goals_agg.max_value)) * 100::numeric
+                    ), 0),
+                    'count_project_reminders', coalesce(reminders_agg.count, 0)
+                )::jsonb
+            from public.projects p
+                -- subscriptions aggregations
+                left join lateral (
+                    select
+                        sum(sub_data.amount) as sum_active,
+                        sum((sub_lp.data->>'amount')::numeric / 100) as sum_active_payments,
+                        count(1) as count_active,
+                        count(distinct(sub.user_id)) as count_per_user
+                    from common_schema.subscriptions sub
+                        left join lateral (
+                            select
+                                (sub.checkout_data->>'amount'::text)::numeric as amount_in_cents,
+                                ((sub.checkout_data->>'amount'::text)::numeric / (100)::numeric) as amount
+                        ) as sub_data on true
+                        left join lateral (
+                            select * from common_schema.catalog_payments cp where cp.subscription_id = sub.id
+                                and cp.status in ('paid', 'pending')
+                                order by cp.created_at desc limit 1
+                        ) as sub_lp on true
+                        where sub.project_id = p.common_id and sub.status = 'active'
+                ) as subs_agg on true
+                -- goals aggregations
+                left join lateral (
+                    select count(1) from project_reminders pr where pr.project_id = p.id
+                ) as reminders_agg on true
+                left join lateral (
+                    select
+                        min(g.value) filter(where g.value > subs_agg.sum_active) as min_value,
+                        max(g.value) as max_value
+                    from public.goals g
+                        where g.project_id = p.id
+                ) as goals_agg on true
+            where p.id = $1.id into v_data;
+        else
+            select json_build_object(
+                'pledged', coalesce(pt_data.pledged, 0)::numeric,
+                'total_contributions', coalesce(pt.total_contributions, 0),
+                'total_contributors', coalesce(pt.total_contributors, 0),
+                'progress', coalesce(pt.progress, 0)::numeric,
+                'count_project_reminders', coalesce(reminders_agg.count, 0)
+            )::jsonb
+            from public.projects p
+            left join "1".project_totals pt on pt.project_id = p.id
+            left join lateral (
+                select count(1) from project_reminders pr where pr.project_id = p.id
+            ) as reminders_agg on true
+            left join lateral (
+                select
+                    (case
+                    when p.state = 'failed' then pt.pledged
+                    else pt.paid_pledged
+                    end) as pledged
+            ) as pt_data on true
+            where p.id = $1.id
+            into v_data;
+        end if;
+
+        begin
+            insert into public.project_metric_storages (project_id, data, refreshed_at, created_at, updated_at)
+                values ($1.id, v_data, now(), now(), now());
+        exception when unique_violation then
+            update public.project_metric_storages
+                set data = v_data,
+                    refreshed_at = now(),
+                    updated_at = now()
+                where project_id = $1.id;
+        end;
+
+        return;
+    end;
+$function$;
+
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.refresh_project_metric_storage(projects)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+declare
+    v_data jsonb;
+    begin
+        if $1.mode = 'sub' then
+            -- build jsonb object for subscription project
+            select
+                json_build_object(
+                    'pledged', coalesce(subs_agg.sum_active_payments, 0),
+                    'total_contributions', coalesce(subs_agg.count_active, 0),
+                    'total_contributors', coalesce(subs_agg.count_per_user, 0),
+                    'progress', coalesce((
+                        (coalesce(subs_agg.sum_active, 0) / coalesce(goals_agg.min_value, goals_agg.max_value)) * 100::numeric
+                    ), 0)
+                )::jsonb
+            from public.projects p
+                -- subscriptions aggregations
+                left join lateral (
+                    select
+                        sum(sub_data.amount) as sum_active,
+                        sum((sub_lp.data->>'amount')::numeric / 100) as sum_active_payments,
+                        count(1) as count_active,
+                        count(distinct(sub.user_id)) as count_per_user
+                    from common_schema.subscriptions sub
+                        left join lateral (
+                            select
+                                (sub.checkout_data->>'amount'::text)::numeric as amount_in_cents,
+                                ((sub.checkout_data->>'amount'::text)::numeric / (100)::numeric) as amount
+                        ) as sub_data on true
+                        left join lateral (
+                            select * from common_schema.catalog_payments cp where cp.subscription_id = sub.id
+                                and cp.status in ('paid', 'pending')
+                                order by cp.created_at desc limit 1
+                        ) as sub_lp on true
+                        where sub.project_id = p.common_id and sub.status = 'active'
+                ) as subs_agg on true
+                -- goals aggregations
+                left join lateral (
+                    select
+                        min(g.value) filter(where g.value > subs_agg.sum_active) as min_value,
+                        max(g.value) as max_value
+                    from public.goals g
+                        where g.project_id = p.id
+                ) as goals_agg on true
+            where p.id = $1.id into v_data;
+        else
+            select json_build_object(
+                'pledged', coalesce(pt_data.pledged, 0)::numeric,
+                'total_contributions', coalesce(pt.total_contributions, 0),
+                'total_contributors', coalesce(pt.total_contributors, 0),
+                'progress', coalesce(pt.progress, 0)::numeric
+            )::jsonb
+            from public.projects p
+            left join "1".project_totals pt on pt.project_id = p.id
+            left join lateral (
+                select
+                    (case
+                    when p.state = 'failed' then pt.pledged
+                    else pt.paid_pledged
+                    end) as pledged
+            ) as pt_data on true
+            where p.id = $1.id
+            into v_data;
+        end if;
+
+        begin
+            insert into public.project_metric_storages (project_id, data, refreshed_at, created_at, updated_at)
+                values ($1.id, v_data, now(), now(), now());
+        exception when unique_violation then
+            update public.project_metric_storages
+                set data = v_data,
+                    refreshed_at = now(),
+                    updated_at = now()
+                where project_id = $1.id;
+        end;
+
+        return;
+    end;
+$function$;
+
+    SQL
+  end
+end

--- a/services/catarse/db/migrate/20211121125952_add_active_saved_and_in_reminder_projects_in_projects_view.rb
+++ b/services/catarse/db/migrate/20211121125952_add_active_saved_and_in_reminder_projects_in_projects_view.rb
@@ -1,0 +1,125 @@
+class AddActiveSavedAndInReminderProjectsInProjectsView < ActiveRecord::Migration[6.1]
+  def change
+    execute <<-SQL
+      DROP VIEW "1".projects CASCADE;
+
+      CREATE OR REPLACE VIEW "1".projects
+        AS SELECT p.id AS project_id,
+        p.category_id,
+        p.name AS project_name,
+        p.headline,
+        p.permalink,
+        p.mode,
+        p.state::text AS state,
+        so.so AS state_order,
+        od.od AS online_date,
+        p.recommended,
+        thumbnail_image(p.*, 'large'::text) AS project_img,
+        remaining_time_json(p.*) AS remaining_time,
+        p.expires_at,
+        COALESCE((pms.data ->> 'pledged'::text)::numeric, 0::numeric) AS pledged,
+        COALESCE((pms.data ->> 'progress'::text)::numeric, 0::numeric) AS progress,
+        s.acronym AS state_acronym,
+        u.name AS owner_name,
+        c.name AS city_name,
+        p.full_text_index,
+        is_current_and_online(p.expires_at, p.state::text) AS open_for_contributions,
+        elapsed_time_json(p.*) AS elapsed_time,
+        COALESCE(pss.score::numeric, 0::numeric) AS score,
+        (EXISTS ( SELECT true AS bool
+              FROM contributions c_1
+                JOIN user_follows uf ON uf.follow_id = c_1.user_id
+              WHERE is_confirmed(c_1.*) AND uf.user_id = current_user_id() AND c_1.project_id = p.id)) AS contributed_by_friends,
+        p.user_id AS project_user_id,
+        p.video_embed_url,
+        p.updated_at,
+        u.public_name AS owner_public_name,
+        zone_timestamp(p.expires_at) AS zone_expires_at,
+        p.common_id,
+        p.content_rating >= 18 AS is_adult_content,
+        p.content_rating,
+        ( SELECT array_to_string(array_agg(COALESCE(integration.data ->> 'name'::text, integration.name::text)), ','::text) AS integration_name
+              FROM project_integrations integration
+              WHERE integration.project_id = p.id) AS integrations,
+        COALESCE(category.name_pt, category.name_en::text) AS category_name,
+        (EXISTS (SELECT true AS bool FROM project_reminders pr
+          WHERE (pr.project_id = p.id AND (is_current_and_online(p.expires_at, (p.state)::text) OR
+          ((SELECT true AS bool FROM project_integrations integration WHERE (integration.project_id = p.id
+              and integration.name = 'COMING_SOON_LANDING_PAGE') and p.state = 'draft' group by p.id)))
+          and ((p.id = pr.project_id) AND (pr.user_id = current_user_id()))))) AS active_saved_projects,
+        current_user_already_in_reminder(p.*) AS in_reminder,
+        COALESCE((pms.data ->> 'count_project_reminders'::text)::numeric, 0::numeric) AS count_project_reminders
+      FROM projects p
+        JOIN users u ON p.user_id = u.id
+        LEFT JOIN project_score_storages pss ON pss.project_id = p.id
+        LEFT JOIN project_metric_storages pms ON pms.project_id = p.id
+        LEFT JOIN cities c ON c.id = p.city_id
+        LEFT JOIN states s ON s.id = c.state_id
+        JOIN LATERAL zone_timestamp(online_at(p.*)) od(od) ON true
+        JOIN LATERAL state_order(p.*) so(so) ON true
+        LEFT JOIN categories category ON category.id = p.category_id
+      WHERE p.state::text <> 'deleted'::text;
+
+      grant select on "1"."projects" to admin, anonymous, web_user;
+
+      CREATE OR REPLACE FUNCTION public.near_me("1".projects)
+      RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+          COALESCE($1.state_acronym, (SELECT u.address_state FROM users u WHERE u.id = $1.project_user_id)) = (SELECT u.address_state FROM users u WHERE u.id = current_user_id());
+      $function$;
+
+      CREATE OR REPLACE FUNCTION public.is_expired(project projects)
+      RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        select
+        case when $1.mode = 'sub' then
+          false
+        else
+          public.is_past($1.expires_at)
+        end;
+      $function$;
+
+      CREATE OR REPLACE FUNCTION public.is_expired(project "1".projects)
+      RETURNS boolean
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        select
+        case when $1.mode = 'sub' then
+            false
+        else
+          public.is_past($1.expires_at)
+        end;
+      $function$;
+
+      CREATE OR REPLACE FUNCTION "1".project_search(query text)
+      RETURNS SETOF "1".projects
+      LANGUAGE sql
+      STABLE
+      AS $function$
+        SELECT
+          p.*
+        FROM
+            "1".projects p
+        WHERE
+            (
+                p.full_text_index @@ plainto_tsquery('portuguese', unaccent(query))
+                OR
+                p.project_name % query
+            )
+            AND p.state_order >= 'published'
+        ORDER BY
+            p.open_for_contributions DESC,
+            p.score DESC NULLS LAST,
+            p.state DESC,
+            ts_rank(p.full_text_index, plainto_tsquery('portuguese', unaccent(query))) DESC,
+            p.project_id DESC;
+      $function$;
+    SQL
+  end
+end

--- a/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
+++ b/services/catarse/spec/workers/project_metric_storage_refresh_worker_spec.rb
@@ -15,24 +15,54 @@ RSpec.describe ProjectMetricStorageRefreshWorker do
 
   context 'when project is in draft' do
     let(:project) { create(:project, state: 'draft') }
+
     before do
       expect(Project).to receive(:find).with(project.id).and_return(project)
       expect(project).not_to receive(:refresh_project_metric_storage)
     end
-    it 'should not call refresh function' do
-      ProjectMetricStorageRefreshWorker.perform_async(project.id)
+
+    it 'does not call refresh function' do
+      described_class.perform_async(project.id)
+    end
+  end
+
+  context 'when project is in draft and has comming soon landing page' do
+    let(:project) { create(:project, state: 'draft') }
+
+    before do
+      create(:coming_soon_integration, { project: project })
+      expect(Project).to receive(:find).with(project.id).and_return(project)
+      expect(project).to receive(:refresh_project_metric_storage)
+    end
+
+    it 'calls refresh_project_metric_storage' do
+      described_class.perform_async(project.id)
+    end
+  end
+
+  context 'when project is in deleted' do
+    let(:project) { create(:project, state: 'deleted') }
+
+    before do
+      expect(Project).to receive(:find).with(project.id).and_return(project)
+      expect(project).not_to receive(:refresh_project_metric_storage)
+    end
+
+    it 'does not call refresh function' do
+      described_class.perform_async(project.id)
     end
   end
 
   context 'when project can be processed' do
     let(:project) { create(:subscription_project, state: 'online') }
+
     before do
       expect(Project).to receive(:find).with(project.id).and_return(project)
       expect(project).to receive(:refresh_project_metric_storage)
     end
 
-    it 'should call refresh_project_metric_storage' do
-      ProjectMetricStorageRefreshWorker.perform_async(project.id)
+    it 'calls refresh_project_metric_storage' do
+      described_class.perform_async(project.id)
     end
   end
 end


### PR DESCRIPTION
### Descrição
No teste de QA, foi observado um refresh na página quando loga pela primeira vez, foi feito um ajuste para substituir esse comportamento.

Adiciona no explore projetos em pré-lançamento tanto em um filtro personalizado: "Em breve no Catarse" e também listado nos "Projetos Salvos". 

### Referência
https://www.notion.so/catarse/Implementar-card-de-projeto-em-Pr-Lan-amento-no-Catarse-cc3d9c4fc67d46deb38474bfe9e9cf78

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
