### PR TITLE
✨ Adiciona botão de desfazer cancelamento na assinatura.

### DIFF
--- a/services/catarse/app/models/common_wrapper.rb
+++ b/services/catarse/app/models/common_wrapper.rb
@@ -802,6 +802,26 @@ class CommonWrapper
     end
   end
 
+  def restore_subscription(resource)
+    @api_key = common_api_key
+    uri = services_endpoint[:payment_service]
+    uri.path = '/rpc/restore_subscription'
+    response = request(
+      uri.to_s,
+      body: {
+        id: resource.id
+      }.to_json,
+      action: :post,
+      current_ip: resource.user.current_sign_in_ip
+    ).run
+    if response.success?
+      json = ActiveSupport::JSON.decode(response.body)
+      return json.try(:[], 'id')
+    else
+      Rails.logger.info(response.body)
+    end
+  end
+
   def refund_subscription_payment(resource)
     @api_key = common_api_key
     uri = services_endpoint[:payment_service]

--- a/services/catarse/catarse.js/legacy/src/c/user-subscription-box-control.js
+++ b/services/catarse/catarse.js/legacy/src/c/user-subscription-box-control.js
@@ -13,8 +13,9 @@ const UserSubscriptionBoxControl = {
             isGeneratingSecondSlip,
             generateSecondSlip,
             showLastSubscriptionVersionEditionNextCharge,
+            restoreSubscription,
         } = attrs;
