### PR TITLE
fix: Remove Catarse Solidária/Covid-19 da descoberta

### DIFF
--- a/services/catarse/catarse.js/legacy/src/c/project-basics-edit.js
+++ b/services/catarse/catarse.js/legacy/src/c/project-basics-edit.js
@@ -214,25 +214,6 @@ const projectBasicsEdit = {
                                             onchange: m.withAttr('value', vm.fields.service_fee),
                                         }),
                                     ],
-                                }),
-
-                                m(inputCard, {
-                                    label: window.I18n.t('solidarity_covid', I18nScope()),
-                                    children: [
-                                        m('select.required.w-input.text-field.w-select.positive.medium', {
-                                            value: `${vm.fields.is_solidarity()}`,
-                                            class: vm.e.hasError('integrations') ? 'error' : '',
-                                            onchange: m.withAttr('value', (value) => vm.fields.is_solidarity(JSON.parse(value))),
-                                        }, [
-                                            m(`option[value=true]`, {
-                                                selected: vm.fields.is_solidarity(),
-                                            }, 'Sim'),
-                                            m(`option[value=false]`, {
-                                                selected: !vm.fields.is_solidarity(),
-                                            }, 'Não')
-                                        ]),
-                                        vm.e.inlineError('integrations'),
-                                    ]
                                 })
                             ]),
                         ])

--- a/services/catarse/catarse.js/legacy/src/c/projects-display.js
+++ b/services/catarse/catarse.js/legacy/src/c/projects-display.js
@@ -24,7 +24,7 @@ const projectsDisplay = {
             sample3 = _.partial(_.sample, _, 3),
             loader = catarse.loaderWithToken,
             project = models.project,
-            subHomeWith6CollectionsFilters = ['projects_we_love_not_sub', 'sub', 'covid_19', 'contributed_by_friends', 'coming_soon_landing_page'],
+            subHomeWith6CollectionsFilters = ['projects_we_love_not_sub', 'sub', 'contributed_by_friends', 'coming_soon_landing_page'],
             windowEventNOTDispatched = true;
 
         project.pageSize(20);

--- a/services/catarse/catarse.js/legacy/src/experiments/c/explore-light-box.js
+++ b/services/catarse/catarse.js/legacy/src/experiments/c/explore-light-box.js
@@ -41,12 +41,6 @@ export class ExploreLightBox {
                 }
             },
             {
-                name: 'Projetos COVID-19',
-                query: {
-                    mode: 'covid_19',
-                }
-            },
-            {
                 name: 'Em breve no Catarse',
                 query: {
                     filter: 'coming_soon_landing_page',

--- a/services/catarse/catarse.js/legacy/src/root/projects-explore.ts
+++ b/services/catarse/catarse.js/legacy/src/root/projects-explore.ts
@@ -177,10 +177,6 @@ const projectsExplore : m.Component<ProjectExploreAttrs, ProjectExploreState> = 
                 label: 'Assinaturas',
                 value: 'sub',
             },
-            {
-                label: 'Projetos COVID-19',
-                value: 'covid_19',
-            },
         ];
 
         return m('#explore', {

--- a/services/catarse/catarse.js/legacy/src/vms/project-filters-vm.js
+++ b/services/catarse/catarse.js/legacy/src/vms/project-filters-vm.js
@@ -4,9 +4,6 @@ import { catarse } from '../api';
 
 const projectFiltersVM = () => {
     const filtersVM = catarse.filtersVM,
-        covid19 = filtersVM({
-            integrations: 'like',
-        }).integrations('COVID-19'),
 
         all = filtersVM({
             state: 'eq'
@@ -97,18 +94,6 @@ const projectFiltersVM = () => {
                 nicename: 'Populares',
                 isContextual: false,
                 keyName: 'all'
-            },
-            covid_19: {
-                title: 'Projetos COVID-19',
-                filter: covid19,
-                mode: 'covid_19',
-                nicename: 'Projetos COVID-19',
-                isContextual: false,
-                keyName: 'covid_19',
-                query: {
-                    mode: 'covid_19',
-                    filter: 'all'
-                }
             },
             active_saved_projects: {
                 title: 'Projetos Salvos',

--- a/services/catarse/catarse.js/legacy/src/vms/projects-explore-vm.ts
+++ b/services/catarse/catarse.js/legacy/src/vms/projects-explore-vm.ts
@@ -26,7 +26,7 @@ interface Observer<T> {
 
 const projectFiltersVM = projectFilters();
 
-type Mode = 'all_modes' | 'sub' | 'not_sub' | 'covid_19';
+type Mode = 'all_modes' | 'sub' | 'not_sub' ;
 export type Category = {
     name: string;
     id: number;


### PR DESCRIPTION
### Descrição
Essa alteração remove visualmente as formas das pessoas criarem projetos da Catarse Solidária e descobrirem projetos da Catarse Solidária. 

### Referência
https://www.notion.so/catarse/Remover-Catarse-Solid-ria-Covid-da-descoberta-de3ccd8208ce487b9d0b335dfa664bb9

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
