### PR TITLE
🐞 Substituí project_totals em projects view para receber dados de project_metric.

### DIFF
--- a/services/catarse/db/migrate/20220126192248_remove_project_totals_to_projects_metric_storage.rb
+++ b/services/catarse/db/migrate/20220126192248_remove_project_totals_to_projects_metric_storage.rb
@@ -1,0 +1,192 @@
+class RemoveProjectTotalsToProjectsMetricStorage < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.refresh_project_metric_storage(projects)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+declare
+    v_data jsonb;
+    begin
+        if $1.mode = 'sub' then
+            -- build jsonb object for subscription project
+            select
+                json_build_object(
+                    'pledged', coalesce(subs_agg.sum_active_payments, 0),
+                    'paid_pledged', coalesce(subs_agg.sum_paid_active_payments, 0),
+                    'total_payment_service_fee', coalesce(subs_agg.payment_method_fee, 0),
+                    'paid_total_payment_service_fee', coalesce(subs_agg.paid_total_payment_method_fee, 0),
+                    'total_contributions', coalesce(subs_agg.count_active, 0),
+                    'total_contributors', coalesce(subs_agg.count_per_user, 0),
+                    'progress', coalesce((
+                        (coalesce(subs_agg.sum_active, 0) / coalesce(goals_agg.min_value, goals_agg.max_value)) * 100::numeric
+                    ), 0)
+                )::jsonb
+            from public.projects p
+                -- subscriptions aggregations
+                left join lateral (
+                    select
+                        sum(sub_data.amount) as sum_active,
+                        sum((sub_lp.data->>'amount')::numeric / 100) as sum_active_payments,
+                        sum((sub_lp.data->>'amount')::numeric / 100) filter (where sub_lp.status in ('paid')) as sum_paid_active_payments,
+                        count(1) as count_active,
+                        count(distinct(sub.user_id)) as count_per_user,
+                        sum(fees.gateway_fee::numeric) AS payment_method_fee,
+                        sum(fees.gateway_fee::numeric) filter (where fees.status in ('paid')) AS paid_total_payment_method_fee
+                    from common_schema.subscriptions sub
+                        left join lateral (
+                            select
+                                (sub.checkout_data->>'amount'::text)::numeric as amount_in_cents,
+                                ((sub.checkout_data->>'amount'::text)::numeric / (100)::numeric) as amount
+                        ) as sub_data on true
+                        left join lateral (
+                            select * from common_schema.catalog_payments cp where cp.subscription_id = sub.id
+                                and cp.status in ('paid', 'pending')
+                                order by cp.created_at desc limit 1
+                        ) as sub_lp on true
+                        LEFT JOIN LATERAL (
+                            select round(
+		                    CASE
+		                        WHEN (cp.gateway_general_data ->> 'gateway_payment_method'::text) = 'credit_card'::text THEN COALESCE((cp.gateway_general_data ->> 'gateway_cost'::text)::numeric, 0::numeric) + COALESCE((cp.gateway_general_data ->> 'payable_total_fee'::text)::numeric, 0::numeric)
+		                        ELSE COALESCE(cp.gateway_general_data ->> 'payable_total_fee'::text, cp.gateway_general_data ->> 'gateway_cost'::text, '0'::text)::numeric
+		                    END / 100::numeric, 2) AS gateway_fee,
+		                    cp.status as status
+		                    from common_schema.catalog_payments cp where cp.subscription_id = sub.id
+                        ) fees ON true
+                        where sub.project_id = p.common_id and sub.status = 'active'
+                ) as subs_agg on true
+                -- goals aggregations
+                left join lateral (
+                    select
+                        min(g.value) filter(where g.value > subs_agg.sum_active) as min_value,
+                        max(g.value) as max_value
+                    from public.goals g
+                        where g.project_id = p.id
+                ) as goals_agg on true
+            where p.id = $1.id into v_data;
+        else
+            select json_build_object(
+                'pledged', sum(COALESCE(pa.value, 0)),
+                'paid_pledged', sum(COALESCE(pa.value, 0)) FILTER (WHERE pa.state = 'paid'::text),
+                'progress', sum(COALESCE(pa.value, 0)) / p.goal * 100::numeric,
+                'total_payment_service_fee', sum(COALESCE(pa.gateway_fee, 0)),
+                'paid_total_payment_service_fee', (SELECT sum(COALESCE(pa.gateway_fee, 0)) FILTER (WHERE pa.state = 'paid'::text)
+                UNION (SELECT 0::numeric) LIMIT 1),
+                'total_contributions', count(DISTINCT c.id),
+                'total_contributors', count(DISTINCT c.user_id)
+            )::jsonb
+            from public.projects p
+            left JOIN contributions c ON c.project_id = p.id
+            left JOIN payments pa ON pa.contribution_id = c.id
+            where p.id = $1.id
+	        GROUP BY c.project_id, p.id
+            into v_data;
+        end if;
+
+        begin
+            insert into public.project_metric_storages (project_id, data, refreshed_at, created_at, updated_at)
+                values ($1.id, v_data, now(), now(), now());
+        exception when unique_violation then
+            update public.project_metric_storages
+                set data = v_data,
+                    refreshed_at = now(),
+                    updated_at = now()
+                where project_id = $1.id;
+        end;
+
+        return;
+    end;
+$function$;
+
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+CREATE OR REPLACE FUNCTION public.refresh_project_metric_storage(projects)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+declare
+    v_data jsonb;
+    begin
+        if $1.mode = 'sub' then
+            -- build jsonb object for subscription project
+            select
+                json_build_object(
+                    'pledged', coalesce(subs_agg.sum_active_payments, 0),
+                    'total_contributions', coalesce(subs_agg.count_active, 0),
+                    'total_contributors', coalesce(subs_agg.count_per_user, 0),
+                    'progress', coalesce((
+                        (coalesce(subs_agg.sum_active, 0) / coalesce(goals_agg.min_value, goals_agg.max_value)) * 100::numeric
+                    ), 0)
+                )::jsonb
+            from public.projects p
+                -- subscriptions aggregations
+                left join lateral (
+                    select
+                        sum(sub_data.amount) as sum_active,
+                        sum((sub_lp.data->>'amount')::numeric / 100) as sum_active_payments,
+                        count(1) as count_active,
+                        count(distinct(sub.user_id)) as count_per_user
+                    from common_schema.subscriptions sub
+                        left join lateral (
+                            select
+                                (sub.checkout_data->>'amount'::text)::numeric as amount_in_cents,
+                                ((sub.checkout_data->>'amount'::text)::numeric / (100)::numeric) as amount
+                        ) as sub_data on true
+                        left join lateral (
+                            select * from common_schema.catalog_payments cp where cp.subscription_id = sub.id
+                                and cp.status in ('paid', 'pending')
+                                order by cp.created_at desc limit 1
+                        ) as sub_lp on true
+                        where sub.project_id = p.common_id and sub.status = 'active'
+                ) as subs_agg on true
+                -- goals aggregations
+                left join lateral (
+                    select
+                        min(g.value) filter(where g.value > subs_agg.sum_active) as min_value,
+                        max(g.value) as max_value
+                    from public.goals g
+                        where g.project_id = p.id
+                ) as goals_agg on true
+            where p.id = $1.id into v_data;
+        else
+            select json_build_object(
+                'pledged', coalesce(pt_data.pledged, 0)::numeric,
+                'pledged', p.value,
+                'total_contributions', coalesce(pt.total_contributions, 0),
+                'total_contributors', coalesce(pt.total_contributors, 0),
+                'progress', coalesce(pt.progress, 0)::numeric
+            )::jsonb
+            from public.projects p
+            left join "1".project_totals pt on pt.project_id = p.id
+            left join lateral (
+                select
+                    (case
+                    when p.state = 'failed' then pt.pledged
+                    else pt.paid_pledged
+                    end) as pledged
+            ) as pt_data on true
+            where p.id = $1.id
+            into v_data;
+        end if;
+
+        begin
+            insert into public.project_metric_storages (project_id, data, refreshed_at, created_at, updated_at)
+                values ($1.id, v_data, now(), now(), now());
+        exception when unique_violation then
+            update public.project_metric_storages
+                set data = v_data,
+                    refreshed_at = now(),
+                    updated_at = now()
+                where project_id = $1.id;
+        end;
+
+        return;
+    end;
+$function$;
+
+    SQL
+  end
+end

