### PR TITLE
🐞 Adiciona autorização para visualizar o informe.

### DIFF
--- a/services/catarse/app/controllers/projects/project_fiscal_data_controller.rb
+++ b/services/catarse/app/controllers/projects/project_fiscal_data_controller.rb
@@ -21,7 +21,7 @@ class Projects::ProjectFiscalDataController < ApplicationController
   def inform
     fiscal_data = ProjectFiscalInform.find_by(project_id: params[:project_id], fiscal_year: params[:fiscal_year])
     if !fiscal_data.nil?
-#      authorize fiscal_data
+      authorize fiscal_data
       template = 'project_inform'
       render "user_notifier/mailer/#{template}", locals: { fiscal_data:fiscal_data }, layout: 'layouts/email'
     else

--- a/services/catarse/app/policies/project_fiscal_inform_policy.rb
+++ b/services/catarse/app/policies/project_fiscal_inform_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class ProjectFiscalDataPolicy < ApplicationPolicy
-  def debit_note?
+class ProjectFiscalInformPolicy < ApplicationPolicy
+  def inform?
     done_by_owner_or_admin?
   end
 end

--- a/services/catarse/spec/controllers/projects/project_fiscal_data_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects/project_fiscal_data_controller_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Projects::ProjectFiscalDataController, type: :controller do
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe 'GET /inform' do
+    context 'when inform not exist' do
+      before do
+        get :inform, params: { project_id: project.id, fiscal_year: project.created_at.year.to_s }
+      end
+
+      let(:project) { create(:project) }
+      let(:user) {  project.user }
+
+      it { is_expected.to redirect_to edit_project_path(project.id, locale: nil) }
+    end
+
+    context 'when inform exist and user isn`t not project owner' do
+      let(:project) { create(:project) }
+      let(:user) { create(:user) }
+      let(:inform) { ProjectFiscalInform.new(user_id: project.user_id, project_id: project.id) }
+
+      before do
+        allow(ProjectFiscalInform).to receive(:find_by).with(
+          project_id: project.id.to_s, fiscal_year: project.created_at.year.to_s
+        ).and_return(inform)
+        get :inform, params: { project_id: project.id, fiscal_year: project.created_at.year.to_s }
+      end
+
+      it { is_expected.to redirect_to root_path }
+    end
+
+    context 'when inform exist and user is admin' do
+      let(:project) { create(:project) }
+      let(:user) { build(:user, admin: true) }
+      let(:inform) { ProjectFiscalInform.new(user_id: project.user_id, project_id: project.id) }
+
+      before do
+        allow(ProjectFiscalInform).to receive(:find_by).with(
+          project_id: project.id.to_s, fiscal_year: project.created_at.year.to_s
+        ).and_return(inform)
+        get :inform, params: { project_id: project.id, fiscal_year: project.created_at.year.to_s }
+      end
+
+      it { is_expected.to render_template('user_notifier/mailer/project_inform') }
+    end
+
+    context 'when inform and user is project owner' do
+      let(:project) { create(:project) }
+      let(:user) {  project.user }
+      let(:inform) { ProjectFiscalInform.new(user_id: project.user_id, project_id: project.id) }
+
+      before do
+        allow(ProjectFiscalInform).to receive(:find_by).with(
+          project_id: project.id.to_s, fiscal_year: project.created_at.year.to_s
+        ).and_return(inform)
+        get :inform, params: { project_id: project.id, fiscal_year: project.created_at.year.to_s }
+      end
+
+      it { is_expected.to render_template('user_notifier/mailer/project_inform') }
+    end
+  end
+end

--- a/services/catarse/spec/policies/project_fiscal_data_policy_spec.rb
+++ b/services/catarse/spec/policies/project_fiscal_data_policy_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectFiscalDataPolicy do
+  subject { described_class }
+
+  shared_examples_for 'access permissions to fiscal_data' do
+    it 'denies access if user is nil' do
+      expect(subject).not_to permit(nil, ProjectFiscalData.new)
+    end
+
+    it 'denies access if user is not project_fiscal owner' do
+      expect(subject).not_to permit(User.new, ProjectFiscalData.new(user: User.new))
+    end
+
+    it 'permits access if user is project_fiscal owner' do
+      new_user = User.new
+      expect(subject).to permit(new_user, ProjectFiscalData.new(user: new_user))
+    end
+
+    it 'permits access if user is admin' do
+      admin = User.new
+      admin.admin = true
+      expect(subject).to permit(admin, ProjectFiscalData.new(user: User.new))
+    end
+  end
+
+  permissions(:debit_note?) { it_behaves_like 'access permissions to fiscal_data' }
+end

--- a/services/catarse/spec/policies/project_fiscal_inform_policy_spec.rb
+++ b/services/catarse/spec/policies/project_fiscal_inform_policy_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectFiscalInformPolicy do
+  subject { described_class }
+
+  shared_examples_for 'access permissions to inform' do
+    it 'denies access if user is nil' do
+      expect(subject).not_to permit(nil, ProjectFiscalInform.new)
+    end
+
+    it 'denies access if user is not project_fiscal owner' do
+      expect(subject).not_to permit(User.new, ProjectFiscalInform.new(user: User.new))
+    end
+
+    it 'permits access if user is project_fiscal owner' do
+      new_user = User.new
+      expect(subject).to permit(new_user, ProjectFiscalInform.new(user: new_user))
+    end
+
+    it 'permits access if user is admin' do
+      admin = User.new
+      admin.admin = true
+      expect(subject).to permit(admin, ProjectFiscalInform.new(user: User.new))
+    end
+  end
+
+  permissions(:inform?) { it_behaves_like 'access permissions to inform' }
+end


### PR DESCRIPTION
### Descrição
Ajuste no QA: criar nova policy para ProjectFiscalInforml.

Havia um comentário na linha de autorização para informs, ela estava lá a 4 anos. Foi então adicionado a verificação de autorização no inform de rendimento antigo.

### Referência
https://www.notion.so/catarse/Fechar-informe-de-rendimentos-76dc575cbb1f44259541db58a40a86bd

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
