### PR TITLE
🐞 Adequa a aba de Dados Cadastrais para opções de privacidade

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_finish.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/invalid_finish.html.slim
@@ -11,10 +11,10 @@ br/
 | O(s) erro(s) pode(m) ter acontecido <strong>por algum(s) dos motivos abaixo</strong>:
 br/
 br/
-| - Se algum dos dados financeiros (<i>Nome / CPF / data de nascimento ou Razão social / CNPJ,  Banco, Agência, conta ou dígitos</i>) estiver incorreto ou em branco. Você pode verificar e alterar essas informações na aba <strong>#{link_to 'Dados cadastrais', edit_url, target: 'blank'}</strong>
+| - Se algum dos dados financeiros (<i>Nome / CPF / data de nascimento ou Razão social / CNPJ,  Banco, Agência, conta ou dígitos</i>) estiver incorreto ou em branco. Você pode verificar e alterar essas informações na aba <strong>#{link_to 'Dados e Privacidade', edit_url, target: 'blank'}</strong>
 br/
 br/
-| - Se algum dos dados de endereço (país, rua, número, bairro, cidade, estado, CEP ou telefone) estiver incorreto ou em branco. Você pode verificar e alterar essas informações na aba <strong>#{link_to 'Dados cadastrais', edit_url, target: 'blank'}</strong>.
+| - Se algum dos dados de endereço (país, rua, número, bairro, cidade, estado, CEP ou telefone) estiver incorreto ou em branco. Você pode verificar e alterar essas informações na aba <strong>#{link_to 'Dados e Privacidade', edit_url, target: 'blank'}</strong>.
 br/
 br/
 | - Se existir uma ou mais recompensas com o prazo de entrega menor que a data do fim do projeto. Para alterá-la, você precisará enviar uma novidade para os seus apoiadores avisando sobre a mudança da data de entrega e pedir a alteração deste campo para a equipe do Catarse, através do email #{mail_to CatarseSettings[:email_contact]}.

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_settings.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/new_user_settings.html.slim
@@ -16,7 +16,7 @@ br/
 | Nessa aba estamos reunindo as informações que você disponibilizou para todos os usuários. Ali estão seu <strong>email de contato</strong>, seu <strong>nome público</strong> (ou nome artístico), <strong>imagem do perfil, perfis de redes sociais</strong> e <strong>outros links</strong> e informações que você decidiu compartilhar.
 br/
 br/
-| <strong>Dados cadastrais</strong> (antiga aba “<strong>Conta</strong>”)
+| <strong>Dados e Privacidade</strong> (antiga aba “<strong>Dados Cadastrais</strong>”)
 br/
 | Nessa aba reunimos os seus dados de cadastro. Eles indicam quem é pessoa responsável por <strong>esse perfil</strong>, pelo <strong>recebimento do dinheiro</strong>, pela <strong>execução do projeto</strong> e <strong>entrega de recompensas</strong> (caso aplicável). Além dessas informações, é aí que você poderá visualizar <strong>os dados bancários</strong> que você cadastrou e o seu <strong>endereço</strong>, para onde será emitida a Nota Fiscal.
 br/
@@ -24,14 +24,14 @@ br/
 |<strong>2. Passamos a aceitar conta poupança</strong>
 br/
 br/
-| Passamos a aceitar além de conta corrente, a <strong>conta poupança</strong>! Caso você tenha uma conta poupança (que esteja no mesmo Nome completo/Razão Social) e prefira que a transferência seja feita para ela, você pode fazer essa alteração entrando na aba <strong>#{settings_link.call("Dados Cadastrais")}</strong>, dentro do dashboard do seu projeto.
+| Passamos a aceitar além de conta corrente, a <strong>conta poupança</strong>! Caso você tenha uma conta poupança (que esteja no mesmo Nome completo/Razão Social) e prefira que a transferência seja feita para ela, você pode fazer essa alteração entrando na aba <strong>#{settings_link.call("Dados e Privacidade")}</strong>, dentro do dashboard do seu projeto.
 br/
 br/
 - if ispf
   | <strong>3. [Ação necessária] Mais segurança</strong>
   br/
   br/