--- a/services/catarse/db/migrate/20220128191349_change_projects_view_to_use_project_metric_storage.rb
+++ b/services/catarse/db/migrate/20220128191349_change_projects_view_to_use_project_metric_storage.rb
@@ -1,0 +1,138 @@
+class ChangeProjectsViewToUseProjectMetricStorage < ActiveRecord::Migration[6.1]
+  def change
+    execute <<-SQL
+    DROP VIEW "1".projects CASCADE;
+
+    create or replace view "1".projects as
+            SELECT p.id AS project_id,
+    p.category_id,
+    p.name AS project_name,
+    p.headline,
+    p.permalink,
+    p.mode,
+    p.state::text AS state,
+    so.so AS state_order,
+    od.od AS online_date,
+    p.recommended,
+    thumbnail_image(p.*, 'large'::text) AS project_img,
+    remaining_time_json(p.*) AS remaining_time,
+    p.expires_at,
+    COALESCE(( SELECT
+      CASE
+          WHEN p.mode = 'sub'::text THEN ( SELECT sum(((s_1.checkout_data ->> 'amount'::text)::numeric) / 100::numeric) AS sum
+             FROM common_schema.subscriptions s_1
+            WHERE s_1.project_id = p.common_id AND s_1.status::text = 'active'::text)
+          ELSE ( SELECT
+                  CASE
+                      WHEN p.state::text = 'failed'::text THEN
+                      ((SELECT COALESCE((pms.data ->> 'pledged'::text)::numeric, 0) FROM project_metric_storages pms
+                      WHERE  pms.project_id = p.id) UNION (SELECT 0::numeric) LIMIT 1)
+                      ELSE
+                      ((SELECT COALESCE((pms.data ->> 'paid_pledged'::text)::numeric, 0) FROM project_metric_storages pms
+                      WHERE  pms.project_id = p.id) UNION (SELECT 0::numeric) LIMIT 1)
+                  END AS paid_pledged
+             FROM "1".project_totals pt
+            WHERE pt.project_id = p.id)
+      END AS paid_pledged), 0::numeric) AS pledged,
+    COALESCE(( SELECT
+                CASE
+                    WHEN p.mode = 'sub'::text THEN (( SELECT sum(((s_1.checkout_data ->> 'amount'::text)::numeric) / 100::numeric) AS sum
+                       FROM common_schema.subscriptions s_1
+                      WHERE s_1.project_id = p.common_id AND s_1.status::text = 'active'::text)) / COALESCE(( SELECT min(g.value)
+                       FROM goals g
+                      WHERE g.project_id = p.id AND g.value > (select sum from ( SELECT sum(((s_2.checkout_data ->> 'amount'::text)::numeric) / 100::numeric) AS sum
+                               FROM common_schema.subscriptions s_2
+                              WHERE s_2.project_id = p.common_id AND s_2.status::text = 'active'::text) total_amount)
+                     LIMIT 1), ( SELECT max(goals.value) AS max
+                       FROM goals
+                      WHERE goals.project_id = p.id)) * 100::numeric
+                    ELSE (( SELECT COALESCE((pms.data ->> 'progress'::text)::numeric, 0) FROM project_metric_storages pms
+                    WHERE  pms.project_id = p.id) UNION (SELECT 0::numeric) LIMIT 1)
+                END AS progress), 0::numeric) AS progress,
+    s.acronym AS state_acronym,
+    u.name AS owner_name,
+    c.name AS city_name,
+    p.full_text_index,
+    is_current_and_online(p.expires_at, p.state::text) AS open_for_contributions,
+    elapsed_time_json(p.*) AS elapsed_time,
+    score(p.*) AS score,
+    (EXISTS ( SELECT true AS bool
+           FROM contributions c_1
+             JOIN user_follows uf ON uf.follow_id = c_1.user_id
+          WHERE is_confirmed(c_1.*) AND uf.user_id = current_user_id() AND c_1.project_id = p.id)) AS contributed_by_friends,
+    p.user_id AS project_user_id,
+    p.video_embed_url,
+    p.updated_at,
+    u.public_name AS owner_public_name,
+    zone_timestamp(p.expires_at) AS zone_expires_at
+   FROM projects p
+     JOIN users u ON p.user_id = u.id
+     LEFT JOIN cities c ON c.id = p.city_id
+     LEFT JOIN states s ON s.id = c.state_id
+     JOIN LATERAL zone_timestamp(online_at(p.*)) od(od) ON true
+     JOIN LATERAL state_order(p.*) so(so) ON true;
+
+    grant select on "1"."projects" to admin, anonymous, web_user;
+
+    CREATE OR REPLACE FUNCTION public.near_me("1".projects)
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT
+        COALESCE($1.state_acronym, (SELECT u.address_state FROM users u WHERE u.id = $1.project_user_id)) = (SELECT u.address_state FROM users u WHERE u.id = current_user_id());
+    $function$;
+
+    CREATE OR REPLACE FUNCTION public.is_expired(project projects)
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      select
+      case when $1.mode = 'sub' then
+        false
+      else
+        public.is_past($1.expires_at)
+      end;
+    $function$;
+
+    CREATE OR REPLACE FUNCTION public.is_expired(project "1".projects)
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      select
+      case when $1.mode = 'sub' then
+          false
+      else
+        public.is_past($1.expires_at)
+      end;
+    $function$;
+
+    CREATE OR REPLACE FUNCTION "1".project_search(query text)
+    RETURNS SETOF "1".projects
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT
+        p.*
+      FROM
+          "1".projects p
+      WHERE
+          (
+              p.full_text_index @@ plainto_tsquery('portuguese', unaccent(query))
+              OR
+              p.project_name % query
+          )
+          AND p.state_order >= 'published'
+      ORDER BY
+          p.open_for_contributions DESC,
+          p.score DESC NULLS LAST,
+          p.state DESC,
+          ts_rank(p.full_text_index, plainto_tsquery('portuguese', unaccent(query))) DESC,
+          p.project_id DESC;
+    $function$;
+
+    SQL
+  end
+end


### PR DESCRIPTION
### Descrição
Altera a função refresh_project_metric_storage para não consultar a view projet_totals e utiliza project_metric na view projects, pois as consultas na view '1'.projects estavam muito lentas em sandbox.

### Referência
https://www.notion.so/catarse/Ajuste-lentid-o-no-sandbox-melhorar-ProjectTotals-8e5a840bef5248538c3c70aed3d7e2ab

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
