### PR TITLE
✨ Adiciona recibo de apoio para pagamentos de assinatura.

### DIFF
--- a/services/catarse/app/controllers/projects/subscriptions_controller.rb
+++ b/services/catarse/app/controllers/projects/subscriptions_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Projects
+  class SubscriptionsController < ApplicationController
+    def receipt
+      subscription_payment = SubscriptionPayment.find(params[:payment_id])
+      authorize subscription_payment
+
+      render 'user_notifier/mailer/subscription_receipt', locals: { subscription_payment: subscription_payment },
+        layout: 'layouts/email'
+    end
+  end
+end

--- a/services/catarse/app/policies/subscription_payment_policy.rb
+++ b/services/catarse/app/policies/subscription_payment_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SubscriptionPaymentPolicy < ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    super
+    @record = record
+  end
+
+  def receipt?
+    record.user == user || user.try(:admin?)
+  end
+end

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/subscription_receipt.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/subscription_receipt.html.slim
@@ -1,0 +1,78 @@
+- subscription_payment ||= @notification.subscription_payment
+- transaction = subscription_payment.gateway_cached_data["transaction"]
+- owner = subscription_payment.project.user
+- owner_name = owner.try(:name)
+- owner_document = owner.try(:cpf)
+
+table#bodyTable border="0" cellpadding="0" cellspacing="0" height="100%" width="100%"
+  tbody
+    tr
+      td align="center" valign="top"
+        table#emailContainer border="0" cellpadding="0" cellspacing="0"
+          tbody
+            tr
+              td align="center" valign="top"
+                table#emailHeader border="0" cellpadding="0" cellspacing="0" width="100%"
+                  tbody
+                    td align="center" valign="top"
+                      img src="https://daks2k3a4ib2z.cloudfront.net/5849f4f0a275a2a744efd93e/5a39380a6964a800012be94b_logo-ass-email.png" style=("margin: 45px 0 45px;") /
+            tr
+              td align="center" valign="top"
+                table#emailBody border="0" cellpadding="0" cellspacing="0" style=("background-color: #ffffff; border-radius: 10px; font-size: 16px; line-height: 24px;") width="100%"
+                  tbody
+                    tr
+                      td align="center" valign="top"
+                        p style=("font-size: 22px; font-weight: 500;") Seu apoio mensal para o projeto #{subscription_payment.project.name} foi confirmado com sucesso!
+                        p
+                          | Olá,
+            tr
+              td align="center" valign="top"
+                table#emailBody border="0" cellpadding="40" cellspacing="0" style=("background-color: #ffffff; border-radius: 10px; font-size: 16px; line-height: 24px; margin:30px 0 0px 0") width="100%"
+                  tbody
+                    tr
+                      td align="left" valign="top"
+                        p style=("text-align: center;")
+                          | Esse e-mail serve como um recibo definitivo do seu apoio este mês. Seguem todos os dados do pagamento:
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b Nome do apoiador:
+                          | #{subscription_payment.user.display_name}
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b CPF/CNPJ do apoiador:
+                          | #{subscription_payment.user.cpf}
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b Data da confirmação do apoio:
+                          | #{I18n.l(transaction["date_created"].to_date)}
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b Valor da contribuição:
+                          | #{number_to_currency (transaction["amount"].to_i / 100.0), precision: 2}
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b ID do apoio:
+                          | #{transaction["id"]}
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b Nome/Razão Social do realizador:
+                          | #{owner_name}
+                        p style=("box-sizing: border-box; font-size: 14px; vertical-align: top; border-top-width: 1px; border-top-color: #eee; border-top-style: solid; margin: 0; padding: 5px 0;") valign="top"
+                          b CPF/CNPJ do realizador:
+                          | #{owner_document}
+            tr
+              td align="center" valign="top"
+                table#emailBody border="0" cellpadding="40" cellspacing="0" style=("background-color: #ffffff; border-radius: 10px; font-size: 16px; line-height: 24px; margin:30px 0 30px") width="100%"
+                  tbody
+                    tr
+                      td align="center" valign="top"
+                        p
+                          b Dúvidas?
+                        p
+                          | Em caso de dúvida sobre o projeto ou a recompensa selecionada entre em contato com
+                          a style=("padding-left: 0.5em;") href=("mailto:#{owner.email}") #{owner.public_name}.
+                          | Em caso de dúvidas sobre o Catarse ou problemas técnicos, entre em contato conosco respondendo a esta mensagem ou através do e-mail
+                          a style=("padding-left: 0.5em;") href=("mailto:assinaturas@catarse.me") assinaturas@catarse.me.
+                        span style=("padding-right:3px; padding-top: 3px; display:inline-block;")
+                          img src="https://daks2k3a4ib2z.cloudfront.net/573a70f6d5c3cb6532f8b1a7/5a34004e5aec59000163f9e5_heart-catarsr.png" style=("width: 15px;") /
+                        | Equipe do Catarse
+            tr
+              td align="center" valign="top"
+                table#emailFooter border="0" cellpadding="30" cellspacing="0" width="100%"
+                  tbody
+                    tr
+                      td align="center" valign="top"

