### PR TITLE
✨ Adiciona integração com e-notas nas actions de project_fiscal.

### DIFF
--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
@@ -11,6 +11,11 @@ class CreateProjectFiscalToProjectFlexAndAonAction
     @project_data = new_project_data
     if @project_data.total_amount_to_pf_cents.positive? || @project_data.total_amount_to_pj_cents.positive?
       @project_data.save!
+      cut_off_date = CatarseSettings[:enotes_initial_cut_off_date]
+      if cut_off_date && @project_data.end_date >= cut_off_date.to_date
+        metadata = ENotas::Client.new.create_nfe(ENotas::ParamsBuilders::Order.new(@project_data).build)
+        @project_data.update(metadata: metadata)
+      end
       @project_data
     end
   rescue StandardError => e

--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_sub_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_sub_action.rb
@@ -13,6 +13,11 @@ class CreateProjectFiscalToProjectSubAction
     @project_data = new_project_data
     if @project_data.total_amount_to_pf_cents.positive? || @project_data.total_amount_to_pj_cents.positive?
       @project_data.save!
+      cut_off_date = CatarseSettings[:enotes_initial_cut_off_date]
+      if cut_off_date && @project_data.end_date >= cut_off_date.to_date
+        metadata = ENotas::Client.new.create_nfe(ENotas::ParamsBuilders::Order.new(@project_data).build)
+        @project_data.update(metadata: metadata)
+      end
       @project_data
     end
   rescue StandardError => e

--- a/services/catarse/spec/old_actions/create_project_fiscal_to_project_sub_action_spec.rb
+++ b/services/catarse/spec/old_actions/create_project_fiscal_to_project_sub_action_spec.rb
@@ -66,5 +66,22 @@ RSpec.describe CreateProjectFiscalToProjectSubAction, type: :action do
         'total_chargeback_cost_cents' => (payment[2].gateway_fee + antifraud[2].cost).to_i * 100
       )
     end
+
+    context 'when project_fiscal generate invoice' do
+      before do
+        CatarseSettings[:enotes_initial_cut_off_date] = '01-01-2020'
+        allow_any_instance_of(ENotas::Client).to receive(:create_nfe).and_return({ 'id' => '1' }) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it 'capture invoice generation' do
+        expect(ENotas::Client.new.create_nfe('invoice')).to eq({ 'id' => '1' })
+
+        result
+      end
+
+      it 'updates metadata' do
+        expect(result.metadata).to eq({ 'id' => '1' })
+      end
+    end
   end
 end


### PR DESCRIPTION
### Descrição
Atualmente temos a integração com e-notas, mas ela não tem integração com a action de criação de project_fiscal. Essa atividade permite gerar a nf durante a geração do project_fiscal.

### Referência
[Link para a atividade
](https://www.notion.so/catarse/Adicionar-integra-o-com-emiss-o-de-NF-assim-que-um-project-fiscal-for-criado-4e4973cb50c84e128df65843e49b29cc)

### Antes de criar esse pull request confira se:
- [x] Testes estão implementados
- [x] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [x] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [x] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
