### PR TITLE
🐞 Ajusta consulta por ano no inform fiscal

### DIFF
--- a/services/catarse/spec/controllers/projects/project_fiscal_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects/project_fiscal_controller_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Projects::ProjectFiscalController, type: :controller do
       let(:project) { create(:project) }
       let(:user) { build(:user, admin: true) }
       let!(:project_fiscal_2) do
-        create(:project_fiscal, project: project, end_date: 1.year.from_now)
+        create(:project_fiscal, project: project, end_date: Time.zone.now.prev_year)
       end
 
       before do
@@ -202,7 +202,7 @@ RSpec.describe Projects::ProjectFiscalController, type: :controller do
       let(:project) { create(:project) }
       let(:user) { project.user }
       let!(:project_fiscal_2) do
-        create(:project_fiscal, user: user, project: project, end_date: 1.year.from_now)
+        create(:project_fiscal, user: user, project: project, end_date: Time.zone.now.prev_year)
       end
 
       before do


### PR DESCRIPTION
### Descrição
Ajusta a data de corte para listar os anos do informe de rendimento, antes não mostrava nenhum por causa do corte ser sempre comparado com o ano atual YEAR < CURRENT_YEAR

### Referência
[Link para a atividade](https://www.notion.so/catarse/Ajustes-no-corte-de-data-do-informe-de-rendimento-13b11288a93e47519ba4eaa6af5b60e5)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
