### PR TITLE
🐞 Corrige autorização e redirecionamente para action connect_facebook.

### DIFF
--- a/services/catarse/app/controllers/application_controller.rb
+++ b/services/catarse/app/controllers/application_controller.rb
@@ -81,8 +81,12 @@ class ApplicationController < ActionController::Base
   end
 
   def connect_facebook
-    FbFriendCollectorWorker.perform_async(current_user.fb_auth.id)
-    redirect_to follow_fb_friends_path
+    if user_signed_in? && current_user.has_fb_auth?
+      FbFriendCollectorWorker.perform_async(current_user.fb_auth.id)
+      redirect_to follow_fb_friends_path
+    else
+      redirect_to root_path
+    end
   end
 
   def public_settings

--- a/services/catarse/catarse.js/legacy/src/c/connect-facebook.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/connect-facebook.tsx
@@ -10,9 +10,10 @@ type ConnectFacebookProps = {
     linkClass: string
     label: string
     buttonClass: string
+    styleInput?: string
 }
 
-function ConnectFacebook({ label, linkClass, buttonClass} : ConnectFacebookProps) {
+function ConnectFacebook({ label, linkClass, buttonClass, styleInput } : ConnectFacebookProps) {
     const currentUser = getCurrentUserCached();
     const hasFBAuth = isLoggedIn(currentUser) && currentUser.has_fb_auth;
 
@@ -23,7 +24,7 @@ function ConnectFacebook({ label, linkClass, buttonClass} : ConnectFacebookProps
             action: '/users/auth/facebook',
             method: 'POST',
         }, [
-            m(`${buttonClass}[type="submit"][value="${label}"]`),
+            m(`${buttonClass}[type="submit"][value="${label}"][style="${styleInput}"]`),
             m(`input[name='authenticity_token'][type='hidden'][value='${h.authenticityToken()}']`),
         ])
     )

--- a/services/catarse/catarse.js/legacy/src/c/user-dropdown-profile-menu.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/user-dropdown-profile-menu.tsx
@@ -3,6 +3,7 @@ import { withHooks } from 'mithril-hooks'
 import { ThisWindow, UserDetails } from '../entities'
 import { CurrencyFormat } from '../shared/components/currency-format'
 import { AdminMenuLinks } from './admin-menu-links'
+import ConnectFacebook from './connect-facebook';
 
 declare var window : ThisWindow
 
@@ -124,10 +125,25 @@ const UserMenuItemLink = withHooks<{ item : MenuItem }>(_UserMenuItemLink)
 
 function _UserMenuItemLink({ item: { label, url }} : { item : MenuItem }) {
     return (
+        use_connect_facebook(label) ?
+        <ConnectFacebook
+            label={'Encontre amigos'}
+            linkClass={'a.alt-link.fontsize-smaller'}
+            buttonClass={'input.alt-link.fontsize-smaller'}
+            styleInput={'border: unset; background-color: unset; padding-left: 0'}
+        />
+        :
         <li class="lineheight-looser">
             <a href={`/${window.I18n.locale}${url}`} class="alt-link fontsize-smaller">
                 {label}
             </a>
         </li>
     )
+}
+
+function use_connect_facebook(label) {
+    if (label == 'Encontre amigos') {
+        return true
+    }
+    false
 }


### PR DESCRIPTION
### Descrição
Caso o usuário não tenha conta vinculada ao facebook, o redirecionamento de 'Encontrar Amigos' retorna um erro. Isso está acontecendo pois ao utilizar get para acessar a rota, não está sendo mais utilizado pela gem omniauth (https://github.com/omniauth/omniauth/releases/tag/v2.0.0), a solução é utilizar um botão com método post.

### Referência
https://www.notion.so/catarse/Link-Encontre-Amigos-do-menu-de-usu-rio-n-o-funciona-se-o-usu-rio-n-o-tiver-uma-conta-do-FB-j-ass-094756df2c4e47c3bc4cba01f2c58af9

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
