### PR TITLE
remove subtitulo do blog na home do catarse

### DIFF
--- a/services/catarse/catarse.js/legacy/src/root/blog-banner-post.tsx
+++ b/services/catarse/catarse.js/legacy/src/root/blog-banner-post.tsx
@@ -13,9 +13,6 @@ export default class BlogBannerPost implements m.Component {
                 <a href={href} class="link-hidden fontweight-semibold fontsize-base u-marginbottom-10" target="_blank">
                     {title}
                 </a>
-                <div class="fontsize-smaller fontcolor-secondary u-margintop-10">
-                    {summary}
-                </div>
             </div>
         )
     }


### PR DESCRIPTION
### Descrição
A home do Catarse está com um bug estético que está deixando de exibir o subtitulo do post de um blog. No lugar, tem a hora e minuto do post. Pra evitar de termos que resolver isso, estou simplesmente removendo o subtitulo dali https://cdn.zappy.app/196a3897ce3db522ba32f6c1771270c8.png

### Referência
https://www.notion.so/catarse/Remover-subtitulo-do-blog-na-home-do-Catarse-db8c2417183c495a86f1893b7913036b

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
