### PR TITLE
✨ Adiciona link no frontend atual para dados fiscais.

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-dashboard-menu.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-dashboard-menu.js
@@ -136,7 +136,7 @@ const projectDashboardMenu = {
                                             m('span.fa.fa.fa-check-square-o.fa-lg.fa-fw'), window.I18n.t('surveys_tab', I18nScope())
                                         ])),
 
-                                    m(`a#dashboard_fiscal_link[class="dashboard-nav-link-left ${h.locationActionMatch('fiscal') ? 'selected' : ''}"][href="${projectRoute}/fiscal"]`, {
+                                    m(`a#dashboard_fiscal_link[class="dashboard-nav-link-left ${h.locationActionMatch('fiscal') ? 'selected' : ''}"][href="${projectRoute}/project_fiscal"]`, {
                                         oncreate: m.route.link
                                     }, [
                                         m('span.fa.fa.fa-book.fa-lg.fa-fw'), window.I18n.t('fiscal_tab', I18nScope())


### PR DESCRIPTION
### Descrição
Atualmente é possível acessar os novos dados fiscal apenas pela url, agora será substituída o link antigo pelo atual.

### Referência
https://www.notion.so/catarse/Adicionar-os-dados-fiscais-no-front-end-atual-5a4d92368bdb4710a31f3b6ad1e81fda

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
