### PR TITLE
Ajusta termos que ficaram faltando

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/deliver-contribution-modal-content.js
+++ b/services/catarse/catarse.js/legacy/src/c/deliver-contribution-modal-content.js
@@ -13,7 +13,7 @@ const deliverContributionModalContent = {
                     m('span.fa.fa-check-circle',
                         ''
                     ),
-                    ' Recompensas a caminho! Obaaa!!!!'
+                    ' Recompensas a caminho!'
                 ])
             ),
             m('.modal-dialog-content', [
@@ -21,12 +21,12 @@ const deliverContributionModalContent = {
                     m('span.fontweight-semibold',
                         `Você selecionou ${attrs.amount} apoios.`
                     ),
-                    ' Após sua confirmação, os apoiadores que efetuaram esses apoios ao seu projeto serão notificados de que suas recompensas serão entregues em breve.'
+                    ' Após sua confirmação, os apoiadores que efetuaram esses apoios ao seu projeto serão notificados de que suas recompensas foram enviadas.'
                 ]),
                 m('.w-form', [
                     m('form', [
                         m('.fontsize-smaller',
-                            'Se quiser adicionar alguma informação nessa mensagem, use o espaço abaixo! É um ótimo momento para agradecer a essas pessoas que acreditaram em você!'
+                            'Se quiser adicionar alguma informação nessa mensagem, use o espaço abaixo. É um ótimo momento para agradecer a essas pessoas que acreditaram em você!'
                         ),
                         m("textarea.height-mini.text-field.w-input[placeholder='Digite sua mensagem (opcional)']", {
                             value: attrs.message(),

--- a/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content.js
@@ -119,23 +119,19 @@ const projectContributionReportContent = {
                                     m('button.btn.btn-inline.btn-small.btn-terciary.w-button', {
                                         onclick: state.showSelectedMenu.toggle
                                     }, [
-                                        'Marcar ',
-                                        m('span.w-hidden-tiny',
-                                            'entrega'
-                                        ),
-                                        ' como'
+                                        'Marcar como'
                                     ]),
                                     (state.showSelectedMenu() ?
                                         m('.card.dropdown-list.dropdown-list-medium.u-radius.zindex-10[id=\'transfer\']', [
                                             m('a.dropdown-link.fontsize-smaller[href=\'#\']', {
                                                 onclick: () => state.displayDeliverModal.toggle()
                                             },
-                                                'Entregue'
+                                                'Enviada'
                                             ),
                                             m('a.dropdown-link.fontsize-smaller[href=\'#\']', {
                                                 onclick: () => state.displayErrorModal.toggle()
                                             },
-                                                'Erro na entrega'
+                                                'Erro no envio'
                                             )
                                         ]) : '')
                                 ]) : '')


### PR DESCRIPTION
### Descrição
Estamos trocando o termo 'Entregue' por 'Enviada' para mantermos consistência, quando o realizador estiver gerenciando a entrega de recompensas.

### Referência
https://www.notion.so/catarse/Alterar-termo-Entregue-para-Enviada-na-plataforma-quando-estivermos-referenciando-sobre-o-envio--7b728a4f449a40d1823ca44a67089597

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
