### PR TITLE
Altera nome da classe de btn para button

### DIFF
--- a/services/catarse/catarse.js/legacy/src/components/Atom/Button/index.tsx
+++ b/services/catarse/catarse.js/legacy/src/components/Atom/Button/index.tsx
@@ -26,7 +26,7 @@ function _Button({
 
     return (
         <button
-            className={`btn-main btn-${variant} btn-${theme} btn-size-${size} text-style-button `}
+            className={`button-main button-${variant} button-${theme} button-size-${size} text-style-button `}
             {...rest}
         >
             <div>

--- a/services/catarse/catarse.js/legacy/src/components/Atom/Button/styles.scss
+++ b/services/catarse/catarse.js/legacy/src/components/Atom/Button/styles.scss
@@ -3,7 +3,7 @@
 
 // ** BUTTON MAIN
 
-.btn-main {
+.button-main {
     padding: 0 0.875rem;
     border-radius: 8px;
     width: auto;
@@ -23,15 +23,15 @@
 
 // ** BUTTON SIZES [SM, MD, LG]
 
-.btn-size-sm {
+.button-size-sm {
     height: 2.125rem;
 }
 
-.btn-size-md {
+.button-size-md {
     height: 2.5rem;
 }
 
-.btn-size-lg {
+.button-size-lg {
     padding: 0 1.625rem;
     height: 3rem;
 }
@@ -40,17 +40,17 @@
 
 // ** BUTTON VARIANT [CONTAINED, OUTLINE, TEXT]
 
-.btn-contained {
+.button-contained {
     border: none;
     color: $color-overlay !important;
 }
 
-.btn-outline {
+.button-outline {
     border: solid 1px;
     background-color: transparent !important;
 }
 
-.btn-text {
+.button-text {
     border: none;
     background-color: transparent !important;
 }
@@ -59,69 +59,69 @@
 
 // ** BUTTON STYLES [PRIMARY, SECONDARY, DANGER]
 
-.btn-primary {
+.button-primary {
     border-color: $color-action-primary-default;
     background-color: $color-action-primary-default;
     color: $color-action-primary-default;
 
-    &.btn-contained:hover {
+    &.button-contained:hover {
         background-color: $color-action-primary-hovered !important;
     }
 
-    &.btn-contained:active {
+    &.button-contained:active {
         background-color: $color-action-primary-pressed !important;
     }
 
-    &.btn-outline:hover, &.btn-text:hover {
+    &.button-outline:hover, &.button-text:hover {
         background-color:  $color-surface-success-subdued-hovered !important;
     }
 
-    &.btn-outline:active, &.btn-text:hover {
+    &.button-outline:active, &.button-text:hover {
         background-color: $color-surface-success-subdued-pressed !important;
     }
 
 }
 
-.btn-secondary {
+.button-secondary {
     border-color: $color-action-secondary-default;
     background-color: $color-action-secondary-default;
     color: $color-action-secondary-default;
 
-    &.btn-contained:hover {
+    &.button-contained:hover {
         background-color: $color-action-secondary-hovered !important;
     }
 
-    &.btn-contained:active {
+    &.button-contained:active {
         background-color: $color-action-secondary-pressed !important;
     }
 
-    &.btn-outline:hover, &.btn-text:hover {
+    &.button-outline:hover, &.button-text:hover {
         background-color:  $color-surface-base-hovered !important;
     }
 
-    &.btn-outline:active, &.btn-text:hover {
+    &.button-outline:active, &.button-text:hover {
         background-color: $color-surface-base-pressed !important;
     }
 }
 
-.btn-danger {
+.button-danger {
     border-color: $color-action-critical-default;
     background-color: $color-action-critical-default;
     color: $color-action-critical-default;
 
-    &.btn-contained:hover {
+    &.button-contained:hover {
         background-color: $color-action-critical-hovered !important;
     }
 
-    &.btn-contained:active {
+    &.button-contained:active {
         background-color: $color-action-critical-pressed !important;
     }
 
-    &.btn-outline:hover, &.btn-text:hover {
+    &.button-outline:hover, &.button-text:hover {
         background-color: $color-surface-critical-subdued-hovered !important;
     }
 
-    &.btn-outline:active, &.btn-text:hover {
+    &.button-outline:active, &.button-text:hover {
         background-color: $color-surface-critical-subdued-pressed !important;
     }
 }


### PR DESCRIPTION
### Descrição
Ao criar o componente do Banner, criamos também o componente Button, porém ao usarmos a classe chamada .btn acabamos criando conflitos com a classe .btn que já usamos hoje no Catarse. Esse PR altera o nome da classe para .button pois assim é a forma mais simples de removermos esses conflitos.

### Referência
https://www.notion.so/catarse/Altera-classe-btn-para-button-f76aa8338c9348c79d81b477e6ee9770


### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
