### PR TITLE
✨ Impede parcelamento de assinaturas

### DIFF
--- a/services/catarse/app/models/billing/payment.rb
+++ b/services/catarse/app/models/billing/payment.rb
@@ -31,6 +31,7 @@ module Billing
 
     validates :installments_count, numericality: { greater_than: 0 }, if: :credit_card?
     validates :installments_count, numericality: { equal_to: 1 }, unless: :credit_card?
+    validate :items_allows_installment, if: :installment?
 
     validate :total_amount_represents_the_sum_of_amount_and_fees
     validate :credit_card_owner_matches_user, if: :credit_card?
@@ -60,6 +61,12 @@ module Billing
       return if credit_card.blank? || user_id == credit_card.user_id
 
       errors.add(:credit_card_id, I18n.t('models.billing.payment.errors.invalid_credit_card'))
+    end
+
+    def items_allows_installment
+      return if items.all?(&:allows_installment?)
+
+      errors.add(:items, I18n.t('models.billing.payment.errors.has_items_that_cannot_be_paid_in_installments'))
     end
   end
 end

--- a/services/catarse/app/models/billing/payment_item.rb
+++ b/services/catarse/app/models/billing/payment_item.rb
@@ -34,6 +34,10 @@ module Billing
       payable_type == 'Contribution'
     end
 
+    def allows_installment?
+      %w[Contribution].include? payable_type
+    end
+
     private
 
     def payment_user_matches_payable_user

--- a/services/catarse/config/locales/billing.en.yml
+++ b/services/catarse/config/locales/billing.en.yml
@@ -8,6 +8,7 @@ en:
         errors:
           invalid_total_amount: "doesn't match other values"
           invalid_credit_card: "credit card owner doesn't match user"
+          has_items_that_cannot_be_paid_in_installments: "has items that cannot be paid in installments"
       payment_item:
         errors:
           invalid_user: "payment user doesn't match payable user"

--- a/services/catarse/config/locales/billing.pt.yml
+++ b/services/catarse/config/locales/billing.pt.yml
@@ -8,6 +8,7 @@ pt:
         errors:
           invalid_total_amount: "incompatível com os outros valores"
           invalid_credit_card: "usuário do cartão de credito não corresponde ao do pagamento"
+          has_items_that_cannot_be_paid_in_installments: "contém um ou mais items que não podem ser parcelados"
       payment_item:
         errors:
           invalid_user: "usuário de pagamento não corresponde ao usuário do pagavel"

--- a/services/catarse/spec/models/billing/payment_spec.rb
+++ b/services/catarse/spec/models/billing/payment_spec.rb
@@ -119,6 +119,27 @@ RSpec.describe Billing::Payment, type: :model do
         expect(payment.errors[:credit_card_id]).to include error_message
       end
     end
+
+    context 'when pay in installment items that cannot be paid in installment' do
+      subject(:payment) { build(:billing_payment, :credit_card, :subscription, installments_count: 2) }
+
+      it 'adds error message to items' do
+        payment.valid?
+
+        error_message = I18n.t('models.billing.payment.errors.has_items_that_cannot_be_paid_in_installments')
+        expect(payment.errors[:items]).to include error_message
+      end
+    end
+
+    context 'when pay in installment items that can be paid in installment' do
+      subject(:payment) { build(:billing_payment, :credit_card, :contribution, installments_count: 2) }
+
+      it 'doesn`t add error to items' do
+        payment.valid?
+
+        expect(payment.errors[:items]).to be_empty
+      end
+    end
   end
 
   describe 'Delegations' do


### PR DESCRIPTION
### Descrição
Impede que pagamentos que contenham assinaturas sejam parcelados.

### Referência
https://www.notion.so/catarse/Validar-que-parcelamento-s-pode-ser-realizado-em-pagamentos-pontuais-e-n-o-em-assinaturas-065f44d4326d45f5aa0a09305f1071ca

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
