### PR TITLE
🐞 Ajusta funções de contagem de eventos em notificações para utilizar…

### DIFF
--- a/services/catarse/db/migrate/20221209104357_update_notification_count_functions.rb
+++ b/services/catarse/db/migrate/20221209104357_update_notification_count_functions.rb
@@ -1,0 +1,34 @@
+class UpdateNotificationCountFunctions < ActiveRecord::Migration[6.1]
+  def up
+  def change
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.delivered_count(project_post project_posts) RETURNS bigint
+      LANGUAGE sql AS $$
+       select count(distinct notification_user) from sendgrid_events where notification_type = 'ProjectPostNotification' and notification_id IN
+       (select ppn.id from project_post_notifications ppn join project_posts pp on pp.id = ppn.project_post_id where pp.id = project_post.id) and event = 'delivered';
+      $$;
+
+      CREATE OR REPLACE FUNCTION public.open_count(project_post project_posts) RETURNS bigint
+      LANGUAGE sql AS $$
+       select count(distinct notification_user) from sendgrid_events where notification_type = 'ProjectPostNotification' and notification_id IN
+       (select ppn.id from project_post_notifications ppn join project_posts pp on pp.id = ppn.project_post_id where pp.id = project_post.id) and event = 'open';
+      $$;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION public.delivered_count(project_post project_posts) RETURNS bigint
+      LANGUAGE sql AS $$
+       select count(distinct notification_user) from sendgrid_events where notification_id IN
+       (select ppn.id from project_post_notifications ppn join project_posts pp on pp.id = ppn.project_post_id where pp.id = project_post.id) and event = 'delivered';
+      $$;
+
+      CREATE OR REPLACE FUNCTION public.open_count(project_post project_posts) RETURNS bigint
+      LANGUAGE sql AS $$
+       select count(distinct notification_user) from sendgrid_events where notification_id IN
+       (select ppn.id from project_post_notifications ppn join project_posts pp on pp.id = ppn.project_post_id where pp.id = project_post.id) and event = 'open';
+      $$;
+    SQL
+  end
+end


### PR DESCRIPTION
… o tipo correto

### Descrição
Ajusta as funções de contagem de eventos de posts para utilizar o tipo correto na hora de filtrar

### Referência
https://www.notion.so/catarse/Identificar-assinantes-que-n-o-receberam-a-novidade-O-piano-de-H-rcules-Gomes-630560e277174868a692d845cc3e5e14

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