-  | Estamos implementando um novo protocolo de segurança e por isso, passamos a pedir também a sua <strong>data de nascimento</strong>. Como esse campo ainda não existia, <strong>precisamos que você preencha o quanto antes essa informação!</strong> Você pode fazer isso através da aba #{settings_link.call("Dados Cadastrais")}.
+  | Estamos implementando um novo protocolo de segurança e por isso, passamos a pedir também a sua <strong>data de nascimento</strong>. Como esse campo ainda não existia, <strong>precisamos que você preencha o quanto antes essa informação!</strong> Você pode fazer isso através da aba #{settings_link.call("Dados e Privacidade")}.
   br/
   br/
 | <strong>Importante:</strong> É possível que antes da reorganização de dados, existisse alguma diferença entre as informações bancárias (que você informou na antiga aba Conta) e as informações do seu perfil, uma vez que esses dados eram pedidos em momentos diferentes. Para esses casos, priorizamos os dados que foram preenchidos aba Conta, uma vez que eles indicam quem irá receber o dinheiro - caso o projeto seja financiado - e também quem é o responsável legal pela campanha. Se você notar alguma inconsistência nestes dados, por favor nos avise <strong>até o dia 17/03</strong>. Depois dessa data esses dados não poderão mais ser modificados

--- a/services/catarse/catarse.js/legacy/src/c/user-about-edit.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/user-about-edit.tsx
@@ -12,14 +12,11 @@ import textEditor from '../shared/components/text-editor';
 import { getUserDetailsWithUserId } from '../shared/services/user/get-updated-current-user';
 
 const userAboutEdit = {
-    oninit: function(vnode) {
+    oninit: function(vnode) {        
         let parsedErrors = userAboutVM.mapRailsErrors(railsErrorsVM.railsErrors());
-        let deleteUser;
         const userId = vnode.attrs.userId;
         const user = vnode.attrs.user || {},
             fields = {
-                password: prop(''),
-                current_password: prop(''),
                 uploaded_image: prop(userVM.displayImage(user)),
                 cover_image: prop(user.profile_cover_image || ''),
                 email: prop(''),
@@ -100,8 +97,6 @@ const userAboutEdit = {
 
             updateUser = () => {
                 const userData = {
-                    current_password: fields.current_password(),
-                    password: fields.password(),
                     email: fields.email(),
                     permalink: fields.permalink(),
                     public_name: fields.public_name(),
@@ -169,31 +164,10 @@ const userAboutEdit = {
                 }
                 return !emailHasError();
             },
-            validatePassword = () => {
-                const pass = String(fields.password());
-                if (pass.length > 0 && pass.length <= 5) {
-                    passwordHasError(true);
-                }
-
-                return !passwordHasError();
-            },
-            setDeleteForm = (localVnode) => {
-                deleteUser = () => localVnode.dom.submit();
-            },
-            deleteAccount = () => {
-                if (window.confirm('Tem certeza que deseja desativar a sua conta?')) {
-                    deleteUser();
-                }
-
-                return false;
-            },
             onSubmit = (e) => {
                 e.preventDefault();
                 if (!validateEmailConfirmation()) {
                     errors('Confirmação de email está incorreta.');
-                    showError(true);
-                } else if (!validatePassword()) {
-                    errors('Nova senha está incorreta.');
                     showError(true);
                 } else {
                     updateUser();
@@ -219,9 +193,6 @@ const userAboutEdit = {
             showEmailForm,
             validateEmailConfirmation,
             passwordHasError,
-            validatePassword,
-            deleteAccount,
-            setDeleteForm,
             parsedErrors
         };
     },
@@ -486,68 +457,7 @@ const userAboutEdit = {
                                             ])
                                         ])
                                     ])
-                                ),
-                                (attrs.hidePasswordChange ? '' : m('.w-form.card.card-terciary.u-marginbottom-30',
-                                    m('.w-row.u-marginbottom-10', [
-                                        m('.fontsize-base.fontweight-semibold',
-                                            'Alterar minha senha'
-                                        ),
-                                        m('.fontsize-small.u-marginbottom-20',
-                                            'Para que a senha seja alterada você precisa confirmar a sua senha atual.'
-                                        ),
-                                        m('.w-row.u-marginbottom-20', [
-                                            m('.w-col.w-col-6.w-sub-col', [
-                                                m('label.field-label.fontweight-semibold',
-                                                    ' Senha atual'
-                                                ),
-                                                m('input.password.optional.w-input.text-field.w-input.text-field.positive[id=\'user_current_password\'][name=\'user[current_password]\'][type=\'password\']', {
-                                                    value: fields.current_password(),
-                                                    onchange: m.withAttr('value', fields.current_password)
-                                                })
-                                            ]),
-                                            m('.w-col.w-col-6', [
-                                                m('label.field-label.fontweight-semibold',
-                                                    ' Nova senha'
-                                                ),
-                                                m('input.password.optional.w-input.text-field.w-input.text-field.positive[id=\'user_password\'][name=\'user[password]\'][type=\'password\']', {
-                                                    class: state.passwordHasError() ? 'error' : '',
-                                                    value: fields.password(),
-                                                    onfocus: () => state.passwordHasError(false),
-                                                    onblur: state.validatePassword,
-                                                    onchange: m.withAttr('value', fields.password)
-                                                }), !state.passwordHasError() ? '' : m(inlineError, {
-                                                    message: 'A sua nova senha deve ter no mínimo 6 caracteres.'
-                                                })
-                                            ])
-                                        ]),
-
-                                    ])
-                                )),
-                                (!user.is_admin && (attrs.hideDisableAcc || user.total_published_projects > 0) ? '' : m('.w-form.card.card-terciary.u-marginbottom-30',
-                                    m('.w-row.u-marginbottom-10', [
-                                        m('.fontweight-semibold.fontsize-smaller',
-                                            'Desativar minha conta'
-                                        ),
-                                        m('.fontsize-smallest',
-                                            'Todos os seus apoios serão convertidos em apoios anônimos, seus dados não serão mais visíveis, você sairá automaticamente do sistema e sua conta será desativada permanentemente.'
-                                        ),
-                                        m(`a.alt-link.fontsize-smaller[href='/${window.I18n.locale}/users/${user.id}'][rel='nofollow']`, {
-                                            onclick: state.deleteAccount
-                                        },
-                                            'Desativar minha conta no Catarse'
-                                        ),
-                                        m('form.w-hidden', {
-                                            action: `/${window.I18n.locale}/users/${user.id}`,
-                                            method: 'post',
-                                            oncreate: state.setDeleteForm
-                                        }, [
-                                            m(`input[name='authenticity_token'][type='hidden'][value='${h.authenticityToken()}']`),
-                                            m('input[name=\'_method\'][type=\'hidden\'][value=\'delete\']')
-                                        ])
-
-                                    ])
-                                ))
-
+                                )
                             ])
                         )
                     ),

