### PR TITLE
✨ Cria função de retentativas de envio das notificações.

### DIFF
--- a/services/catarse/lib/queries/notifications_without_sendgrid_event.rb
+++ b/services/catarse/lib/queries/notifications_without_sendgrid_event.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Queries
+  class NotificationsWithoutSendgridEvent
+    def call
+      @notifications = []
+      SendgridEvent.distinct.pluck(:notification_type).each do |notification_type|
+        list_notifications = find_notifications_without_sendgrid_events(notification_type)
+
+        @notifications += list_notifications if list_notifications.present?
+      end
+      @notifications
+    rescue StandardError => e
+      Sentry.capture_exception(e, level: :fatal)
+    end
+
+    private
+
+    def find_notifications_without_sendgrid_events(notification_type)
+      table_name = notification_type.camelize.singularize.constantize.table_name
+      join_conditions = "left outer join sendgrid_events on sendgrid_events.notification_id = #{table_name}.id
+        and sendgrid_events.notification_type = '#{notification_type}'"
+      notification_type.camelize.singularize.constantize.joins(ActiveRecord::Base.sanitize_sql(join_conditions)).where(
+        sendgrid_events: { notification_id: nil }, table_name => { created_at: 5.days.ago..4.hours.ago }
+      ).all.to_a
+    end
+  end
+end

--- a/services/catarse/lib/tasks/cron.rake
+++ b/services/catarse/lib/tasks/cron.rake
@@ -213,6 +213,13 @@ namespace :cron do
     end
   end
 
+  desc 'retry send notifications without sendgrid event'
+  task retry_send_notifications: [:environment] do
+    Queries::NotificationsWithoutSendgridEvent.new.call.each do |notification|
+      Notifier.notify(notification)
+    end
+  end
+
   desc 'Update all fb users'
   task update_fb_users: [:environment] do
     User.joins(:projects).distinct.where("users.fb_parsed_link~'^pages/\\d+$'").each do |u|

--- a/services/catarse/spec/factories/sendgrid_events.rb
+++ b/services/catarse/spec/factories/sendgrid_events.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :sendgrid_event do
+    notification_id { Faker::Number.number(digits: 4) }
+    notification_user { Faker::Number.number(digits: 4) }
+    notification_type { 'ContributionNotification' }
+    template_name { 'payment_slip' }
+    event { 'delivered' }
+    email { Faker::Internet.email }
+    useragent { 'Mozilla/5.0 (Windows NT 5.1) ' }
+    sendgrid_data { {} }
+  end
+end

--- a/services/catarse/spec/lib/queries/notifications_without_sendgrid_event_spec.rb
+++ b/services/catarse/spec/lib/queries/notifications_without_sendgrid_event_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Queries::NotificationsWithoutSendgridEvent do
+  let!(:notifications) do
+    [
+      create(:project_notification, created_at: 4.days.ago),
+      create(:notification, created_at: 6.hours.ago),
+      create(:project_notification, created_at: 1.month.ago),
+      create(:notification, created_at: Time.zone.now)
+    ]
+  end
+
+  before do
+    create(:sendgrid_event, notification_id: create(:project_notification).id,
+      notification_type: 'ProjectNotification'
+    )
+    create(:sendgrid_event, notification_id: create(:notification).id, notification_type: 'Notification')
+  end
+
+  describe '#call' do
+    context 'when the query is successfull' do
+      it 'doesn`t capture message via Sentry' do
+        expect(Sentry).not_to receive(:capture_message)
+
+        described_class.new.call
+      end
+
+      it 'return expected notifications' do
+        expect(described_class.new.call).to eq([notifications[0], notifications[1]])
+      end
+    end
+
+    context 'when the query fails' do
+      let(:exception) { RuntimeError.new('Error') }
+
+      before do
+        allow(SendgridEvent).to receive(:distinct).and_raise(exception)
+      end
+
+      it 'captures error message via Sentry' do
+        expect(Sentry).to receive(:capture_exception).with(exception, level: :fatal)
+
+        described_class.new.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Descrição
Adicionar rotina para capturar todas as notificações em determinado período de tempo que não tiveram sendgrid_events e retenta-lós. 

### Referência
https://www.notion.so/catarse/Criar-um-sistema-para-retentativa-de-envio-das-notifica-es-40d329cf35fb4d8c925777880ed8cb4a

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
