### PR TITLE
🐞 Não devemos notificar assinaturas canceladas sobre o boleto expirando

### DIFF
--- a/services/service-core-db/migrations/2022-11-01-122804_adjust_notify_expiring_slip/down.sql
+++ b/services/service-core-db/migrations/2022-11-01-122804_adjust_notify_expiring_slip/down.sql
@@ -1,0 +1,68 @@
+-- This file should undo anything in `up.sql`
+CREATE OR REPLACE FUNCTION payment_service.notify_expiring_slips()
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _payment payment_service.catalog_payments;
+            _last_subscription_payment payment_service.catalog_payments;
+            _subscription payment_service.subscriptions;
+            _result json;
+            _relations_json json;
+            _affected_payments_ids uuid[];
+            _total_affected_payments integer default 0;
+        begin
+            -- get all slips expiring in the next 24h
+            for _payment in (select cp.*
+                from payment_service.catalog_payments cp
+                where cp.data->>'payment_method' = 'boleto' and cp.status = 'pending'
+                    and (cp.gateway_general_data->>'boleto_expiration_date')::timestamp is not null
+                    and (cp.gateway_general_data->>'boleto_expiration_date')::timestamp BETWEEN now() and (now() + '24 hours'::interval)
+            )
+            loop
+                -- if payment is from subscription
+                if _payment.subscription_id is not null then
+                    -- get last payment from subscription
+                    select * from payment_service.catalog_payments
+                        where subscription_id = _payment.subscription_id
+                            order by created_at desc limit 1
+                            into _last_subscription_payment;
+
+                    -- get subscription
+                    select * from payment_service.subscriptions
+                        where id = _payment.subscription_id
+                        into _subscription;
+                end if;
+
+                -- if payment is the same of last_payment
+                if _payment.id = _last_subscription_payment.id then
+                    if not exists (
+                        select true from notification_service.user_catalog_notifications n
+                        where n.user_id = _subscription.user_id
+                            and (n.data -> 'relations' ->> 'catalog_payment_id')::uuid = _payment.id
+                            and n.label = 'expiring_slip'
+                            and n.created_at >= ((_payment.gateway_general_data->>'boleto_expiration_date')::timestamp - '48 hours'::interval)
+                    ) then
+                        _relations_json := json_build_object(
+                        'relations', json_build_object(
+                            'catalog_payment_id', _last_subscription_payment.id,
+                            'subscription_id', _subscription.id,
+                            'project_id', _subscription.project_id,
+                            'user_id', _subscription.user_id
+                        ));
+                        perform notification_service.notify('expiring_slip', _relations_json);
+                        _total_affected_payments := _total_affected_payments + 1;
+                        _affected_payments_ids := array_append(_affected_payments_ids, _payment.id);
+                    end if;
+
+                end if;
+            end loop;
+
+            _result := json_build_object(
+                'total_payments_affected', _total_affected_payments,
+                'affected_payments_ids', _affected_payments_ids
+            );
+
+            return _result;
+        end;
+    $function$;

--- a/services/service-core-db/migrations/2022-11-01-122804_adjust_notify_expiring_slip/up.sql
+++ b/services/service-core-db/migrations/2022-11-01-122804_adjust_notify_expiring_slip/up.sql
@@ -1,0 +1,71 @@
+-- Your SQL goes here
+CREATE OR REPLACE FUNCTION payment_service.notify_expiring_slips()
+ RETURNS json
+ LANGUAGE plpgsql
+AS $function$
+        declare
+            _payment payment_service.catalog_payments;
+            _last_subscription_payment payment_service.catalog_payments;
+            _subscription payment_service.subscriptions;
+            _result json;
+            _relations_json json;
+            _affected_payments_ids uuid[];
+            _total_affected_payments integer default 0;
+        begin
+            -- get all slips expiring in the next 24h
+            for _payment in (select cp.*
+                from payment_service.catalog_payments cp
+                join payment_service.subscriptions s on s.id = cp.subscription_id
+                where s.status in ('active', 'inactive', 'started')
+                    and cp.data->>'payment_method' = 'boleto'
+                    and cp.status = 'pending'
+                    and (cp.gateway_general_data->>'boleto_expiration_date')::timestamp is not null
+                    and (cp.gateway_general_data->>'boleto_expiration_date')::timestamp BETWEEN now() and (now() + '24 hours'::interval)
+            )
+            loop
+                -- if payment is from subscription
+                if _payment.subscription_id is not null then
+                    -- get last payment from subscription
+                    select * from payment_service.catalog_payments
+                        where subscription_id = _payment.subscription_id
+                            order by created_at desc limit 1
+                            into _last_subscription_payment;
+
+                    -- get subscription
+                    select * from payment_service.subscriptions
+                        where id = _payment.subscription_id
+                        into _subscription;
+                end if;
+
+                -- if payment is the same of last_payment
+                if _payment.id = _last_subscription_payment.id then
+                    if not exists (
+                        select true from notification_service.user_catalog_notifications n
+                        where n.user_id = _subscription.user_id
+                            and (n.data -> 'relations' ->> 'catalog_payment_id')::uuid = _payment.id
+                            and n.label = 'expiring_slip'
+                            and n.created_at >= ((_payment.gateway_general_data->>'boleto_expiration_date')::timestamp - '48 hours'::interval)
+                    ) then
+                        _relations_json := json_build_object(
+                        'relations', json_build_object(
+                            'catalog_payment_id', _last_subscription_payment.id,
+                            'subscription_id', _subscription.id,
+                            'project_id', _subscription.project_id,
+                            'user_id', _subscription.user_id
+                        ));
+                        perform notification_service.notify('expiring_slip', _relations_json);
+                        _total_affected_payments := _total_affected_payments + 1;
+                        _affected_payments_ids := array_append(_affected_payments_ids, _payment.id);
+                    end if;
+
+                end if;
+            end loop;
+
+            _result := json_build_object(
+                'total_payments_affected', _total_affected_payments,
+                'affected_payments_ids', _affected_payments_ids
+            );
+
+            return _result;
+        end;
+    $function$;


### PR DESCRIPTION
### Descrição
Não devemos notificar assinaturas canceladas sobre o boleto expirando

### Referência
https://www.notion.so/catarse/Ajustar-rotina-de-notifica-o-de-boletos-pendentes-para-desconsiderar-assinaturas-canceladas-ou-em-c-e6383de6ae7f42d08a99f7a90a60d721

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
