### PR TITLE
Remove nome do realizador na notificação de confirmação de dados em questionario

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/answer_survey.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/user_notifier/mailer/answer_survey.html.slim
@@ -8,7 +8,7 @@ h2 style="text-align:center; line-height: 45px;"
 | Olá!
 
 br/
-| #{project.user.display} precisa confirmar algumas informações para realizar a entrega da sua recompensa ao projeto #{project.name}!
+| Precisamos confirmar algumas informações para realizar a entrega da sua recompensa ao projeto #{project.name}!
 
 p Relembrando as informações do seu apoio:
 


### PR DESCRIPTION
### Descrição
Essa notificação estava vindo em branco ali na parte do nome do realizador. Ao invés de colocar o código certo ali, preferi só remover o nome mesmo.

### Referência
https://www.notion.so/catarse/Remover-nome-do-realizador-da-notifica-o-de-question-rio-752bf9fb8471490ead50a853f1d0b945

### Antes de criar esse pull request confira se:
- [X] Testes estão implementados
- [X] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [X] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [X] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