-        
+
         if (subscription.status === 'started') {
 
             if (subscription.last_payment_data.status === 'refused' && subscription.payment_method != 'boleto') {
@@ -47,14 +48,14 @@ const UserSubscriptionBoxControl = {
                             m('span.fa.fa-exclamation-triangle'),
                             ` O boleto de sua assinatura venceu dia ${h.momentify(subscription.boleto_expiration_date)}`,
                         ]),
-                        isGeneratingSecondSlip() ? 
+                        isGeneratingSecondSlip() ?
                             h.loader()
-                        : 
+                        :
                             m('button.btn.btn-inline.btn-small.w-button', {
                                 disabled: isGeneratingSecondSlip(),
                                 onclick: generateSecondSlip,
                             }, 'Gerar segunda via'),
-                            
+
                         m('button.btn-link.fontsize-smallest.link-hidden-light.u-margintop-10', {
                             onclick: () => { displayCancelModal.toggle(); },
                         }, 'Cancelar assinatura'),
@@ -68,7 +69,7 @@ const UserSubscriptionBoxControl = {
                         m(`a.btn.btn-inline.btn-small.w-button[target=_blank][href=${
                             subscription.boleto_url
                         }]`, 'Imprimir boleto'),
-        
+
                         m('button.btn-link.fontsize-smallest.link-hidden-light.u-margintop-10', {
                             onclick: () => { displayCancelModal.toggle(); },
                         }, 'Cancelar assinatura'),
@@ -85,9 +86,9 @@ const UserSubscriptionBoxControl = {
             } else {
                 return '';
             }
-        
+
         } else if (subscription.status === 'inactive') {
-        
+
             if (subscription.payment_status === 'pending' && subscription.boleto_url && subscription.boleto_expiration_date) {
                 return [
                     m('.card-alert.fontsize-smaller.fontweight-semibold.u-marginbottom-10.u-radius', [
@@ -112,7 +113,7 @@ const UserSubscriptionBoxControl = {
                     ),
                 ]
             }
-        
+
         } else if (subscription.status === 'canceled' && subscription.project.state == 'online') {
             return [
                 m('.card-error.fontsize-smaller.fontweight-semibold.u-marginbottom-10.u-radius', [
@@ -129,16 +130,19 @@ const UserSubscriptionBoxControl = {
                     'Assinar novamente'
                 ),
             ]
-        
+
         } else if (subscription.status === 'canceling') {
-            return m('.u-radius.fontsize-smaller.u-marginbottom-10.fontweight-semibold.card-error',
+            return [m('.u-radius.fontsize-smaller.u-marginbottom-10.fontweight-semibold.card-error',
                 m('div', [
                     m('span.fa.fa-exclamation-triangle', ' '),
                     ` Sua assinatura será cancelada no dia ${
                         h.momentify(subscription.next_charge_at, 'DD/MM/YYYY')
                     }. Até lá, ela ainda será considerada ativa.`,
-                ])
-            );
+                ])),
+                m('button.btn.btn-inline.btn-small.btn-terciary.w-button', {
+                    onclick: restoreSubscription,
+                }, 'Desfazer cancelamento')
+            ]
         } else if (subscription.status === 'active') {
             if (subscription.last_payment_data.status === 'refused') {
                 return [
@@ -164,7 +168,7 @@ const UserSubscriptionBoxControl = {
                     }, 'Cancelar assinatura'),
                 ]
             } else {
-        
+
                 if (subscription.payment_status !== 'pending') {
                     const editHref = `/projects/${subscription.project_external_id}/subscriptions/start?${subscription.reward_external_id ? `reward_id=${subscription.reward_external_id}` : ''}&subscription_id=${subscription.id}&subscription_status=${subscription.status}`;
                     return [
@@ -172,7 +176,7 @@ const UserSubscriptionBoxControl = {
                         m('a.btn.btn-terciary.btn-inline.w-button', {
                             href: editHref,
                         }, 'Editar assinatura'),
-                        
+
                         m('button.btn-link.fontsize-smallest.link-hidden-light.u-margintop-10', {
                             onclick: () => { displayCancelModal.toggle(); },
                         }, 'Cancelar assinatura'),
@@ -188,18 +192,18 @@ const UserSubscriptionBoxControl = {
                                     h.momentify(subscription.boleto_expiration_date)
                                 }`,
                             ]),
-                            isGeneratingSecondSlip() ? 
+                            isGeneratingSecondSlip() ?
                                 h.loader()
-                            : 
+                            :
                                 m('button.btn.btn-inline.btn-small.u-marginbottom-20.w-button', {
                                     disabled: isGeneratingSecondSlip( ),
                                     onclick: generateSecondSlip,
                                 }, 'Gerar segunda via'),
-                            
+
                             m('button.btn-link.fontsize-smallest.link-hidden-light', {
                                 onclick: () => { displayCancelModal.toggle(); },
                             }, 'Cancelar assinatura'),
-                        ]                
+                        ]
                     } else {
                         return [
                             showLastSubscriptionVersionEditionNextCharge(),

--- a/services/catarse/catarse.js/legacy/src/models.js
+++ b/services/catarse/catarse.js/legacy/src/models.js
@@ -23,6 +23,7 @@ const models = {
     projectSubscriber: commonProject.model('subscribers'),
     commonPayment: commonPayment.model('rpc/pay'),
     cancelSubscription: commonPayment.model('rpc/cancel_subscription'),
+    restoreSubscription: commonPayment.model('rpc/restore_subscription'),
     commonPaymentInfo: commonPayment.model('rpc/payment_info'),
     commonPayments: commonPayment.model('payments'),
     subscriptionsPerMonth: commonPayment.model('subscriptions_per_month'),

--- a/services/service-core-db/migrations/2022-02-08-121359_add_restore_subscriptions_function/down.sql
+++ b/services/service-core-db/migrations/2022-02-08-121359_add_restore_subscriptions_function/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+drop function payment_service_api.restore_subscription(id uuid);

--- a/services/service-core-db/migrations/2022-02-08-121359_add_restore_subscriptions_function/up.sql
+++ b/services/service-core-db/migrations/2022-02-08-121359_add_restore_subscriptions_function/up.sql
@@ -1,0 +1,35 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION payment_service_api.restore_subscription(id uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _subscription payment_service.subscriptions;
+            _result json;
+        begin
+            -- ensure that roles come from any permitted
+            perform core.force_any_of_roles('{platform_user,scoped_user}');
+
+            select * from payment_service.subscriptions s
+                where core.is_owner_or_admin(s.user_id)
+                    and s.id = $1
+                    and s.platform_id = core.current_platform_id()
+                into _subscription;
+
+            if _subscription.id is null then
+                raise 'subscription not found';
+            end if;
+
+            if _subscription.status <> 'canceling' then
+                raise 'subscription is not in canceling';
+            end if;
+
+            perform payment_service.transition_to(_subscription, 'active', row_to_json(_subscription.*));
+
+            select json_build_object(
+            'id', _subscription.id,
+            'status', _subscription.status
+            ) into _result;
+            return _result;
+        end;
+    $function$;


### PR DESCRIPTION
### Descrição
Ajuste do QA: Ao verificar o comportamento em navegadores firefox, foi capturado um erro após o envio da requisição. 

Foi adicionado uma função para atualizar uma subscription para 'active' quando ela ainda está em 'canceling'. Além de um botão que o usuário pode clicar. 

### Referência
https://www.notion.so/catarse/Op-o-para-usu-rios-e-admins-cancelarem-o-cancelamento-de-assinaturas-4c311ef13be0414fa4e1cd61230a48d5

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