--- a/services/catarse/catarse.js/legacy/src/c/user-dropdown-profile-menu.tsx
+++ b/services/catarse/catarse.js/legacy/src/c/user-dropdown-profile-menu.tsx
@@ -110,7 +110,7 @@ function createMenusItems(user: { id: number }, balance: number) {
             url: `/users/${user.id}/edit#notifications`
         },
         {
-            label: 'Dados cadastrais',
+            label: 'Dados e Privacidade',
             url: `/users/${user.id}/edit#settings`
         }
     ]

--- a/services/catarse/catarse.js/legacy/src/c/user-settings-change-password.js
+++ b/services/catarse/catarse.js/legacy/src/c/user-settings-change-password.js
@@ -1,0 +1,47 @@
+import m from 'mithril';
+import _ from 'underscore';
+import bigCard from './big-card';
+import h from '../h';
+
+const I18nScope = _.partial(h.i18nScope, 'users.edit.settings_tab.change_password');
+
+const userSettingsChangePassword = {
+    view: function({attrs}) 
+    {
+        const fields = attrs.fields(),
+              parsedErrors = attrs.parsedErrors;
+        
+        return m(bigCard, 
+            {
+                label: window.I18n.t('title', I18nScope()),
+                label_hint: window.I18n.t('subtitle', I18nScope()),
+                children: [                
+                    m('.divider.u-marginbottom-20'),  
+                    m('.w-row',
+                        m('.w-col.w-col-6.w-sub-col', [
+                            m('label.field-label.fontweight-semibold', window.I18n.t('current_label', I18nScope())),
+                            m('input.password.optional.w-input.text-field.w-input.text-field.positive[id=\'user_current_password\'][name=\'user[current_password]\'][type=\'password\']', {
+                                class: parsedErrors.hasError('current_password') ? 'error' : false,
+                                value: fields.current_password(),
+                                onchange: m.withAttr('value', fields.current_password)
+                            }),
+                            parsedErrors.inlineError('current_password')
+                        ]),
+                        m('.w-col.w-col-6', [
+                            m('label.field-label.fontweight-semibold', window.I18n.t('new_label', I18nScope())),
+                            m('input.password.optional.w-input.text-field.w-input.text-field.positive[id=\'user_password\'][name=\'user[password]\'][type=\'password\']', {
+                                class: parsedErrors.hasError('password') ? 'error' : false,
+                                value: fields.password(),
+                                onchange: m.withAttr('value', fields.password)
+                            }),
+                            parsedErrors.inlineError('password')
+                        ])
+                    )
+                    
+                ]
+            });
+        
+    }
+};
+
+export default userSettingsChangePassword;

