### PR TITLE
🐞 Ajusta o filtro de busca para utilizar apenas a data fixa sem tempo

### DIFF
--- a/services/catarse/app/controllers/projects/project_fiscal_controller.rb
+++ b/services/catarse/app/controllers/projects/project_fiscal_controller.rb
@@ -83,7 +83,7 @@ module Projects
 
     def project_fiscals_from_sub_project
       ProjectFiscal.where(
-        'project_id = :project_id AND begin_date >= :begin_date AND end_date <= :end_date',
+        'project_id = :project_id AND begin_date::date >= :begin_date AND end_date::date <= :end_date',
         project_id: params[:project_id], begin_date: @begin_date, end_date: @end_date
       )
     end
@@ -93,7 +93,7 @@ module Projects
       return if last_end_date.try(:year).nil? || last_end_date.try(:year) < params[:fiscal_year].to_i
 
       ProjectFiscal.where(
-        'project_id = :project_id AND end_date <= :end_date', project_id: params[:project_id], end_date: @end_date
+        'project_id = :project_id AND end_date::date <= :end_date', project_id: params[:project_id], end_date: @end_date
       )
     end
   end


### PR DESCRIPTION
### Descrição
Alguns períodos estão faltando na hora de exibir o informe de rendimentos do ano

### Referência
https://www.notion.so/catarse/Alguns-meses-est-o-faltando-na-hora-de-exibir-o-informe-de-rendimentos-3674abf5a5fd43b3836340e28941b1bc

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
