### PR TITLE
feat: Remove login do Facebook no devise

### DIFF
--- a/services/catarse/app/views/catarse_bootstrap/devise/registrations/new.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/devise/registrations/new.html.slim
@@ -10,16 +10,11 @@
       .w-col.w-col-6.box-login.w-col-push-3
         .fontweight-semibold.u-text-center.fontsize-large.u-marginbottom-30= t '.titles.header'
         .w-row
-          .w-col.w-col-6
+          .w-col.w-col-12
             .login-oauth
               = button_to user_google_oauth2_omniauth_authorize_path(locale: nil), class: 'btn btn-medium btn-google w-inline-block', :data_onsuccess => 'onSignIn'
                 img.google-icon[src="/assets/catarse_bootstrap/google-icon.png" loading="lazy"]
                 div = t('.form.inputs.google')
-          .w-col.w-col-6
-            .login-oauth
-              = button_to user_facebook_omniauth_authorize_path(locale: nil), class: 'btn btn-medium btn-fb btn-fb-flex'
-                span.fa.fa-facebook-f&nbsp;
-                text = t('.form.inputs.facebook')
         .separator
           .text.or = t('or')
         .w-form

--- a/services/catarse/app/views/catarse_bootstrap/devise/sessions/new.html.slim
+++ b/services/catarse/app/views/catarse_bootstrap/devise/sessions/new.html.slim
@@ -8,16 +8,11 @@
         .u-marginbottom-30
           .fontweight-semibold.u-text-center.fontsize-large= t '.titles.header'
         .w-row
-          .w-col.w-col-6
+          .w-col.w-col-12
             .login-oauth
               = button_to user_google_oauth2_omniauth_authorize_path(locale: nil), class: 'btn btn-medium btn-google w-inline-block', :data_onsuccess => 'onSignIn'
                 img.google-icon[src="/assets/catarse_bootstrap/google-icon.png" loading="lazy"]
                 div = t('.form.inputs.google')
-          .w-col.w-col-6
-            .login-oauth
-              = button_to user_facebook_omniauth_authorize_path(locale: nil), class: 'btn btn-medium btn-fb'
-                span.fa.fa-facebook-f&nbsp;
-                text = t('.form.inputs.facebook')
         .separator
           .text.or= t('or')
         .w-form


### PR DESCRIPTION
### Descrição
A avaliação do Facebook já foi respondida e nós não iremos conseguir responder o que eles estão pedindo de modo a evitar uma sanção. Esse PR está sendo aberto para já nos anteciparmos e removermos o login do Facebook. É medida de emergência e mexe somente no Front-end.

### Referência
https://www.notion.so/catarse/Remove-login-do-Facebook-do-Front-End-do-Devise-d08adaa8170045a298fe60f52cc1c5ac

