### PR TITLE
🐞 Ajusta rotina de criação de documentos fiscais quanto projeto não t…

### DIFF
--- a/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
+++ b/services/catarse/app/old_actions/create_project_fiscal_to_project_flex_and_aon_action.rb
@@ -95,8 +95,13 @@ class CreateProjectFiscalToProjectFlexAndAonAction
 
   def begin_date
     ProjectFiscal.where(project_id: @project.id)&.last&.created_at ||
-      Payment.joins(:contribution).where(contribution: { project_id: @project.id }, state: 'paid')
-        .order(:created_at).first.created_at.beginning_of_month
+      begin_date_from_payment ||
+      @project.online_at.beginning_of_month
+  end
+
+  def begin_date_from_payment
+    Payment.joins(:contribution).where(contribution: { project_id: @project.id }, state: 'paid')
+      .order(:created_at).first&.created_at&.beginning_of_month
   end
 
   def end_date


### PR DESCRIPTION
…em nenhum pagamento

### Descrição
Quando o projeto não tem nenhum apoio, não é possível definir uma data de inicio, agora utilizamos a data em que o projeto foi o ar nesses casos.

### Referência
[Link para a atividade](https://www.notion.so/catarse/Ajustar-rotinas-de-cria-o-de-documentos-fiscais-quanto-projeto-n-o-tem-nenhum-pagamento-8c05fd8e1459444c85699ca432a5463b)

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
