### PR TITLE
🐞 Adiciona operador try para evitar erro caso questão de multipla esc…

### DIFF
--- a/services/catarse/app/models/contribution_reports_for_project_owner.rb
+++ b/services/catarse/app/models/contribution_reports_for_project_owner.rb
@@ -35,7 +35,7 @@ class ContributionReportsForProjectOwner < ApplicationRecord
         if survey
           row += contribution.open_questions.map{ |attr| attr['answer'] } if contribution.open_questions
           row += contribution.multiple_choice_questions.map do |question|
-            question['question_choices'].find {|c| c['id'] == question['survey_question_choice_id']}.try(:[], 'option')
+            question['question_choices']&.find {|c| c['id'] == question['survey_question_choice_id']}.try(:[], 'option')
           end if contribution.multiple_choice_questions
         end
 


### PR DESCRIPTION
…olha esteja com resposta vazia

### Descrição
Quando a resposta de multipla escolha esta vazia um erro acontece ao tentar acessar a propriedade vazia.

### Referência
https://www.notion.so/catarse/Erro-ao-baixar-relat-rios-de-R-1400-e-R-740-Mulheres-do-Suspense-8b617de2171e4433bb837ce39aee923e

### Antes de criar esse pull request confira se:
- [ ] Testes estão implementados
- [ ] Descreveu bem o título do PR a mensagem de commit e usou o emoji no início da mensagem.
- [ ] Mudanças estão unificadas em um único commit e só há 1 commit no pull request.
- [ ] Revisou seu próprio código
- [ ] ~~A base de conhecimento foi atualizada~~
