### PR TITLE
🐞 Adiciona autorização para visualizar o informe.

### DIFF
--- a/services/catarse/app/controllers/projects/project_fiscal_data_controller.rb
+++ b/services/catarse/app/controllers/projects/project_fiscal_data_controller.rb
@@ -21,7 +21,7 @@ class Projects::ProjectFiscalDataController < ApplicationController
   def inform
     fiscal_data = ProjectFiscalInform.find_by(project_id: params[:project_id], fiscal_year: params[:fiscal_year])
     if !fiscal_data.nil?
-#      authorize fiscal_data
+      authorize fiscal_data
       template = 'project_inform'
       render "user_notifier/mailer/#{template}", locals: { fiscal_data:fiscal_data }, layout: 'layouts/email'
     else

--- a/services/catarse/spec/policies/project_fiscal_data_policy_spec.rb
+++ b/services/catarse/spec/policies/project_fiscal_data_policy_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectFiscalDataPolicy do
+  subject { described_class }
+
+  shared_examples_for 'access permissions to fiscal_data' do
+    it 'denies access if user is nil' do
+      expect(subject).not_to permit(nil, ProjectFiscalData.new)
+    end
+
+    it 'denies access if user is not project_fiscal owner' do
+      expect(subject).not_to permit(User.new, ProjectFiscalData.new(user: User.new))
+    end
+
+    it 'permits access if user is project_fiscal owner' do
+      new_user = User.new
+      expect(subject).to permit(new_user, ProjectFiscalData.new(user: new_user))
+    end
+
+    it 'permits access if user is admin' do
+      admin = User.new
+      admin.admin = true
+      expect(subject).to permit(admin, ProjectFiscalData.new(user: User.new))
+    end
+  end
+
+  shared_examples_for 'access permissions to inform' do
+    it 'denies access if user is nil' do
+      expect(subject).not_to permit(nil, ProjectFiscalInform.new)
+    end
+
+    it 'denies access if user is not project_fiscal owner' do
+      expect(subject).not_to permit(User.new, ProjectFiscalInform.new(user: User.new))
+    end
+
+    it 'permits access if user is project_fiscal owner' do
+      new_user = User.new
+      expect(subject).to permit(new_user, ProjectFiscalInform.new(user: new_user))
+    end
+
+    it 'permits access if user is admin' do
+      admin = User.new
+      admin.admin = true
+      expect(subject).to permit(admin, ProjectFiscalInform.new(user: User.new))
+    end
+  end
+
+  permissions(:debit_note?) { it_behaves_like 'access permissions to fiscal_data' }
+
+  permissions(:inform?) { it_behaves_like 'access permissions to inform' }
+end


### PR DESCRIPTION
### Descrição
Havia um comentário na linha de autorização para informs, ela estava lá a 4 anos. Foi então adicionado a verificação de autorização no inform de rendimento antigo.

### Referência
https://www.notion.so/catarse/Fechar-informe-de-rendimentos-76dc575cbb1f44259541db58a40a86bd

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
