### PR TITLE
✨ Remove logica que deleta os projects_reminders ao desativar uma lan…

### DIFF
--- a/services/catarse/app/controllers/projects/coming_soon_controller.rb
+++ b/services/catarse/app/controllers/projects/coming_soon_controller.rb
@@ -18,8 +18,6 @@ module Projects
     def deactivate
       authorize resource, policy_class: ProjectIntegrationPolicy
 
-      parent.reminders.destroy_all
-
       resource.destroy
 
       respond_to do |format|

--- a/services/catarse/app/models/project.rb
+++ b/services/catarse/app/models/project.rb
@@ -410,8 +410,6 @@ class Project < ApplicationRecord
         options
       )
     end
-
-    reminders.destroy_all
   end
 
   def delete_from_reminder_queue(user_id)

--- a/services/catarse/spec/controllers/projects/coming_soon_controller_spec.rb
+++ b/services/catarse/spec/controllers/projects/coming_soon_controller_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Projects::ComingSoonController, type: :controller do
       post :activate, params: { format: :json, id: project.id }
     end
 
-    it 'deactivates coming soon landing page and have 0 reminders' do
+    it 'deactivates coming soon landing page' do
       delete :deactivate, params: { format: :json, id: project.id }
-      expect(project.reminders.length).to eq(0)
+      expect(project.integrations.coming_soon.first.present?).to be false
     end
   end
 end

--- a/services/catarse/spec/models/project_integration_spec.rb
+++ b/services/catarse/spec/models/project_integration_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe ProjectIntegration, type: :model do
       project.notify_reminder_of_publish
 
       expect(project.notifications.length).to eq(reminders_count)
-      expect(project.reminders.length).to eq(0)
     end
   end
 


### PR DESCRIPTION
…ding page ou publicar um projeto

### Descrição
Vamos manter o registro dos reminders mesmo após o projeto ser publica ou desativado a landing page

### Referência
[Link para a atividade](https://www.notion.so/catarse/Remover-logica-que-deleta-os-projects_reminders-ao-desativar-uma-landing-page-ou-publicar-um-projeto-113bd1622c9047659d393d118ad07d69)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
