### PR TITLE
🐞 Corrige rotina para encontrar projetos e gerar projec_fiscals.

### DIFF
--- a/services/catarse/lib/tasks/cron.rake
+++ b/services/catarse/lib/tasks/cron.rake
@@ -244,11 +244,21 @@ namespace :cron do
       .where("project_fiscals.end_date > ?", Time.zone.now - 2.months).each do |project|
         CreateProjectFiscalToProjectFlexAndAonAction.new(project_id: project.id).call
     end
+
+    Project.left_outer_joins(:project_fiscals).where('project_fiscals.id IS NULL')
+      .where(mode: %i[aon flex], state: %i[waiting_funds successful]).each do |project|
+      CreateProjectFiscalToProjectFlexAndAonAction.new(project_id: project.id).call
+    end
   end
 
   desc 'create project fiscal to project sub'
   task create_project_fiscal_to_project_sub: :environment do
     Project.where(mode: %i[sub], state: %i[online]).each do |project|
+      CreateProjectFiscalToProjectSubAction.new(project_id: project.id, month: Time.zone.now.month, year: Time.zone.now.year).call
+    end
+
+    Project.left_outer_joins(:project_fiscals).where('project_fiscals.id IS NULL')
+      .where(mode: %i[sub], state: %i[successful]).each do |project|
       CreateProjectFiscalToProjectSubAction.new(project_id: project.id, month: Time.zone.now.month, year: Time.zone.now.year).call
     end
 


### PR DESCRIPTION
### Descrição
Atualmente a task de geração de nota fiscal só engloba projetos que tenham project_fiscal. A solução é adicionar uma query para projetos que não tiveram project_fiscals gerados. 

### Referência
https://www.notion.so/catarse/Corrigir-rake-task-de-gera-o-de-project-fiscal-3bd28e4d724b43a28bd919a781ca93b6

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