--- a/services/catarse/catarse.js/legacy/src/c/user-settings-delete-account.js
+++ b/services/catarse/catarse.js/legacy/src/c/user-settings-delete-account.js
@@ -1,0 +1,39 @@
+import m from 'mithril';
+import _ from 'underscore';
+import bigCard from './big-card';
+import h from '../h';
+
+const I18nScope = _.partial(h.i18nScope, 'users.edit.settings_tab.delete_account');
+
+const userSettingsDeleteAccount = {
+    view: function({attrs})
+    {
+        const userId = attrs.idUser();
+
+        return m(bigCard, {
+            label: window.I18n.t('title', I18nScope()),
+            label_hint: window.I18n.t('subtitle', I18nScope()),
+            children: [
+                m('.divider.u-marginbottom-20'),                 
+                m('.w-row', [
+                    m(`a.alt-link.fontsize-smaller[href='/${window.I18n.locale}/users/${userId}'][rel='nofollow']`, {
+                        onclick: attrs.deleteAccount
+                    },
+                        window.I18n.t('label', I18nScope())
+                    ),
+                    m('form.w-hidden', {
+                        action: `/${window.I18n.locale}/users/${userId}`,
+                        method: 'post',
+                        oncreate: attrs.setDeleteForm                        
+                    }, [
+                        m(`input[name='authenticity_token'][type='hidden'][value='${h.authenticityToken()}']`),
+                        m('input[name=\'_method\'][type=\'hidden\'][value=\'delete\']')
+                    ])
+
+                ])
+            ]   
+        });
+    }
+};
+
+export default userSettingsDeleteAccount;

