### PR TITLE
Ajusta termos que ficaram faltando

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_approaching.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/delivery_approaching.html.slim
@@ -6,7 +6,7 @@ p Olá!
 
 p Estamos enviando essa mensagem para te lembrar que, pela estimativa que você publicou na sua  #{link_to 'página da sua campanha', project_by_slug_url(permalink: project.permalink)}, nesse próximo mês já começam os envios das recompensas para as pessoas que contribuíram com o seu projeto!
 
-p Você pode baixar os dados dos apoiadores e gerenciar o envio das recompensas através da aba #{link_to 'relatórios de apoios', contributions_report_project_url(project)}. Conforme for realizando o envio, basta selecionar os apoios e marcar como "Entregue". Assim, você irá automaticamente avisar o seu apoiador de que a recompensa dele está a caminho. :-)
+p Você pode baixar os dados dos apoiadores e gerenciar o envio das recompensas através da aba #{link_to 'relatórios de apoios', contributions_report_project_url(project)}. Conforme for realizando o envio, basta selecionar os apoios e marcar como "Enviada". Assim, você irá automaticamente avisar o seu apoiador de que a recompensa dele está a caminho. :-)
 
 p Veja como é fácil e simples controlar suas entregas:
 

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/rewards_manager_subject.text.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/rewards_manager_subject.text.slim
@@ -1,1 +1,1 @@
-| [IMPORTANTE] Marque suas recompensas como entregues!
+| [IMPORTANTE] Marque suas recompensas como enviadas!

--- a/services/catarse/catarse.js/legacy/src/c/deliver-contribution-modal-content.js
+++ b/services/catarse/catarse.js/legacy/src/c/deliver-contribution-modal-content.js
@@ -13,7 +13,7 @@ const deliverContributionModalContent = {
                     m('span.fa.fa-check-circle',
                         ''
                     ),
-                    ' Recompensas a caminho! Obaaa!!!!'
+                    ' Recompensas a caminho!'
                 ])
             ),
             m('.modal-dialog-content', [
@@ -21,12 +21,12 @@ const deliverContributionModalContent = {
                     m('span.fontweight-semibold',
                         `Você selecionou ${attrs.amount} apoios.`
                     ),
-                    ' Após sua confirmação, os apoiadores que efetuaram esses apoios ao seu projeto serão notificados de que suas recompensas serão entregues em breve.'
+                    ' Após sua confirmação, os apoiadores que efetuaram esses apoios ao seu projeto serão notificados de que suas recompensas foram enviadas.'
                 ]),
                 m('.w-form', [
                     m('form', [
                         m('.fontsize-smaller',
-                            'Se quiser adicionar alguma informação nessa mensagem, use o espaço abaixo! É um ótimo momento para agradecer a essas pessoas que acreditaram em você!'
+                            'Se quiser adicionar alguma informação nessa mensagem, use o espaço abaixo. É um ótimo momento para agradecer a essas pessoas que acreditaram em você!'
                         ),
                         m("textarea.height-mini.text-field.w-input[placeholder='Digite sua mensagem (opcional)']", {
                             value: attrs.message(),

--- a/services/catarse/catarse.js/legacy/src/c/project-contribution-delivery-legend-modal.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-contribution-delivery-legend-modal.js
@@ -23,7 +23,7 @@ const ProjectContributionDeliveryLegendModal = {
                 ]),
                 m('div',
                     m('span.fontsize-smaller.badge.badge-success',
-                        'Entregue'
+                        'Enviada'
                     )
                 ),
                 m('.u-marginbottom-20',
@@ -34,7 +34,7 @@ const ProjectContributionDeliveryLegendModal = {
                 m('.u-marginbottom-20', [
                     m('div',
                         m('span.fontsize-smaller.badge.badge-attention',
-                            'Erro na entrega'
+                            'Erro no envio'
                         )
                     ),
                     m('.fontsize-smaller',

--- a/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-contribution-report-content.js
@@ -119,23 +119,19 @@ const projectContributionReportContent = {
                                     m('button.btn.btn-inline.btn-small.btn-terciary.w-button', {
                                         onclick: state.showSelectedMenu.toggle
                                     }, [
-                                        'Marcar ',
-                                        m('span.w-hidden-tiny',
-                                            'entrega'
-                                        ),
-                                        ' como'
+                                        'Marcar como'
                                     ]),
                                     (state.showSelectedMenu() ?
                                         m('.card.dropdown-list.dropdown-list-medium.u-radius.zindex-10[id=\'transfer\']', [
                                             m('a.dropdown-link.fontsize-smaller[href=\'#\']', {
                                                 onclick: () => state.displayDeliverModal.toggle()
                                             },
-                                                'Entregue'
+                                                'Enviada'
                                             ),
                                             m('a.dropdown-link.fontsize-smaller[href=\'#\']', {
                                                 onclick: () => state.displayErrorModal.toggle()
                                             },
-                                                'Erro na entrega'
+                                                'Erro no envio'
                                             )
                                         ]) : '')
                                 ]) : '')

--- a/services/catarse/catarse.js/legacy/src/root/projects-contribution-report.js
+++ b/services/catarse/catarse.js/legacy/src/root/projects-contribution-report.js
@@ -137,11 +137,11 @@ const projectContributionReport = {
                             },
                             {
                                 value: 'undelivered',
-                                option: 'Não entregue',
+                                option: 'Não enviada',
                             },
                             {
                                 value: 'delivered',
-                                option: 'Entregue',
+                                option: 'Enviada',
                             },
                             {
                                 value: 'error',


### PR DESCRIPTION
### Descrição
Estamos trocando o termo 'Entregue' por 'Enviada' para mantermos consistência, quando o realizador estiver gerenciando a entrega de recompensas.

### Referência
https://www.notion.so/catarse/Alterar-termo-Entregue-para-Enviada-na-plataforma-quando-estivermos-referenciando-sobre-o-envio--7b728a4f449a40d1823ca44a67089597

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