--- a/services/catarse/catarse.js/legacy/src/c/dashboard-subscription-card-detail-payment-history-entry.js
+++ b/services/catarse/catarse.js/legacy/src/c/dashboard-subscription-card-detail-payment-history-entry.js
@@ -25,6 +25,8 @@ const dashboardSubscriptionCardDetailPaymentHistoryEntry = {
     view: function({state, attrs}) {
         const
             captalize = (str) => str.charAt(0).toUpperCase() + str.slice(1),
+            contributionScope = _.partial(h.i18nScope, 'users.contribution_row'),
+            paymentId = attrs.payment.id,
             paymentStatus = attrs.payment.status,
             paymentAmount = attrs.payment.amount,
             paymentMethod = attrs.payment ? attrs.payment.payment_method : '',
@@ -49,7 +51,13 @@ const dashboardSubscriptionCardDetailPaymentHistoryEntry = {
                     m(`span.fa.fa-circle${state.statusClass[paymentStatus]}`, m.trust('&nbsp;')),
                     `R$${paymentAmount / 100} ${paymentStatusText} - ${captalize(paymentMethodText)} ${paymentMethodEndText}`,
                     m.trust('&nbsp;&nbsp;&nbsp;&nbsp;'),
-                    m('span.fontcolor-secondary', `( ID ${gatewayId} ) `)
+                    m('span.fontcolor-secondary', `( ID ${gatewayId} ) `),
+                    ( paymentStatus == 'paid' ?
+                        (
+                            m.trust('&nbsp;&nbsp;&nbsp;&nbsp;'),
+                            m(`a.alt-link.u-margintop-10[href='/projects/subscriptions/receipt/${paymentId}'][target='__blank']`,
+                              `- ${window.I18n.t('show_receipt', contributionScope())}`
+                        )) : ''),
                     ]
 
                 )

--- a/services/catarse/config/brakeman.ignore
+++ b/services/catarse/config/brakeman.ignore
@@ -103,7 +103,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/project.rb",
-      "line": 110,
+      "line": 111,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"projects.#{column} between :start and :end\", :start => start_at, :end => end_at)",
       "render_path": null,
@@ -135,8 +135,28 @@
       "user_input": "params[:notification_type].camelize.singularize",
       "confidence": "High",
       "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "fd610f2e5d42b68af4a9e7337423e0679a9c5e3c6177087d3e1b16d374de19e5",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `SubscriptionPayment#find`",
+      "file": "app/controllers/projects/subscriptions_controller.rb",
+      "line": 6,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "SubscriptionPayment.find(params[:payment_id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Projects::SubscriptionsController",
+        "method": "receipt"
+      },
+      "user_input": "params[:payment_id]",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2021-02-24 10:19:18 -0300",
-  "brakeman_version": "5.0.0"
+  "updated": "2022-02-16 08:01:41 -0300",
+  "brakeman_version": "5.1.2"
 }

--- a/services/catarse/config/routes.rb
+++ b/services/catarse/config/routes.rb
@@ -138,6 +138,7 @@ Catarse::Application.routes.draw do
 
         collection do
           get :fallback_create, to: 'projects#create'
