### PR TITLE
Melhora o copy do painel de controle de projetos de assinatura

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-insights-sub.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-insights-sub.js
@@ -175,13 +175,13 @@ const projectInsightsSub = {
                         ]),
                         m('.card.card-terciary.flex-column.u-marginbottom-10.u-radius', [
                             m('.fontsize-small.u-marginbottom-10',
-                                'Receita Mensal'
+                                'Arrecadação Mensal Potencial'
                             ),
                             m('.fontsize-largest.fontweight-semibold.u-marginbottom-10',
                                 `R$${h.formatNumber(subscribersDetails.amount_paid_for_valid_period, 2, 3)}`
                             ),
                             m('.fontsize-mini.fontcolor-secondary.lineheight-tighter',
-                                'Com base nas assinaturas ativas que você possui hoje (taxas já descontadas).'
+                                'Com base nas assinaturas ativas que você possui hoje (sem descontar taxas e sem considerar perdas com pagamentos que não serão bem-sucedidos).'
                             )
                         ]),
                         m('.card.flex-column.u-marginbottom-10.u-radius', [
@@ -209,7 +209,7 @@ const projectInsightsSub = {
                         m('.flex-row.u-marginbottom-40.u-text-center-small-only', [
                             m('.flex-column.card.u-radius.u-marginbottom-10', [
                                 m('div',
-                                    'Receita média por assinatura'
+                                    'Arrecadação média por assinatura'
                                 ),
                                 m('.fontsize-smallest.fontcolor-secondary.lineheight-tighter',
                                     `em ${moment().format('DD/MM/YYYY')}`
@@ -226,7 +226,7 @@ const projectInsightsSub = {
                                 oldCount: state.insightResumeDataLast2Week().subscriptions_count
                             }),
                             m(insightsInfoBox, {
-                                label: 'Nova receita',
+                                label: 'Nova arrecadação',
                                 info: `R$${h.formatNumber(totalAmountFromLastWeek, 2, 3)}`,
                                 newCount: totalAmountFromLastWeek,
                                 oldCount: totalAmountFromLast2Week


### PR DESCRIPTION
### Descrição
Melhora o copy do painel de controle de projetos de assinatura para deixar claro que a receita mensal é na verdade arrecadação mensal potencial 

### Referência
https://www.notion.so/catarse/Melhora-copy-no-painel-de-controle-de-projetos-de-assinatura-para-deixar-claro-que-Receita-Mensal--06ffc5129818446a805108191280cf3c

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
