### PR TITLE
🐞 Ajuste em valores do informe de rendimento

### DIFF
--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
@@ -100,6 +100,6 @@ class CreateProjectFiscalToProjectFlexAndAonAction
   end
 
   def end_date
-    Time.zone.now.end_of_month
+    @project.successful_at || Time.zone.now.end_of_month
   end
 end

--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_inform.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/project_fiscal_inform.slim
@@ -76,7 +76,7 @@ table style="border: 1px solid;width:100%;border-collapse: collapse;"
     td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"
       span Taxa Líquida Catarse (-)
     td style="border: 1px solid;text-align:center;vertical-align: middle;white-space: nowrap;"
-      span #{project_fiscals.sum { |pf| -pf.total_catarse_fee - pf.total_gateway_fee - pf.total_antifraud_fee }.format}
+      span #{project_fiscals.sum { |pf| pf.total_catarse_fee - pf.total_gateway_fee - pf.total_antifraud_fee }.format}
   - unless total_irrf.positive?
     tr
       td style="border: 1px solid;text-align:left;vertical-align: middle;white-space: nowrap;"


### PR DESCRIPTION
### Descrição
Ajusta o valor da taxa liquida do catarse, da forma que estava acabava somando tudo pois o primeiro valor era convertido para negativo.
Utiliza também a data em que o projeto finalizou para gerar o end_date dos dados fiscais de projetos aon/flex

### Referência
[Link para a atividade](https://www.notion.so/catarse/Tarefas-gerais-de-Produto-f085463d388348bb85b32c8b72ed9342?p=25b9d6ac8d8e4a16ab325613de0e8145)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