--- a/services/catarse/catarse.js/legacy/src/root/users/edit/index.js
+++ b/services/catarse/catarse.js/legacy/src/root/users/edit/index.js
@@ -93,7 +93,7 @@ const usersEdit = {
                                 'Perfil Público'
                             ),
                             m(`a.dashboard-nav-link${(state.hash() === '#settings' ? '.selected' : '')}[data-target='#dashboard_settings'][href='#settings'][id='dashboard_settings_link']`,
-                                'Dados cadastrais'
+                                'Dados e Privacidade'
                             ),
                             m(`a.dashboard-nav-link${(state.hash() === '#notifications' ? '.selected' : '')}[data-target='#dashboard_notifications'][href='#notifications'][id='dashboard_notifications_link']`,
                                 'Notificações'

--- a/services/catarse/catarse.js/legacy/src/vms/user-about-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/user-about-vm.js
@@ -8,8 +8,6 @@ import generateErrorInstance from '../error';
 const e = generateErrorInstance();
 
 const fields = {
-    password: prop(''),
-    current_password: prop(''),
     uploaded_image: prop(''),
     cover_image: prop(''),
     email: prop(''),

--- a/services/catarse/catarse.js/legacy/src/vms/user-settings-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/user-settings-vm.js
@@ -28,7 +28,9 @@ const fields = {
     state_inscription: prop(''),
     birth_date: prop(''),
     account_type: prop(''),
-    bank_account_type: prop('')
+    bank_account_type: prop(''),
+    password: prop(''),
+    current_password: prop('')
 };
 
 const mapRailsErrors = (rails_errors) => {
@@ -67,6 +69,8 @@ const mapRailsErrors = (rails_errors) => {
     extractAndSetErrorMsg('bank_id', ['user.bank_account.bank', 'bank_account.bank']);
     extractAndSetErrorMsg('birth_date', ['user.birth_date', 'birth_date']);
     extractAndSetErrorMsg('account_type', ['user.account_type', 'account_type']);
+    extractAndSetErrorMsg('password', ['user.password', 'password']);
+    extractAndSetErrorMsg('current_password', ['user.current_password', 'current_password']);
 
     return e;
 };

--- a/services/catarse/config/locales/catarse_bootstrap/views/projects/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/projects/edit.pt.yml
@@ -251,7 +251,7 @@ pt:
       publish: Continuar
     dashboard_nav_links:
       preview_tab: Preview
-      account_tab: Dados cadastrais
+      account_tab: Dados e Privacidade
       basics_tab: Básico
       goal_tab: Financiamento
       goals_tab: Metas

--- a/services/catarse/config/locales/catarse_bootstrap/views/shared/menus.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/shared/menus.pt.yml
@@ -4,7 +4,7 @@ pt:
       user:
         find_friends: 'Encontrar amigos'
         about: 'Perfil Público'
-        access_address: 'Dados cadastrais'
+        access_address: 'Dados e Privacidade'
         activity: 'Atividade'
         banking: 'Banco e cartões'
         contributions_history: 'Meu histórico'

--- a/services/catarse/config/locales/catarse_bootstrap/views/users/edit.pt.yml
+++ b/services/catarse/config/locales/catarse_bootstrap/views/users/edit.pt.yml
@@ -5,7 +5,7 @@ pt:
         contributions: 'Apoiados'
         projects: 'Criados'
         about_me: 'Perfil público'
-        settings: 'Dados cadastrais'
+        settings: 'Dados e Privacidade'
         contributions: 'Apoiados'
         notifications: 'Notificações'
         balance: 'Saldo'
@@ -19,6 +19,16 @@ pt:
         update_success_msg: 'As suas informações foram atualizadas'
         legal_title: 'Responsável'
         legal_subtitle: '<strong>IMPORTANTE</strong> Nome completo/Razão social e CPF/CNPJ <strong>não poderão ser modificados</strong> após serem salvos.'
+        change_password:
+          title: 'Alterar Senha'
+          subtitle: 'Para que a senha seja alterada você precisa confirmar a sua senha atual.'
+          current_label: 'Senha atual'
+          new_label: 'Nova senha'
+        delete_account:
+          title: 'Desativar minha conta'
+          subtitle: 'Todos os seus apoios serão convertidos em apoios anônimos, seus dados não serão mais visíveis, você sairá automaticamente do sistema e sua conta será desativada permanentemente.'
+          label: 'Desativar minha conta no Catarse'
+          confirmation: 'Tem certeza que deseja desativar a sua conta?'
         account_types:
           pf: 'Pessoa Física'
           pj: 'Pessoa Jurídica'


### PR DESCRIPTION
### Descrição
A aba de `Dados Cadastrais` irá receber opções de privacidade. Essa alteração adequa a aba para receber essas opções, além de trazer alguns campos da aba `Perfil Público` para maior coerência.

### Referência
https://www.notion.so/catarse/Adequar-aba-de-Dados-cadastrais-para-abranger-op-es-de-privacidade-5dd80e539f55432b9b94d22462cb53e8

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