+          get 'subscriptions/receipt/:payment_id', action: :receipt, controller: 'projects/subscriptions', to: 'projects/subscriptions#receipt', as: :subscriptions_receipt
         end
         get 'video', on: :collection
         member do

--- a/services/catarse/spec/controllers/projects/subscriptions_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects/subscriptions_controller_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Projects::SubscriptionsController, type: :controller do
+  let(:payment_common_id) { SecureRandom.uuid }
+  let(:user) { create(:user) }
+  let(:subscription_payment) do
+    SubscriptionPayment.new(
+      id: SecureRandom.uuid,
+      project: create(:subscription_project, user: user),
+      user: user,
+      gateway_cached_data: {
+        payables: {
+          amount: Faker::Number.number(digits: 4),
+          id: Faker::Number.number(digits: 4),
+          payment_date: Time.zone.now,
+          payment_method: 'boleto'
+        }
+      }
+    )
+  end
+
+  describe 'Get /receipt' do
+    before do
+      allow(SubscriptionPayment).to receive(:find).with(payment_common_id).and_return(subscription_payment)
+    end
+
+    context 'when user is admin and subscriptionpayment is successful' do
+      let(:admin) { create(:user, admin: true) }
+      let(:current_user) { admin }
+
+      before do
+        allow(controller).to receive(:current_user).and_return(current_user)
+        get :receipt, params: { payment_id: payment_common_id }
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders 'subscription_receipt' template" do
+        expect(response).to render_template('user_notifier/mailer/subscription_receipt')
+      end
+    end
+
+    context 'when user is owner and subscriptionpayment is successful' do
+      let(:current_user) { user }
+
+      before do
+        allow(controller).to receive(:current_user).and_return(current_user)
+        get :receipt, params: { payment_id: payment_common_id }
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders 'subscription_receipt' template" do
+        expect(response).to render_template('user_notifier/mailer/subscription_receipt')
+      end
+    end
+
+    context 'when user is not owner and subscriptionpayment is successful' do
+      let(:current_user) { create(:user) }
+
+      before do
+        allow(controller).to receive(:current_user).and_return(current_user)
+        get :receipt, params: { payment_id: payment_common_id }
+      end
+
+      it 'is redirect' do
+        expect(response.code.to_i).to eq(302)
+      end
+    end
+  end
+end

--- a/services/catarse/spec/policies/subscription_payment_policy_spec.rb
+++ b/services/catarse/spec/policies/subscription_payment_policy_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubscriptionPaymentPolicy do
+  subject { described_class }
+
+  let(:user) { create(:user) }
+  let(:subscription_payment) do
+    SubscriptionPayment.new(
+      id: SecureRandom.uuid,
+      project: create(:subscription_project, user: user),
+      user: user,
+      gateway_cached_data: {
+        payables: {
+          amount: Faker::Number.number(digits: 4),
+          id: Faker::Number.number(digits: 4),
+          payment_date: Time.zone.now,
+          payment_method: 'boleto'
+        }
+      }
+    )
+  end
+
+  shared_examples_for 'create permissions' do
+    it 'denies access if user is nil' do
+      expect(subject).not_to permit(nil, subscription_payment)
+    end
+
+    it 'denies access if user is not project owner' do
+      expect(subject).not_to permit(User.new, subscription_payment)
+    end
+
+    it 'permits access if user is project owner' do
+      expect(subject).to permit(user, subscription_payment)
+    end
+
+    it 'permits access if user is admin' do
+      admin = build(:user, admin: true)
+      expect(subject).to permit(admin, subscription_payment)
+    end
+  end
+
+  permissions(:receipt?) { it_behaves_like 'create permissions' }
+end


### PR DESCRIPTION
### Descrição
Isso é um retorno do QA duma atividade que o Gabriel tinha feito e faltavam apenas alguns ajustes visuais no HTML do recibo e a formatação do valor do apoio.

### Referência
https://www.notion.so/catarse/Op-o-para-usu-rios-e-admins-acessarem-o-recibo-de-apoios-mensais-6107c519d49a48b1aa8c7792aae090cc?d=c75323fd91aa40d5a008a04bd0f10c4e

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
